### PR TITLE
ISSUE-22: Fix Routing issues and Active/inactive, Gives the Config Entity some Love

### DIFF
--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -63,7 +63,8 @@ format_strawberryfield.iiifbinary:
     uuid: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
     format: .+
     _entity_access: 'node.view'
-# Direct access to Metadata display processed json
+
+# Direct access to Metadata display processed json using Metadata Expose Config Entity.
 format_strawberryfield.metadatadisplay_caster:
   path: '/do/{node}/metadata/{metadataexposeconfig_entity}/{format}'
   methods: [GET]
@@ -80,6 +81,7 @@ format_strawberryfield.metadatadisplay_caster:
   requirements:
     format: .+
     _entity_access: 'node.view'
+    _entity_access: 'metadataexpose_entity.view'
 
 format_strawberryfield.iiif_admin_settings_form:
   path: '/admin/config/archipelago/iiif'
@@ -90,12 +92,3 @@ format_strawberryfield.iiif_admin_settings_form:
     _permission: 'access administration pages'
   options:
     _admin_route: TRUE
-
-# All Routes for the Metadata Expose Content Entity that will store Twig templates
-entity.metadataexpose_entity.canonical:
-  path: '/admin/config/archipelago/metadataexpose/{metadataexpose_entity}'
-  defaults:
-    _entity_view: 'metadataexpose_entity'
-    _title: 'Metadata Expose Content'
-  requirements:
-    _entity_access: 'metadataexpose_entity.view'

--- a/src/Entity/Controller/MetadataExposeConfigEntityListBuilder.php
+++ b/src/Entity/Controller/MetadataExposeConfigEntityListBuilder.php
@@ -1,16 +1,17 @@
 <?php
+
 namespace Drupal\format_strawberryfield\Entity\Controller;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
+use Drupal\format_strawberryfield\Entity\MetadataExposeConfigEntity;
+use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
 
