### PR TITLE
Allow for Page sorting using a json key

### DIFF
--- a/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
@@ -169,6 +169,7 @@ class StrawberryPagedFormatter extends FormatterBase implements ContainerFactory
       'mediasource' => 'json_key',
       'json_key_source' => 'as:image',
       'metadatadisplayentity_source' => NULL,
+      'manifesturl_source' => 'iiifmanifest',
       'max_width' => 720,
       'max_height' => 480,
 
@@ -233,7 +234,7 @@ class StrawberryPagedFormatter extends FormatterBase implements ContainerFactory
       ],
       'manifesturl_source' => [
         '#type' => 'url',
-        '#title' => t('JSON Key from where to fetch Media URLs'),
+        '#title' => t('JSON Key from where to fetch a full IIIF manifest URL'),
         '#default_value' => $this->getSetting('manifesturl_source'),
         '#states' => [
           'visible' => [
@@ -497,6 +498,23 @@ class StrawberryPagedFormatter extends FormatterBase implements ContainerFactory
     }
   }
 
+  /**
+   * Sort passed pages based on a sequence key integer
+   *
+   * @param array $jsondata
+   */
+  protected function orderPages(array &$jsondata, $mainkey = 'as:image', $orderkey ='sequence') {
+    if (!isset($jsondata[$mainkey])){
+      return;
+    }
+    uasort($jsondata[$mainkey],function($a, $b) use ($orderkey) {
+      if ((array_key_exists($orderkey, $a)) && (array_key_exists($orderkey, $b))) {
+        return (int) $a[$orderkey] <=> (int) $b[$orderkey];
+      } else {
+        return 0;
+      }
+    });
+  }
 
   public function processElementsforImages(
     $delta = 0,
@@ -619,11 +637,21 @@ class StrawberryPagedFormatter extends FormatterBase implements ContainerFactory
     $nodeuuid = $item->getEntity()->uuid();
     $max_width = $this->getSetting('max_width');
     $max_height = $this->getSetting('max_height');
+
+
+
     if ($this->getSetting('metadatadisplayentity_source')) {
       $entity = $this->entityTypeManager->getStorage(
         'metadatadisplay_entity'
       )->load($this->getSetting('metadatadisplayentity_source'));
       if ($entity) {
+
+        // Quickly sort the pages. We assume user will use the as:image key
+        // Since the actual generation happens via a twig template.
+        $mainkey = 'as:image';
+        $ordersubkey = 'sequence';
+        $this->orderPages($jsondata, $mainkey, $ordersubkey);
+
         $context = [
           'data' => $jsondata,
           'node' => $item->getEntity(),


### PR DESCRIPTION
# What is new?
This pull implements @giancarlobi (👏 ) code to allow Page sorting for the IIIF manifest generated using a Metadata Display (Twig template). It assumes we will have a "sequence" key for each as:image item (each one is a JSON object) but will work even when the key is missing.

# HOW TO TEST
This should work out of the box for the book reader using the existing IIIF 3.0 Manifest Metadata Display. But if you feel you have the time to experiment a bit more you can add a "sequence" key with an Integer value to any  (or all) of the JSON Objects inside the `as:image` key. Something like


```JSON
 "as:image": {
        "s3:\/\/7a4\/1b3d19e9764ffee26440de032d26d66e1a90def9-en-image-1b3d19e9764ffee26440de032d26d66e1a90def9.jpg": {
            "url": "s3:\/\/7a4\/1b3d19e9764ffee26440de032d26d66e1a90def9-en-image-1b3d19e9764ffee26440de032d26d66e1a90def9.jpg",
            "name": "My First Image",
            "type": "Image",
            "dr:fid": 1,
            "dr:for": "images",
            "dr:url": "s3:\/\/7a4\/1b3d19e9764ffee26440de032d26d66e1a90def9-en-image-1b3d19e9764ffee26440de032d26d66e1a90def9.jpg",
            "checksum": "7a4972866a60a54c70d36a3b07da984a",
            "sequence": 1
        },
        "s3:\/\/b2a\/1bddc9e9764ffee26440de032d26d66e1a90def9-en-image-1b3d19e9714ffee26410ee032d26d66e1a90def9.jpg": {
            "url": "s3:\/\/b2a\/1bddc9e9764ffee26440de032d26d66e1a90def9-en-image-1b3d19e9714ffee26410ee032d26d66e1a90def9.jpg",
            "name": "My Second Image",
            "type": "Image",
            "dr:fid": 1,
            "dr:for": "images",
            "dr:url": "s3:\/\/7a4\/1b3d19e9764ffee26440de032d26d66e1a90def9-en-image-1b3d19e9764ffee26440de032d26d66e1a90def9.jpg",
            "checksum": "7a4972866a60a54c70d36a3b07da984a",
            "sequence": 2
        }
    },
````

Now get crazy and inverse the sequence, or mix some with and without. Should be safe without sequence, with or with mixed integers. 

# TODO

- We need to document this key. To be honest, every key that has a namespace is generated by the module(s) so what is really next is to add a Page Ordering Form Element of tab for objects that have images.
- We also need to make sure this works for OpenSeadragon and in general anything that needs an ordered sequence. 

@giancarlobi you wrote the most of this code, i just wrapped it a little. Could you give it a try and request changes/comment before we merge?

Thanks a lot!