### PR TITLE
ISSUE-20: Tour/Scene builder Multi panorama aware Formatter.

### DIFF
--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -94,6 +94,8 @@ format_strawberryfield.formatter.strawberry_pannellum_formatter:
       type: string
     rotation:
       type: string
+    autoLoad:
+      type: boolean
 format_strawberryfield.formatter.settings.strawberry_video_formatter:
   type: config_object
   label: 'Specific Config for strawberry_video_formatter'

--- a/format_strawberryfield.libraries.yml
+++ b/format_strawberryfield.libraries.yml
@@ -63,12 +63,13 @@ iiif_iabookreader_strawberry:
     - core/drupal.debounce
     - format_strawberryfield/iiif_iabookreader
 pannellum:
-  version: 2.4.1
+  version: 2.5.4
   css:
     component:
-      https://cdn.jsdelivr.net/npm/pannellum@2.4.1/build/pannellum.css: { external: true}
+      https://cdn.jsdelivr.net/npm/pannellum@2.5.4/build/pannellum.css: { external: true}
   js:
-    https://cdn.jsdelivr.net/npm/pannellum@2.4.1/build/pannellum.min.js: { external: true, minified: true, preprocess: false}
+    https://cdn.jsdelivr.net/npm/pannellum@2.5.4/build/pannellum.js: { external: true, minified: true, preprocess: false}
+
 
 iiif_pannellum_strawberry:
   version: 1.0

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -26,6 +26,10 @@ function format_strawberryfield_page_attachments(array &$page) {
     $page['#attached']['library'][] = 'format_strawberryfield/iiif_iabookreader';
     $page['#attached']['library'][] = 'format_strawberryfield/pannellum';
     $page['#attached']['library'][] = 'format_strawberryfield/jsm_modeler';
+    $page['#attached']['library'][] = 'core/jquery';
+    $page['#attached']['library'][] = 'core/drupal.dialog.ajax';
+    $page['#attached']['library'][] = 'core/jquery.form';
+    $page['#attached']['library'][] = 'core/drupal.ajax';
 
 }
 

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -28,7 +28,6 @@ function format_strawberryfield_page_attachments(array &$page) {
     $page['#attached']['library'][] = 'format_strawberryfield/jsm_modeler';
     $page['#attached']['library'][] = 'core/jquery';
     $page['#attached']['library'][] = 'core/drupal.dialog.ajax';
-    $page['#attached']['library'][] = 'core/jquery.form';
     $page['#attached']['library'][] = 'core/drupal.ajax';
 
 }

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -24,6 +24,8 @@ function format_strawberryfield_page_attachments(array &$page) {
     }*/
     $page['#attached']['library'][] = 'format_strawberryfield/iiif_openseadragon';
     $page['#attached']['library'][] = 'format_strawberryfield/iiif_iabookreader';
+    $page['#attached']['library'][] = 'format_strawberryfield/pannellum';
+    $page['#attached']['library'][] = 'format_strawberryfield/jsm_modeler';
 
 }
 