-
-
-  /**
-   * Provides a list controller for the MetadataDisplay entity.
-   *
-   * @ingroup format_strawberryfield
-   */
+/**
+ * Provides a list controller for the MetadataDisplay entity.
+ *
+ * @ingroup format_strawberryfield
+ */
 class MetadataExposeConfigEntityListBuilder extends ConfigEntityListBuilder {
 
   /**
@@ -22,10 +23,13 @@ class MetadataExposeConfigEntityListBuilder extends ConfigEntityListBuilder {
    */
   public function render() {
     $build['description'] = [
-      '#markup' => $this->t('Strawberry Field Formatter Module implements a Metadata Display Entity. You can manage the fields on the <a href="@adminlink">Metadata Display admin page</a>.', array(
-        '@adminlink' => \Drupal::urlGenerator()
-          ->generateFromRoute('format_strawberryfield.metadatadisplay_settings'),
-      )),
+      '#markup' => $this->t(
+        'Strawberry Field Formatter Module implements Metadata Exposed Endpoints and uses Metadata Display Entities as a configuration option to process Metadata present in each Node that contains a Strawberryfield type of field (JSON). You can manage those Metadata Display entities on the <a href="@adminlink">Metadata Display Content Page</a>.',
+        [
+          '@adminlink' => \Drupal::urlGenerator()
+            ->generateFromRoute('entity.metadatadisplay_entity.collection'),
+        ]
+      ),
     ];
 
     $build += parent::render();
@@ -42,7 +46,9 @@ class MetadataExposeConfigEntityListBuilder extends ConfigEntityListBuilder {
    */
   public function buildHeader() {
     $header['id'] = $this->t('Metadata Endpoint Config Display ID');
-    $header['label'] = $this->t('Name');
+    $header['label'] = $this->t('Label');
+    $header['url'] = $this->t('URL access point');
+    $header['active'] = $this->t('Is active ?');
     return $header + parent::buildHeader();
   }
 
@@ -50,11 +56,125 @@ class MetadataExposeConfigEntityListBuilder extends ConfigEntityListBuilder {
    * {@inheritdoc}
    */
   public function buildRow(EntityInterface $entity) {
-    /* @var $entity \Drupal\format_strawberryfield\Entity\MetadataDisplayEntity */
+    /* @var $entity \Drupal\format_strawberryfield\Entity\MetadataExposeConfigEntity */
+    // Build a demo URL so people can see it working
+    $uuid = $this->getOneNode($entity);
+
+    $url = $uuid ? $this->getDemoUrlForItem($entity, $uuid) : $this->t('No Content matches this Endpoint Enabled Bundles Configuration yet. Please create one to see a Demo link here');
     $row['id'] = $entity->id();
     $row['label'] = $entity->label();
+    $row['url'] = $url && $uuid ? [
+      'data' => [
+        '#markup' => $this->t(
+        '<a href="@demolink">@demolink</a>.',
+        [
+          '@demolink' => $url,
+        ]
+        ),
+      ],
+    ] : $url;
+
+    $row['active'] = $entity->isActive() ? $this->t('Yes') : $this->t('No');
 
     return $row + parent::buildRow($entity);
+  }
+
+  /**
+   * Generates a valid Example URL given a Node UUID.
+   *
+   * @param \Drupal\format_strawberryfield\Entity\MetadataExposeConfigEntity $entity
+   *   The Exposed Metadata Entity we are processing the URL for.
+   * @param string $uuid
+   *   An UUID of a node of bundle type configured for this Exposed endpoint.
+   *
+   * @return \Drupal\Core\GeneratedUrl|null|string
+   *   A Drupal URL if we have enough arguments or NULL if not.
+   */
+  private function getDemoUrlForItem(MetadataExposeConfigEntity $entity, string $uuid) {
+    $url = NULL;
+    $extension = NULL;
+
+    try {
+      $responsetypefield = $entity->getMetadataDisplayEntity()->get('mimetype');
+      $responsetype = $responsetypefield->first()->getValue();
+      // We can have a LogicException or a Data One, both extend different
+      // classes, so better catch any.
+    }
+    catch (\Exception $exception) {
+      $this->messenger()->addError(
+        'For Metadata endpoint @metadataexposed, either @metadatadisplay does not exist or has no mimetype Drupal field setup or no value for it. Please check that @metadatadisplay still exists, the entity has that field and there is a default Output Format value for it. Error message is @e',
+        [
+          '@metadataexposed' => $entity->label(),
+          '@metadatadisplay' => $entity->getMetadataDisplayEntity()->label(),
+          '@e' => $exception->getMessage(),
+        ]
+          );
+      return $url;
+    }
+
+    $responsetype = !empty($responsetype['value']) ? $responsetype['value'] : 'text/html';
+
+    // Guess extension based on mime,
+    // \Symfony\Component\HttpFoundation\File\MimeType\MimeTypeExtensionGuesser
+    // has no application/ld+json even if recent
+    // And Drupal provides no mime to extension.
+    // @TODO maybe we could have https://github.com/FileEye/MimeMap as
+    // a dependency in SBF. That way the next hack would not needed.
+    if ($responsetype == 'application/ld+json') {
+      $extension = 'jsonld';
+    }
+    else {
+      $guesser = ExtensionGuesser::getInstance();
+      $extension = $guesser->guess($responsetype);
+    }
+
+    $filename = !empty($extension) ? 'default.' . $extension : 'default.html';
+
+    $url = \Drupal::urlGenerator()
+      ->generateFromRoute(
+        'format_strawberryfield.metadatadisplay_caster',
+        [
+          'node' => $uuid,
+          'metadataexposeconfig_entity' => $entity->id(),
+          'format' => $filename,
+        ]
+      );
+
+    return $url;
+  }
+
+  /**
+   * Fetches a single Node for the first configured Bundle.
+   *
+   * @param \Drupal\format_strawberryfield\Entity\MetadataExposeConfigEntity $entity
+   *   The Exposed Metadata Entity we are getting an example Node UUID for.
+   *
+   * @return null|string
+   *   A Valid Node UUID.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  private function getOneNode(MetadataExposeConfigEntity $entity) {
+    $uuid = NULL;
+    $id = NULL;
+    $node_ids = [];
+    // WE should always have a bundle.
+    $bundles = $entity->getTargetEntityTypes();
+    $bundle = reset($bundles);
+    if ($bundle) {
+      $query = \Drupal::entityQuery('node');
+      $query->condition('status', 1);
+      $query->condition('type', $bundle);
+      $query->range(0, 1);
+      $node_ids = $query->execute();
+    }
+    foreach (\Drupal::entityTypeManager()->getStorage('node')->loadMultiple(
+      $node_ids
+    ) as $node) {
+      $uuid = $node->uuid();
+    }
+    return $uuid;
   }
 
 }

--- a/src/Form/MetadataExposeConfigEntityForm.php
+++ b/src/Form/MetadataExposeConfigEntityForm.php
@@ -100,7 +100,7 @@ class MetadataExposeConfigEntityForm extends EntityForm {
         '#type' => 'checkbox',
         '#title' => $this->t('Is this exposed Metadata Endpoint active?'),
         '#return_value' => TRUE,
-        '#default_value' => TRUE
+        '#default_value' => ($metadataconfig->isNew()) ? TRUE : $metadataconfig->isActive()
       ]
      ];
 


### PR DESCRIPTION
# What is new?

Bug fixes and enhancements
![improvements on exposed endpoints](https://user-images.githubusercontent.com/6946023/67971101-8986bc00-fbe2-11e9-97a5-f7b54ba3012c.png)

See #27 and #22 and #31 

- This adds a better Collection Listing format for each Config Entity, 
  - We also now (cool) show a demo/example link on the listing, so people can see/where/how each endpoint can be found. I like it!
- Makes sure `isActive()` is enforced in config but also on the Controller
- Adds also the Config Entity as a Cacheable dependency so changes like enable/disabling are visible immediately.
-  removes some wrong routing (no canonical for the config entity!). 

@giancarlobi this is all yours, please test if you can before merging. I feel i finally addressed everything. @marlo-longley if you want to look at this too!