### PR TITLE
Fix static image processing on failure

### DIFF
--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -282,30 +282,26 @@ class StrawberryImageFormatter extends FormatterBase {
                     '#width' => $max_width,
                     '#height' => $max_height,
                   ];
+                  if (isset($item->_attributes)) {
+                    $elements[$delta] += ['#attributes' => []];
+                    $elements[$delta]['#attributes'] += $item->_attributes;
+                    // Unset field item attributes since they have been included in the
+                    // formatter output and should not be rendered in the field template.
+                    unset($item->_attributes);
+                  }
+                  // @TODO deal with a lot of Media single strawberryfield
+                  // Idea would be to allow a setting that says, A) all same viewer(aggregate)
+                  // B) individual viewers for each?
+                  // C) only first one?
+                  // We will assign a group based on the UUID of the node containing this
+                  // to idenfity all the divs that we will create. And only first one will be the container in case of many?
+                  // so a jquery selector that uses that group as filter for a search.
+                  // Drupal JS settings get accumulated. So in a single search results site we will have for each
+                  // Formatter one passed. Reason we use 'innode' array using our $uniqueid
+                  // @TODO probably better to use uuid() or the node id() instead of $uniqueid
+                  $elements[$delta]['media'.$i]['#attributes']['data-iiif-infojson'] = $iiifserver;
+                  $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon']['innode'][$uniqueid] = $nodeuuid;
                 }
-
-
-                if (isset($item->_attributes)) {
-                  $elements[$delta] += ['#attributes' => []];
-                  $elements[$delta]['#attributes'] += $item->_attributes;
-                  // Unset field item attributes since they have been included in the
-                  // formatter output and should not be rendered in the field template.
-                  unset($item->_attributes);
-                }
-                // @TODO deal with a lot of Media single strawberryfield
-                // Idea would be to allow a setting that says, A) all same viewer(aggregate)
-                // B) individual viewers for each?
-                // C) only first one?
-                // We will assign a group based on the UUID of the node containing this
-                // to idenfity all the divs that we will create. And only first one will be the container in case of many?
-                // so a jquery selector that uses that group as filter for a search.
-                // Drupal JS settings get accumulated. So in a single search results site we will have for each
-                // Formatter one passed. Reason we use 'innode' array using our $uniqueid
-                // @TODO probably better to use uuid() or the node id() instead of $uniqueid
-                $elements[$delta]['media'.$i]['#attributes']['data-iiif-infojson'] = $iiifserver;
-                $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon']['innode'][$uniqueid] = $nodeuuid;
-
-
 
               }
               else {

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -295,44 +295,43 @@ class StrawberryPannellumFormatter extends FormatterBase {
                       ['@label' => $items->getEntity()->label()]
                     )
                   ];
-                }
-                // Lets add hotspots
-                $elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'][$htmlid]['nodeuuid'] = $nodeuuid;
-                $elements[$delta]['#attached']['library'][] = 'format_strawberryfield/iiif_pannellum_strawberry';
-                // Hotspots are a list of objects in the form of
-                /*{
-                  "yaw": "-14.626185026728738",
-                   "text": "Sheryl's team at the Theater",
-                  "type": "info",
-                  "pitch": "-4.409886580572494"
-                 }, */
-                // @TODO enable multiple scenes and more hotspot options
+                  // Lets add hotspots
+                  $elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'][$htmlid]['nodeuuid'] = $nodeuuid;
+                  $elements[$delta]['#attached']['library'][] = 'format_strawberryfield/iiif_pannellum_strawberry';
+                  // Hotspots are a list of objects in the form of
+                  /*{
+                    "yaw": "-14.626185026728738",
+                     "text": "Sheryl's team at the Theater",
+                    "type": "info",
+                    "pitch": "-4.409886580572494"
+                   }, */
+                  // @TODO enable multiple scenes and more hotspot options
 
-                if (isset($jsondata[$hotspots])) {
-                  $hotspotsjs = [];
-                  $i=0;
-                  foreach ($jsondata[$hotspots] as $hotspotitems) {
-                    $i++;
-                    $hotspotdefaults = [
-                      'id' => $i,
-                      'pitch' => 0,
-                      'yaw' => 0,
-                      'type' => 'info',
-                      'text' => '',
-                    ];
-                    $hotspotsjs[] = $hotspotitems + $hotspotdefaults;
+                  if (isset($jsondata[$hotspots])) {
+                    $hotspotsjs = [];
+                    $i=0;
+                    foreach ($jsondata[$hotspots] as $hotspotitems) {
+                      $i++;
+                      $hotspotdefaults = [
+                        'id' => $i,
+                        'pitch' => 0,
+                        'yaw' => 0,
+                        'type' => 'info',
+                        'text' => '',
+                      ];
+                      $hotspotsjs[] = $hotspotitems + $hotspotdefaults;
+                    }
+                    $elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'][$htmlid]['hotspots'] = $hotspotsjs;
                   }
-                  $elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'][$htmlid]['hotspots'] = $hotspotsjs;
-                }
 
-                if (isset($item->_attributes)) {
-                  $elements[$delta] += ['#attributes' => []];
-                  $elements[$delta]['#attributes'] += $item->_attributes;
-                  // Unset field item attributes since they have been included in the
-                  // formatter output and should not be rendered in the field template.
-                  unset($item->_attributes);
+                  if (isset($item->_attributes)) {
+                    $elements[$delta] += ['#attributes' => []];
+                    $elements[$delta]['#attributes'] += $item->_attributes;
+                    // Unset field item attributes since they have been included in the
+                    // formatter output and should not be rendered in the field template.
+                    unset($item->_attributes);
+                  }
                 }
-
               }
               else {
                 // @TODO Deal with no access here


### PR DESCRIPTION
# FIXES

This pull moves some logic into an existing conditional: can we retrieve the size of an image via cantaloupe? If not, stop processing. Previously, if you had a badly set Formatter (because you are moving configurations around and your IIIF server IPs do not match!) or you are referencing an image that does not exist (because you are testing stuff) you will get some bad errors.

# HOW TO TEST 
 - If you reference a non existing image in your JSON or
 - you have a badly set IIIF endpoint

And you are trying to display a thumbnail or a static image from Cantaloupe

You will see a notice about a wrong operand on line 289.

Apply this and thumbnail generation will simply be skipped.

@giancarlobi i will go an merge this one, because i need it on production. But please feel free to test and give me some feedback.  Thanks a lot!