--- a/js/iiif-iabookreader_strawberry.js
+++ b/js/iiif-iabookreader_strawberry.js
@@ -6,27 +6,10 @@
         attach: function(context, settings) {
             $('.strawberry-iabook-item[data-iiif-infojson]').once('attache_iab')
                 .each(function (index, value) {
-
                     // Get the node uuid for this element
                     var element_id = $(this).attr("id");
                     // Check if we got some data passed via Drupal settings.
                     if (typeof(drupalSettings.format_strawberryfield.iabookreader[element_id]) != 'undefined') {
-                        console.log(drupalSettings.format_strawberryfield.iabookreader);
-
-                        /*                        var data = drupalSettings.webprofiler.time.events;
-                                                var parts = [];
-                                                var dataL = data.length;
-                                                var perL;
-                                                var labelW = [];
-                                                var rowW;
-                                                var scalePadding;
-                                                var endTime = parseInt(data[(dataL - 1)].endtime);
-                                                var roundTime = Math.ceil(endTime / 1000) * 1000;
-                                                var endScale;
-
-                                                for (var j = 0; j < dataL; j++) {
-                                                    perL = data[j].periods.length; */
-
 
                         $(this).height(drupalSettings.format_strawberryfield.iabookreader[element_id]['height']);
                         $(this).width(drupalSettings.format_strawberryfield.iabookreader[element_id]['width']);

--- a/js/iiif-openseadragon_strawberry.js
+++ b/js/iiif-openseadragon_strawberry.js
@@ -37,8 +37,6 @@
                     var nodeuuid = settings.format_strawberryfield.openseadragon.innode[element_id];
                 });
 
-            console.log(groupsinfojsons);
-            console.log(groupsid);
             $.each(groupsid, function (group, element_id)  {
                 var tiles = groupsinfojsons[group];
                 var sequence = false;
@@ -47,7 +45,6 @@
                     sequence = true;
                     thumbs = showthumbs;
                 }
-                console.log(element_id);
                 viewers[element_id] = OpenSeadragon({
                     showRotationControl: true,
                     gestureSettingsTouch: {

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -4,7 +4,6 @@
 
     function FormatStrawberryfieldPanoramas(panorama) {
         this.panorama = panorama;
-        console.log('new viewer!');
     }
 
     function FormatStrawberryfieldhotspotPopUp(event, url) {
@@ -54,8 +53,7 @@
                        $(this).height(520); //@TODO this needs to be a setting. C'mon
                        $(this).css("width","100%");
 
-                        console.log('initializing Pannellum')
-                        console.log(drupalSettings.format_strawberryfield.pannellum[element_id].settings);
+                        console.log('Initializing Pannellum.')
                         // When loading a webform with an embeded Viewer
                         // The context of Pannellum is not global
                         // So we can't really use 'pannellum' directly
@@ -70,15 +68,12 @@
                             });
                         }
                         else {
-                            console.log('multiscene!');
-                            console.log(drupalSettings.format_strawberryfield.pannellum[element_id].tour);
+                            console.log('Pannellum Multiscene found.');
                             $.each(drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes, function (sceneid, data)  {
                             // Add Model Window Behaviour to hotSpots with Links
                                 if (data.hasOwnProperty('hotSpots')) {
                                     $.each(data.hotSpots, function (hotspotid, hotspotdata) {
-                                        console.log(hotspotdata);
                                         if (hotspotdata.hasOwnProperty('URL')) {
-                                            console.log(hotspotdata);
                                             drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes[sceneid].hotSpots[hotspotid].clickHandlerFunc = Drupal.FormatStrawberryfieldhotspotPopUp;
                                             drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes[sceneid].hotSpots[hotspotid].clickHandlerArgs = hotspotdata.URL;
                                         }

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -29,7 +29,7 @@
                         });
                         }
                        $(this).height(520); //@TODO this needs to be a setting. C'mon
-                       $(this).width('100%');
+                       $(this).css("width","100%");
 
                         console.log('initializing Pannellum')
                         // When loading a webform with an embeded Viewer

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -2,32 +2,73 @@
 
     'use strict';
 
+    function FormatStrawberryfieldPanoramas(panorama) {
+        this.panorama = panorama;
+        console.log('new viewer!');
+    }
+
     Drupal.behaviors.format_strawberryfield_pannellum_initiate = {
         attach: function(context, settings) {
             $('.strawberry-panorama-item[data-iiif-image]').once('attache_pnl')
                 .each(function (index, value) {
+                    // New 2019.
+                    // If value is a an array then we have a multiscene panorama
+                    // Mostlikely, if i coded this right, hotspots will also be arrays
                     var hotspots = [];
                     // Get the node uuid for this element
                     var element_id = $(this).attr("id");
+                    var $multiscene = drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('tour');
+
                     // Check if we got some data passed via Drupal settings.
                     if (typeof(drupalSettings.format_strawberryfield.pannellum[element_id]) != 'undefined') {
-                        if (drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('hotspots')) {
+                        if (drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('hotspots') &&
+                            !$multiscene
+                        ) {
                             $.each(drupalSettings.format_strawberryfield.pannellum[element_id].hotspots, function (id, hotspotdata)  {
                                 hotspots.push(hotspotdata);
                         });
                         }
-                       $(this).height(520);
+                       $(this).height(520); //@TODO this needs to be a setting. C'mon
                        $(this).width('100%');
 
                         console.log('initializing Pannellum')
-                        pannellum.viewer(element_id, {
-                            "type": "equirectangular",
-                            "panorama": $(value).data('iiifImage'),
-                            "hotSpotDebug": true,
-                            "hotSpots": hotspots,
-                        });
+                        // When loading a webform with an embeded Viewer
+                        // The context of Pannellum is not global
+                        // So we can't really use 'pannellum' directly
+
+
+                        if (!$multiscene) {
+                            var viewer = window.pannellum.viewer(element_id, {
+                                "type": "equirectangular",
+                                "panorama": $(value).data('iiifImage'),
+                                "hotSpotDebug": true,
+                                "hotSpots": hotspots,
+                            });
+                        }
+                        else {
+                            console.log('multiscene!');
+                            var viewer = window.pannellum.viewer(element_id, drupalSettings.format_strawberryfield.pannellum[element_id].tour);
+                        }
+                        FormatStrawberryfieldPanoramas.panoramas.set(element_id, new FormatStrawberryfieldPanoramas(viewer));
 
                     }
 
                 })}}
-})(jQuery, Drupal, drupalSettings, pannellum);
+    /**
+     * Extend the TableResponsive function with a list of managed tables.
+     */
+    $.extend(
+        FormatStrawberryfieldPanoramas,
+        /** @lends Drupal.FormatStrawberryfieldPanoramas */ {
+            /**
+             * Store all created Panorama Viewer Instances.
+             *
+             * @type {Array.<Drupal.FormatStrawberryfieldPanoramas>}
+             */
+            panoramas: new Map(),
+            hotspots:  new Map(),
+        },
+    );
+    // Make the FormatStrawberryfieldPanoramas object available in the Drupal namespace.
+    Drupal.FormatStrawberryfieldPanoramas = FormatStrawberryfieldPanoramas;
+})(jQuery, Drupal, drupalSettings, window.pannellum);

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -8,10 +8,8 @@
     }
 
     function FormatStrawberryfieldhotspotPopUp(event, url) {
-
         if (url!== null) {
             var $myDialog = $('<div class="format-strawberryfield-hotspot-dialog"></div>').appendTo('body');
-            console.log(url);
             var ajaxObject = Drupal.ajax({
                 url: url,
                 dialogType: 'modal',
@@ -24,7 +22,6 @@
             ajaxObject.execute();
         event.preventDefault();
         }
-
     }
 
 
@@ -46,6 +43,11 @@
                             !$multiscene
                         ) {
                             $.each(drupalSettings.format_strawberryfield.pannellum[element_id].hotspots, function (id, hotspotdata)  {
+                                // Also add Popups for Standalone Panoramas if they have an URL.
+                                if (hotspotdata.hasOwnProperty('URL')) {
+                                    hotspotdata.clickHandlerFunc = Drupal.FormatStrawberryfieldhotspotPopUp;
+                                    hotspotdata.clickHandlerArgs = hotspotdata.URL;
+                                }
                                 hotspots.push(hotspotdata);
                         });
                         }

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -19,7 +19,7 @@
                 }
             });
             ajaxObject.execute();
-        event.preventDefault();
+            event.preventDefault();
         }
     }
 
@@ -48,10 +48,10 @@
                                     hotspotdata.clickHandlerArgs = hotspotdata.URL;
                                 }
                                 hotspots.push(hotspotdata);
-                        });
+                            });
                         }
-                       $(this).height(520); //@TODO this needs to be a setting. C'mon
-                       $(this).css("width","100%");
+                        $(this).height(520); //@TODO this needs to be a setting. C'mon
+                        $(this).css("width","100%");
 
                         console.log('Initializing Pannellum.')
                         // When loading a webform with an embeded Viewer
