### PR TITLE
Fix BookReader fullscreen

### DIFF
--- a/css/iabookreader.css
+++ b/css/iabookreader.css
@@ -10,7 +10,12 @@
 .BookReader {
     overflow: hidden;
     margin: 20px;
-    background-color: rgba(245,245,245,0.5) !important;
+    background-color: rgba(245,245,245,1) !important;
+}
+
+.BookReader.fullscreenActive {
+    width: 100% !important;
+    height: 100% !important;
 }
 
 .BRtoolbar,.BRnav {

--- a/js/iiif-iabookreader_strawberry.js
+++ b/js/iiif-iabookreader_strawberry.js
@@ -28,8 +28,8 @@
                                                     perL = data[j].periods.length; */
 
 
-                        $(this).height(800);
-                        $(this).width(800);
+                        $(this).height(drupalSettings.format_strawberryfield.iabookreader[element_id]['height']);
+                        $(this).width(drupalSettings.format_strawberryfield.iabookreader[element_id]['width']);
                         // Defines our basic options for IIIF.
                         var options = {
                             ui: 'full', // embed, full (responsive)

--- a/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
@@ -670,6 +670,8 @@ class StrawberryPagedFormatter extends FormatterBase implements ContainerFactory
         $element['media']['#attached']['drupalSettings']['format_strawberryfield']['iabookreader'][$htmlid]['manifest'] = json_decode(
           $manifest
         );
+        $element['media']['#attached']['drupalSettings']['format_strawberryfield']['iabookreader'][$htmlid]['width'] = max($max_width, 400);
+        $element['media']['#attached']['drupalSettings']['format_strawberryfield']['iabookreader'][$htmlid]['height'] = max($max_height, 320);
       }
     }
     return $element;


### PR DESCRIPTION
We have to override .BookReader.fullscreen to add !important.
Using @DiegoPino code, max width/height settings applyed to BookReader div