@@ -70,7 +70,7 @@
                         else {
                             console.log('Pannellum Multiscene found.');
                             $.each(drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes, function (sceneid, data)  {
-                            // Add Model Window Behaviour to hotSpots with Links
+                                // Add Model Window Behaviour to hotSpots with Links
                                 if (data.hasOwnProperty('hotSpots')) {
                                     $.each(data.hotSpots, function (hotspotid, hotspotdata) {
                                         if (hotspotdata.hasOwnProperty('URL')) {

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -65,7 +65,7 @@
                                 "type": "equirectangular",
                                 "panorama": $(value).data('iiifImage'),
                                 "hotSpotDebug": drupalSettings.format_strawberryfield.pannellum[element_id].settings.hotSpotDebug,
-                                "autoLoad":drupalSettings.format_strawberryfield.pannellum[element_id].settings.autoLoad,
+                                "autoLoad": Boolean(drupalSettings.format_strawberryfield.pannellum[element_id].settings.autoLoad),
                                 "hotSpots": hotspots,
                             });
                         }

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -57,7 +57,7 @@
 
                 })}}
     /**
-     * Extend the TableResponsive function with a list of managed tables.
+     * Extend the FormatStrawberryfieldPanoramas.
      */
     $.extend(
         FormatStrawberryfieldPanoramas,

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -32,6 +32,7 @@
                        $(this).css("width","100%");
 
                         console.log('initializing Pannellum')
+                        console.log(drupalSettings.format_strawberryfield.pannellum[element_id].settings);
                         // When loading a webform with an embeded Viewer
                         // The context of Pannellum is not global
                         // So we can't really use 'pannellum' directly
@@ -41,7 +42,8 @@
                             var viewer = window.pannellum.viewer(element_id, {
                                 "type": "equirectangular",
                                 "panorama": $(value).data('iiifImage'),
-                                "hotSpotDebug": true,
+                                "hotSpotDebug": drupalSettings.format_strawberryfield.pannellum[element_id].settings.hotSpotDebug,
+                                "autoLoad":drupalSettings.format_strawberryfield.pannellum[element_id].settings.autoLoad,
                                 "hotSpots": hotspots,
                             });
                         }

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -7,6 +7,27 @@
         console.log('new viewer!');
     }
 
+    function FormatStrawberryfieldhotspotPopUp(event, url) {
+
+        if (url!== null) {
+            var $myDialog = $('<div class="format-strawberryfield-hotspot-dialog"></div>').appendTo('body');
+            console.log(url);
+            var ajaxObject = Drupal.ajax({
+                url: url,
+                dialogType: 'modal',
+                dialog: {width: '800px'},
+                progress: {
+                    type: 'fullscreen',
+                    message: Drupal.t('Please wait...')
+                }
+            });
+            ajaxObject.execute();
+        event.preventDefault();
+        }
+
+    }
+
+
     Drupal.behaviors.format_strawberryfield_pannellum_initiate = {
         attach: function(context, settings) {
             $('.strawberry-panorama-item[data-iiif-image]').once('attache_pnl')
@@ -37,7 +58,6 @@
                         // The context of Pannellum is not global
                         // So we can't really use 'pannellum' directly
 
-
                         if (!$multiscene) {
                             var viewer = window.pannellum.viewer(element_id, {
                                 "type": "equirectangular",
@@ -49,9 +69,26 @@
                         }
                         else {
                             console.log('multiscene!');
+                            console.log(drupalSettings.format_strawberryfield.pannellum[element_id].tour);
+                            $.each(drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes, function (sceneid, data)  {
+                            // Add Model Window Behaviour to hotSpots with Links
+                                if (data.hasOwnProperty('hotSpots')) {
+                                    $.each(data.hotSpots, function (hotspotid, hotspotdata) {
+                                        console.log(hotspotdata);
+                                        if (hotspotdata.hasOwnProperty('URL')) {
+                                            console.log(hotspotdata);
+                                            drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes[sceneid].hotSpots[hotspotid].clickHandlerFunc = Drupal.FormatStrawberryfieldhotspotPopUp;
+                                            drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes[sceneid].hotSpots[hotspotid].clickHandlerArgs = hotspotdata.URL;
+                                        }
+
+                                    });
+
+                                }
+                            });
                             var viewer = window.pannellum.viewer(element_id, drupalSettings.format_strawberryfield.pannellum[element_id].tour);
                         }
                         FormatStrawberryfieldPanoramas.panoramas.set(element_id, new FormatStrawberryfieldPanoramas(viewer));
+
 
                     }
 
@@ -71,6 +108,9 @@
             hotspots:  new Map(),
         },
     );
+
     // Make the FormatStrawberryfieldPanoramas object available in the Drupal namespace.
     Drupal.FormatStrawberryfieldPanoramas = FormatStrawberryfieldPanoramas;
+    // Make the FormatStrawberryfieldhotspotPopUp function available in the Drupal namespace.
+    Drupal.FormatStrawberryfieldhotspotPopUp = FormatStrawberryfieldhotspotPopUp;
 })(jQuery, Drupal, drupalSettings, window.pannellum);

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -73,4 +73,4 @@
                     }
                 });
         }};
-})(jQuery, Drupal, drupalSettings, JSM);
+})(jQuery, Drupal, drupalSettings, window.JSM);

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -23,7 +23,7 @@
                     if (browser_supported) {
                         var urls = sourceurl;
                         if (urls === undefined || urls === null) {
-                            console.log('Invalid source files for' + element_id);
+                            console.log('JSM Invalid source files for' + element_id);
                             return;
                         }
 
@@ -39,7 +39,7 @@
 
                                 var viewer = new JSM.ThreeViewer();
                                 if (!viewer.Start(canvas, viewerSettings)) {
-                                    console.log('Error initializing Viewer' + element_id);
+                                    console.log('Error initializing JSM Viewer' + element_id);
                                     return;
                                 }
 

--- a/src/MetadataExposeConfigEntityHtmlRouteProvider.php
+++ b/src/MetadataExposeConfigEntityHtmlRouteProvider.php
@@ -2,6 +2,10 @@
 
 namespace Drupal\format_strawberryfield;
 
+
+
+
+
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\Routing\AdminHtmlRouteProvider;
 

--- a/src/MetadataExposeConfigEntityHtmlRouteProvider.php
+++ b/src/MetadataExposeConfigEntityHtmlRouteProvider.php
@@ -2,10 +2,6 @@
 
 namespace Drupal\format_strawberryfield;
 
-
-
-
-
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\Routing\AdminHtmlRouteProvider;
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryBaseFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryBaseFormatter.php
@@ -7,7 +7,7 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\format_strawberryfield\Tools\IiifUrlValidator;
 use Drupal\Core\Access\AccessResult;
@@ -224,7 +224,7 @@ abstract class StrawberryBaseFormatter extends FormatterBase implements Containe
   /**
    * {@inheritdoc}
    */
-  protected function checkAccess(EntityInterface $entity) {
+  protected function checkAccess(ContentEntityInterface $entity) {
     // Only check access if the current file access control handler explicitly
     // opts in by implementing FileAccessFormatterControlHandlerInterface.
     $access_handler_class = $entity->getEntityType()->getHandlerClass('access');

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -412,23 +412,42 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
               if ($key == 0) {
                 $reusedarray = $renderarray;
                 // Lets build our objects here!
-                $default_scene->firstScene = 'scene'.$nid.'-'.$i;
+                $default_scene->firstScene = 'scene'.$nid;
                 $single_scene_details = new \stdClass();
                 $single_scene_details->title = $node->label();
                 $single_scene_details->type = 'equirectangular';
+                if (isset($scenes['hfov'])) {
+                  $single_scene_details->hfov = (int) $scenes['hfov'];
+                }
+                if (isset($scenes['pitch'])) {
+                  $single_scene_details->pitch = (int) $scenes['pitch'];
+                }
+                if (isset($scenes['yaw'])) {
+                  $single_scene_details->yaw = (int) $scenes['yaw'];
+                }
                 $single_scene_details->panorama =  $renderarray['panorama1']['#attributes']['data-iiif-image'];
                 $single_scene_details->hotSpots = isset($scenes['hotspots']) ? $scenes['hotspots'] : [];
                 // So. All scenes have this form: scene1-0 (more than 0-1 if SBF is multivalued)
-                $single_scenes->{'scene'.$nid.'-'.$i} = clone $single_scene_details;
+                $single_scenes->{'scene'.$nid} = clone $single_scene_details;
                 $panorama_id = $renderarray['panorama1']['#attributes']['id'];
 
                 unset($reusedarray['panorama1']["#attached"]["drupalSettings"]["format_strawberryfield"][$panorama_id]["hotspots"]);
               } else {
+
                 $single_scene_details->title = $node->label();
                 $single_scene_details->type = 'equirectangular';
+                if (isset($scenes['hfov'])) {
+                  $single_scene_details->hfov = (int) $scenes['hfov'];
+                }
+                if (isset($scenes['pitch'])) {
+                  $single_scene_details->pitch = (int) $scenes['pitch'];
+                }
+                if (isset($scenes['yaw'])) {
+                  $single_scene_details->yaw = (int) $scenes['yaw'];
+                }
                 $single_scene_details->panorama =  $renderarray['panorama1']['#attributes']['data-iiif-image'];
                 $single_scene_details->hotSpots = isset($scenes['hotspots']) ? $scenes['hotspots'] : [];
-                $single_scenes->{'scene'.$nid.'-'.$i} = clone $single_scene_details;
+                $single_scenes->{'scene'.$nid} = clone $single_scene_details;
               }
             }
           }
@@ -440,6 +459,8 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
     //@TODO we should validate these puppies probably.
     if (!empty($panorama_id)) {
       $reusedarray["#attached"]["drupalSettings"]["format_strawberryfield"]["pannellum"][$panorama_id]["tour"] = $full_tour;
+      // make sure Drupal Ajax Dialog Library is present for the pop ups.
+      // $reusedarray["#attached"]["library"][] = 'core/drupal.dialog.ajax';
     }
     return $reusedarray;
   }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -397,7 +397,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
           $node = \Drupal::service('entity.manager')->getStorage('node')->load(
             $nid
           );
-          if (!node) {
+          if (!$node) {
             continue;
           }
           $type = $this->pluginId;

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -404,9 +404,10 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
                 $single_scene_details->type = 'equirectangular';
                 $single_scene_details->panorama =  $renderarray['panorama1']['#attributes']['data-iiif-image'];
                 $single_scene_details->hotSpots = isset($scenes['hotspots']) ? $scenes['hotspots'] : [];
+                // So. All scenes have this form: scene1-0 (more than 0-1 if SBF is multivalued)
                 $single_scenes->{'scene'.$nid.'-'.$i} = clone $single_scene_details;
                 $panorama_id = $renderarray['panorama1']['#attributes']['id'];
-                dpm($panorama_id);
+
                 unset($reusedarray['panorama1']["#attached"]["drupalSettings"]["format_strawberryfield"][$panorama_id]["hotspots"]);
               } else {
                 $single_scene_details->title = $node->label();
@@ -422,7 +423,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
     }
     $full_tour->default = $default_scene;
     $full_tour->scenes = $single_scenes;
-    //@TODO we should validate this puppies probably.
+    //@TODO we should validate these puppies probably.
     if (!empty($panorama_id)) {
       $reusedarray["#attached"]["drupalSettings"]["format_strawberryfield"]["pannellum"][$panorama_id]["tour"] = $full_tour;
     }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -389,65 +389,73 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
     foreach ($scenes as $key => $scenes) {
       // Now this is sweet, We will assume that the user wants same specs as this
       // Formatter (makes sense!).
-      $nid = $scenes["scene"];
-      // Don't allow circular references
-      if ($nid != $ownnodeid) {
-        // @TODO inject-it as we do in the other formatters.
-        $node = \Drupal::service('entity.manager')->getStorage('node')->load(
-          $nid
-        );
-        $type = $this->pluginId;
-        $settings = $this->getSettings();
-        // Let's reuse the same settings we have!
-        // but remove 'multiscene' key to make sure
-        // That we don't end loading circular
-        // references, deep tours in tours or even ourselves!
-        $settings['json_key_multiscene'] = '';
-        if ($this->checkAccess($node)) {
-          foreach ($node->{$fieldname} as $i => $delta) {
-            // @see \Drupal\Core\Entity\EntityViewBuilderInterface::viewField()
-            $renderarray = $delta->view(['type' => $type, 'settings' => $settings]);
-            // We only want first image always.
-            if (isset($renderarray['panorama1'])) {
-              if ($key == 0) {
-                $reusedarray = $renderarray;
-                // Lets build our objects here!
-                $default_scene->firstScene = "{$nid}";
-                $single_scene_details = new \stdClass();
-                $single_scene_details->title = $node->label();
-                $single_scene_details->type = 'equirectangular';
-                if (isset($scenes['hfov'])) {
-                  $single_scene_details->hfov = (int) $scenes['hfov'];
-                }
-                if (isset($scenes['pitch'])) {
-                  $single_scene_details->pitch = (int) $scenes['pitch'];
-                }
-                if (isset($scenes['yaw'])) {
-                  $single_scene_details->yaw = (int) $scenes['yaw'];
-                }
-                $single_scene_details->panorama =  $renderarray['panorama1']['#attributes']['data-iiif-image'];
-                $single_scene_details->hotSpots = isset($scenes['hotspots']) ? $scenes['hotspots'] : [];
-                // So. All scenes have this form: scene1-0 (more than 0-1 if SBF is multivalued)
-                $single_scenes->{"$nid"} = clone $single_scene_details;
-                $panorama_id = $renderarray['panorama1']['#attributes']['id'];
+      if (isset($scenes["scene"])) {
+        $nid = $scenes["scene"];
+        // Don't allow circular references
+        if ($nid != $ownnodeid) {
+          // @TODO inject-it as we do in the other formatters.
+          $node = \Drupal::service('entity.manager')->getStorage('node')->load(
+            $nid
+          );
+          if (!node) {
+            continue;
+          }
+          $type = $this->pluginId;
+          $settings = $this->getSettings();
+          // Let's reuse the same settings we have!
+          // but remove 'multiscene' key to make sure
+          // That we don't end loading circular
+          // references, deep tours in tours or even ourselves!
+          $settings['json_key_multiscene'] = '';
+          if ($this->checkAccess($node)) {
+            foreach ($node->{$fieldname} as $i => $delta) {
+              // @see \Drupal\Core\Entity\EntityViewBuilderInterface::viewField()
+              $renderarray = $delta->view(
+                ['type' => $type, 'settings' => $settings]
+              );
+              // We only want first image always.
+              if (isset($renderarray['panorama1'])) {
+                if ($key == 0) {
+                  $reusedarray = $renderarray;
+                  // Lets build our objects here!
+                  $default_scene->firstScene = "{$nid}";
+                  $single_scene_details = new \stdClass();
+                  $single_scene_details->title = $node->label();
+                  $single_scene_details->type = 'equirectangular';
+                  if (isset($scenes['hfov'])) {
+                    $single_scene_details->hfov = (int) $scenes['hfov'];
+                  }
+                  if (isset($scenes['pitch'])) {
+                    $single_scene_details->pitch = (int) $scenes['pitch'];
+                  }
+                  if (isset($scenes['yaw'])) {
+                    $single_scene_details->yaw = (int) $scenes['yaw'];
+                  }
+                  $single_scene_details->panorama = $renderarray['panorama1']['#attributes']['data-iiif-image'];
+                  $single_scene_details->hotSpots = isset($scenes['hotspots']) ? $scenes['hotspots'] : [];
+                  // So. All scenes have this form: scene1-0 (more than 0-1 if SBF is multivalued)
+                  $single_scenes->{"$nid"} = clone $single_scene_details;
+                  $panorama_id = $renderarray['panorama1']['#attributes']['id'];
 
-                unset($reusedarray['panorama1']["#attached"]["drupalSettings"]["format_strawberryfield"][$panorama_id]["hotspots"]);
-              } else {
+                  unset($reusedarray['panorama1']["#attached"]["drupalSettings"]["format_strawberryfield"][$panorama_id]["hotspots"]);
+                }
+                else {
 
-                $single_scene_details->title = $node->label();
-                $single_scene_details->type = 'equirectangular';
-                if (isset($scenes['hfov'])) {
-                  $single_scene_details->hfov = (int) $scenes['hfov'];
+                  $single_scene_details->title = $node->label();
+                  $single_scene_details->type = 'equirectangular';
+                  if (isset($scenes['hfov'])) {
+                    $single_scene_details->hfov = (int) $scenes['hfov'];
+                  }
+                  if (isset($scenes['pitch'])) {
+                    $single_scene_details->pitch = (int) $scenes['pitch'];
+                  }
+                  if (isset($scenes['yaw'])) {
+                    $single_scene_details->yaw = (int) $scenes['yaw'];
+                  }
+                  $single_scene_details->panorama = $renderarray['panorama1']['#attributes']['data-iiif-image'];
+                  $single_scene_details->hotSpots = isset($scenes['hotspots']) ? $scenes['hotspots'] : [];
+                  $single_scenes->{"$nid"} = clone $single_scene_details;
                 }
-                if (isset($scenes['pitch'])) {
-                  $single_scene_details->pitch = (int) $scenes['pitch'];
-                }
-                if (isset($scenes['yaw'])) {
-                  $single_scene_details->yaw = (int) $scenes['yaw'];
-                }
-                $single_scene_details->panorama =  $renderarray['panorama1']['#attributes']['data-iiif-image'];
-                $single_scene_details->hotSpots = isset($scenes['hotspots']) ? $scenes['hotspots'] : [];
-                $single_scenes->{"$nid"} = clone $single_scene_details;
               }
             }
           }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -412,7 +412,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
               if ($key == 0) {
                 $reusedarray = $renderarray;
                 // Lets build our objects here!
-                $default_scene->firstScene = 'scene'.$nid;
+                $default_scene->firstScene = "{$nid}";
                 $single_scene_details = new \stdClass();
                 $single_scene_details->title = $node->label();
                 $single_scene_details->type = 'equirectangular';
@@ -428,7 +428,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
                 $single_scene_details->panorama =  $renderarray['panorama1']['#attributes']['data-iiif-image'];
                 $single_scene_details->hotSpots = isset($scenes['hotspots']) ? $scenes['hotspots'] : [];
                 // So. All scenes have this form: scene1-0 (more than 0-1 if SBF is multivalued)
-                $single_scenes->{'scene'.$nid} = clone $single_scene_details;
+                $single_scenes->{"$nid"} = clone $single_scene_details;
                 $panorama_id = $renderarray['panorama1']['#attributes']['id'];
 
                 unset($reusedarray['panorama1']["#attached"]["drupalSettings"]["format_strawberryfield"][$panorama_id]["hotspots"]);
@@ -447,7 +447,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
                 }
                 $single_scene_details->panorama =  $renderarray['panorama1']['#attributes']['data-iiif-image'];
                 $single_scene_details->hotSpots = isset($scenes['hotspots']) ? $scenes['hotspots'] : [];
-                $single_scenes->{'scene'.$nid} = clone $single_scene_details;
+                $single_scenes->{"$nid"} = clone $single_scene_details;
               }
             }
           }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -20,8 +20,9 @@ use Drupal\file\FileInterface;
  *
  * @FieldFormatter(
  *   id = "strawberry_pannellum_formatter",
- *   label = @Translation("Strawberry Field Panorama Formatter using Pannellum and IIIF"),
- *   class = "\Drupal\format_strawberryfield\Plugin\Field\FieldFormatter\StrawberryPannellumFormatter",
+ *   label = @Translation("Strawberry Field Panorama Formatter using Pannellum
+ *   and IIIF"), class =
+ *   "\Drupal\format_strawberryfield\Plugin\Field\FieldFormatter\StrawberryPannellumFormatter",
  *   field_types = {
  *     "strawberryfield_field"
  *   },
@@ -31,25 +32,26 @@ use Drupal\file\FileInterface;
  * )
  */
 class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
+
   /**
    * {@inheritdoc}
    */
   public static function defaultSettings() {
     return parent::defaultSettings() + [
-      'json_key_source' => 'as:image',
-      'json_key_hotspots' => 'hotspot',
-      'json_key_multiscene' => 'panorama_tour',
-      'max_width' => 600,
-      'max_height' => 400,
-      'panorama_type' => 'equirectangular',
-      'image_type' => 'jpg',
-      'number_images' => 1,
-      // todo: quality, rotation, and hotspotdebug not used but I put them in schema for now
-      'quality' => 'default',
-      'rotation' => '0',
-      'hotSpotDebug' => TRUE,
-      'autoLoad' => FALSE,
-    ];
+        'json_key_source' => 'as:image',
+        'json_key_hotspots' => 'hotspot',
+        'json_key_multiscene' => 'panorama_tour',
+        'max_width' => 600,
+        'max_height' => 400,
+        'panorama_type' => 'equirectangular',
+        'image_type' => 'jpg',
+        'number_images' => 1,
+        // todo: quality, rotation, and hotspotdebug not used but I put them in schema for now
+        'quality' => 'default',
+        'rotation' => '0',
+        'hotSpotDebug' => TRUE,
+        'autoLoad' => FALSE,
+      ];
   }
 
   /**
@@ -57,54 +59,58 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
    */
   public function settingsForm(array $form, FormStateInterface $form_state) {
     return [
-      'json_key_source' => [
-        '#type' => 'textfield',
-        '#title' => t('JSON Key from where to fetch Media URLs'),
-        '#default_value' => $this->getSetting('json_key_source'),
-      ],
-      'json_key_hotspots' => [
-        '#type' => 'textfield',
-        '#title' => t('JSON Key from where to fetch Pannellum Hotspots'),
-        '#default_value' => $this->getSetting('json_key_hotspots'),
-      ],
-      'json_key_multiscene' => [
-        '#type' => 'textfield',
-        '#title' => t('JSON Key from where to fetch a Multi Scene Panellum Tour.'),
-        '#description' => t('If found, JSON Key from where to fetch Media URLs will be used to load images from other Digital Object Panoramas'),
-        '#default_value' => $this->getSetting('json_key_multiscene'),
-      ],
-      'number_images' => [
-        '#type' => 'number',
-        '#title' => $this->t('Number of images'),
-        '#default_value' => $this->getSetting('number_images'),
-        '#size' => 2,
-        '#maxlength' => 2,
-        '#min' => 0,
-      ],
-      'max_width' => [
-        '#type' => 'number',
-        '#title' => $this->t('Maximum width'),
-        '#default_value' => $this->getSetting('max_width'),
-        '#size' => 5,
-        '#maxlength' => 5,
-        '#field_suffix' => $this->t('pixels'),
-        '#min' => 0,
-      ],
-      'max_height' => [
-        '#type' => 'number',
-        '#title' => $this->t('Maximum height'),
-        '#default_value' => $this->getSetting('max_height'),
-        '#size' => 5,
-        '#maxlength' => 5,
-        '#field_suffix' => $this->t('pixels'),
-        '#min' => 0,
-      ],
+        'json_key_source' => [
+          '#type' => 'textfield',
+          '#title' => t('JSON Key from where to fetch Media URLs'),
+          '#default_value' => $this->getSetting('json_key_source'),
+        ],
+        'json_key_hotspots' => [
+          '#type' => 'textfield',
+          '#title' => t('JSON Key from where to fetch Pannellum Hotspots'),
+          '#default_value' => $this->getSetting('json_key_hotspots'),
+        ],
+        'json_key_multiscene' => [
+          '#type' => 'textfield',
+          '#title' => t(
+            'JSON Key from where to fetch a Multi Scene Panellum Tour.'
+          ),
+          '#description' => t(
+            'If found, JSON Key from where to fetch Media URLs will be used to load images from other Digital Object Panoramas'
+          ),
+          '#default_value' => $this->getSetting('json_key_multiscene'),
+        ],
+        'number_images' => [
+          '#type' => 'number',
+          '#title' => $this->t('Number of images'),
+          '#default_value' => $this->getSetting('number_images'),
+          '#size' => 2,
+          '#maxlength' => 2,
+          '#min' => 0,
+        ],
+        'max_width' => [
+          '#type' => 'number',
+          '#title' => $this->t('Maximum width'),
+          '#default_value' => $this->getSetting('max_width'),
+          '#size' => 5,
+          '#maxlength' => 5,
+          '#field_suffix' => $this->t('pixels'),
+          '#min' => 0,
+        ],
+        'max_height' => [
+          '#type' => 'number',
+          '#title' => $this->t('Maximum height'),
+          '#default_value' => $this->getSetting('max_height'),
+          '#size' => 5,
+          '#maxlength' => 5,
+          '#field_suffix' => $this->t('pixels'),
+          '#min' => 0,
+        ],
         'autoLoad' => [
           '#type' => 'checkbox',
           '#title' => $this->t('Autoload Panoramas'),
           '#default_value' => $this->getSetting('autoLoad'),
         ],
-    ] + parent::settingsForm($form, $form_state);
+      ] + parent::settingsForm($form, $form_state);
   }
 
   /**
@@ -112,32 +118,49 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
    */
   public function settingsSummary() {
     $summary = parent::settingsSummary();
-    $summary[] = $this->t('Displays Panoramas from JSON using Pannellum and a IIIF server endpoint');
+    $summary[] = $this->t(
+      'Displays Panoramas from JSON using Pannellum and a IIIF server endpoint'
+    );
     if ($this->getSetting('json_key_source')) {
-      $summary[] = $this->t('Media fetched from JSON "%json_key_source" key', [
-        '%json_key_source' => $this->getSetting('json_key_source'),
-      ]);
+      $summary[] = $this->t(
+        'Media fetched from JSON "%json_key_source" key',
+        [
+          '%json_key_source' => $this->getSetting('json_key_source'),
+        ]
+      );
     }
     if ($this->getSetting('number_images')) {
-      $summary[] = $this->t('Number of images: "%number"', [
-        '%number' => $this->getSetting('number_images'),
-      ]);
+      $summary[] = $this->t(
+        'Number of images: "%number"',
+        [
+          '%number' => $this->getSetting('number_images'),
+        ]
+      );
     }
     if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
-      $summary[] = $this->t('Maximum size: %max_width x %max_height pixels', [
-        '%max_width' => $this->getSetting('max_width'),
-        '%max_height' => $this->getSetting('max_height'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum size: %max_width x %max_height pixels',
+        [
+          '%max_width' => $this->getSetting('max_width'),
+          '%max_height' => $this->getSetting('max_height'),
+        ]
+      );
     }
     elseif ($this->getSetting('max_width')) {
-      $summary[] = $this->t('Maximum width: %max_width pixels', [
-        '%max_width' => $this->getSetting('max_width'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum width: %max_width pixels',
+        [
+          '%max_width' => $this->getSetting('max_width'),
+        ]
+      );
     }
     elseif ($this->getSetting('max_height')) {
-      $summary[] = $this->t('Maximum height: %max_height pixels', [
-        '%max_height' => $this->getSetting('max_height'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum height: %max_height pixels',
+        [
+          '%max_height' => $this->getSetting('max_height'),
+        ]
+      );
     }
 
     return $summary;
@@ -151,11 +174,11 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
     $elements = [];
     $max_width = $this->getSetting('max_width');
     $max_height = $this->getSetting('max_height');
-    $number_images =  $this->getSetting('number_images');
+    $number_images = $this->getSetting('number_images');
     /* @var \Drupal\file\FileInterface[] $files */
     // Fixing the key to extract while coding to 'Media'
     $key = $this->getSetting('json_key_source');
-    $hotspots =  $this->getSetting('json_key_hotspots');
+    $hotspots = $this->getSetting('json_key_hotspots');
     $multiscene = trim($this->getSetting('json_key_multiscene'));
     $settings_hotspotdebug = $this->getSetting('hotSpotDebug');
     $settings_autoload = $this->getSetting('autoLoad');
@@ -164,29 +187,39 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
     $nodeid = $items->getEntity()->id();
     $fieldname = $items->getName();
     foreach ($items as $delta => $item) {
-      $main_property = $item->getFieldDefinition()->getFieldStorageDefinition()->getMainPropertyName();
+      $main_property = $item->getFieldDefinition()
+        ->getFieldStorageDefinition()
+        ->getMainPropertyName();
       $value = $item->{$main_property};
       if (empty($value)) {
         continue;
       }
 
-      $jsondata = json_decode($item->value, true);
+      $jsondata = json_decode($item->value, TRUE);
       // @TODO use future flatversion precomputed at field level as a property
       $json_error = json_last_error();
       if ($json_error != JSON_ERROR_NONE) {
-        $message= $this->t('We could had an issue decoding as JSON your metadata for node @id, field @field',
+        $message = $this->t(
+          'We could had an issue decoding as JSON your metadata for node @id, field @field',
           [
             '@id' => $nodeid,
             '@field' => $items->getName(),
-          ]);
+          ]
+        );
         return $elements[$delta] = ['#markup' => $this->t('ERROR')];
       }
 
-      if (!empty($multiscene) && isset($jsondata[$multiscene]) && count($jsondata[$multiscene])) {
+      if (!empty($multiscene) && isset($jsondata[$multiscene]) && count(
+          $jsondata[$multiscene]
+        )) {
         // We assume that any other Entity will contain Data in the same fieldname
         // @TODO explore edge cases of multi SBFs around?
         // WE could use the SBF service to get the field names too.
-        $elements[$delta] = $this->processMultiScene($jsondata[$multiscene], $fieldname, $nodeid);
+        $elements[$delta] = $this->processMultiScene(
+          $jsondata[$multiscene],
+          $fieldname,
+          $nodeid
+        );
         if (is_array($elements[$delta]) && !empty($elements[$delta])) {
           continue;
         }
@@ -206,7 +239,10 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
 
       $i = 0;
       if (isset($jsondata[$key])) {
-        $iiifhelper = new IiifHelper($this->getIiifUrls()['public'], $this->getIiifUrls()['internal']);
+        $iiifhelper = new IiifHelper(
+          $this->getIiifUrls()['public'],
+          $this->getIiifUrls()['internal']
+        );
         foreach ($jsondata[$key] as $mediaitem) {
           $i++;
           if ($i > $number_images) {
@@ -237,25 +273,36 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
                 $filecachetags = $file->getCacheTags();
                 //@TODO check this filecachetags and see if they make sense
 
-
                 $uniqueid =
-                  'iiif-'.$items->getName(
-                  ).'-'.$nodeuuid.'-'.$delta.'-panorama'.$i;
+                  'iiif-' . $items->getName(
+                  ) . '-' . $nodeuuid . '-' . $delta . '-panorama' . $i;
                 $htmlid = $uniqueid;
 
-                $cache_contexts = ['url.site', 'url.path', 'url.query_args','user.permissions'];
+                $cache_contexts = [
+                  'url.site',
+                  'url.path',
+                  'url.query_args',
+                  'user.permissions',
+                ];
                 // @ see https://www.drupal.org/files/issues/2517030-125.patch
-                $cache_tags = Cache::mergeTags($filecachetags, $items->getEntity()->getCacheTags());
+                $cache_tags = Cache::mergeTags(
+                  $filecachetags,
+                  $items->getEntity()->getCacheTags()
+                );
                 // http://localhost:8183/iiif/2/e8c%2Fa-new-label-en-image-05066d9ae32580cffb38342323f145f74faf99a1.jpg/full/220,/0/default.jpg
-                $iiifpublicinfojson = $iiifhelper->getPublicInfoJson($iiifidentifier);
+                $iiifpublicinfojson = $iiifhelper->getPublicInfoJson(
+                  $iiifidentifier
+                );
                 $iiifsizes = $iiifhelper->getImageSizes($iiifidentifier);
 
                 if (!$iiifsizes) {
-                  $message= $this->t('We could not fetch Image sizes from IIIF @url <br> for node @id, defaulting to base formatter configuration.',
+                  $message = $this->t(
+                    'We could not fetch Image sizes from IIIF @url <br> for node @id, defaulting to base formatter configuration.',
                     [
                       '@url' => $iiifpublicinfojson,
                       '@id' => $nodeid,
-                    ]);
+                    ]
+                  );
                   \Drupal::logger('format_strawberryfield')->warning($message);
                   //continue; // Nothing can be done here?
                 }
@@ -267,17 +314,22 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
                     $max_width = $iiifsizes[0]['width'];
                     $max_height = $iiifsizes[0]['height'];
                   }
-                  if (($max_width == 0) &&  ($max_height > 0)){
-                    $max_width = round($iiifsizes[0]['width']/$iiifsizes[0]['height'] * $max_height,0);
-
+                  if (($max_width == 0) && ($max_height > 0)) {
+                    $max_width = round(
+                      $iiifsizes[0]['width'] / $iiifsizes[0]['height'] * $max_height,
+                      0
+                    );
                   }
-                  elseif (($max_width > 0) &&  ($max_height == 0)){
-                    $max_height = round($iiifsizes[0]['height']/$iiifsizes[0]['width'] * $max_width,0);
+                  elseif (($max_width > 0) && ($max_height == 0)) {
+                    $max_height = round(
+                      $iiifsizes[0]['height'] / $iiifsizes[0]['width'] * $max_width,
+                      0
+                    );
                   }
                   // Pannellum recommends max 4096 pixel width images for WebGl. Lets use that as max.
                   $max_width_source = ($iiifsizes[0]['width'] > 4096) ? '4096,' : 'max';
 
-                  $iiifserverimg = "{$this->getIiifUrls()['public']}/{$iiifidentifier}"."/full/{$max_width_source}/0/default.jpg";
+                  $iiifserverimg = "{$this->getIiifUrls()['public']}/{$iiifidentifier}" . "/full/{$max_width_source}/0/default.jpg";
                   $elements[$delta]['panorama' . $i] = [
                     '#type' => 'container',
                     '#attributes' => [
@@ -290,12 +342,12 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
                     '#title' => $this->t(
                       'Panorama for @label',
                       ['@label' => $items->getEntity()->label()]
-                    )
+                    ),
                   ];
                   // Lets add hotspots
                   $elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'][$htmlid]['settings'] = [
-                    'hotSpotDebug' => $settings_hotspotdebug ,
-                    'autoLoad' => $settings_autoload ,
+                    'hotSpotDebug' => $settings_hotspotdebug,
+                    'autoLoad' => $settings_autoload,
                   ];
                   $elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'][$htmlid]['nodeuuid'] = $nodeuuid;
                   $elements[$delta]['#attached']['library'][] = 'format_strawberryfield/iiif_pannellum_strawberry';
@@ -310,7 +362,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
 
                   if (isset($jsondata[$hotspots])) {
                     $hotspotsjs = [];
-                    $i=0;
+                    $i = 0;
                     foreach ($jsondata[$hotspots] as $hotspotitems) {
                       $i++;
                       $hotspotdefaults = [
@@ -338,15 +390,16 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
                 // @TODO Deal with no access here
                 // Should we put a thumb? Just hide?
                 // @TODO we can bring a plugin here and there that deals with
-                $elements[$delta]['panorama'.$i] = [
+                $elements[$delta]['panorama' . $i] = [
                   '#markup' => '<i class="fas fa-times-circle"></i>',
                   '#prefix' => '<span>',
                   '#suffix' => '</span>',
                 ];
               }
-            } elseif (isset($mediaitem['url'])) {
-              $elements[$delta]['[panorama'.$i] = [
-                '#markup' => 'Non managed '.$mediaitem['url'],
+            }
+            elseif (isset($mediaitem['url'])) {
+              $elements[$delta]['[panorama' . $i] = [
+                '#markup' => 'Non managed ' . $mediaitem['url'],
                 '#prefix' => '<pre>',
                 '#suffix' => '</pre>',
               ];
@@ -360,11 +413,17 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
   }
 
   /**
-   * Processes a Multi Scene JSON key and extracts referenced Scenes and HotSpots.
+   * Processes a Multi Scene JSON key and extracts referenced Scenes and
+   * HotSpots.
+   *
    * @param array $jsondata_scene
    * @param string $fieldname
    */
-  public function processMultiScene(array $jsondata_scene, string $fieldname, int $ownnodeid) {
+  public function processMultiScene(
+    array $jsondata_scene,
+    string $fieldname,
+    int $ownnodeid
+  ) {
     // We need to check if there are many or a single one first.
 
     if (isset($jsondata_scene['scene'])) {
@@ -372,18 +431,18 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
       $scenes[] = $jsondata_scene;
     }
     else {
-      foreach($jsondata_scene as $scene) {
+      foreach ($jsondata_scene as $scene) {
         $scenes[] = $scene;
       }
     }
     // Now we have a common structure
     // Create an Empty render array
     $reusedarray['panorama1'] = [
-      "#type" => "container"
+      "#type" => "container",
     ];
     $single_scenes = new \stdClass();
     $default_scene = new \stdClass();
-    $full_tour =  new \stdClass();
+    $full_tour = new \stdClass();
     $single_scene_details = new \stdClass();
     $panorama_id = NULL;
     foreach ($scenes as $key => $scenes) {
@@ -440,7 +499,6 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
                   unset($reusedarray['panorama1']["#attached"]["drupalSettings"]["format_strawberryfield"][$panorama_id]["hotspots"]);
                 }
                 else {
-
                   $single_scene_details->title = $node->label();
                   $single_scene_details->type = 'equirectangular';
                   if (isset($scenes['hfov'])) {
@@ -467,11 +525,10 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
     //@TODO we should validate these puppies probably.
     if (!empty($panorama_id)) {
       $reusedarray["#attached"]["drupalSettings"]["format_strawberryfield"]["pannellum"][$panorama_id]["tour"] = $full_tour;
-      // make sure Drupal Ajax Dialog Library is present for the pop ups.
-      // $reusedarray["#attached"]["library"][] = 'core/drupal.dialog.ajax';
     }
     return $reusedarray;
   }
+
   /**
    * {@inheritdoc}
    */

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -20,9 +20,8 @@ use Drupal\file\FileInterface;
  *
  * @FieldFormatter(
  *   id = "strawberry_pannellum_formatter",
- *   label = @Translation("Strawberry Field Panorama Formatter using Pannellum
- *   and IIIF"), class =
- *   "\Drupal\format_strawberryfield\Plugin\Field\FieldFormatter\StrawberryPannellumFormatter",
+ *   label = @Translation("Strawberry Field Panorama Formatter using Pannellum and IIIF"),
+ *   class = "\Drupal\format_strawberryfield\Plugin\Field\FieldFormatter\StrawberryPannellumFormatter",
  *   field_types = {
  *     "strawberryfield_field"
  *   },


### PR DESCRIPTION
# What is new?
see #20 
- New Pannellum JS version (2.5.4) only 22 days old!
- Tested Dynamically loading Libraries via Ajax via Ajax again. That was failing (of course, who does that) but know it, now it works. Short answer, Document context of JS does not exist when there is an in memory document. Who would have guessed.
- StrawberryPannellumFormatter now gets another setting. With that it can try to fetch a nested list of other Scenes and their hotspots, where each scene is a node id. Basically a Formatter that uses other Nodes and their Formatters. It gets render arrays from each Node using the same setting of the one you/me/someone is viewing (so smart...gosh...i wish i was me) and rebuilds a new render `array` with all the results. Pushed that data into a little bit modifed JS and BUM! You have a multi scene, multi hotspot panorama!

~~This is not ready and not beautiful but enough to discuss over some coffee. And well, it does work~~

I will mark this as good enough for our needs. If any other issues appear after this we can deal with them in a further pull