### PR TITLE
ISSUE-33: JSON Type/ADO  to View Mode Mapping

### DIFF
--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -106,3 +106,33 @@ format_strawberryfield.formatter.settings.strawberry_video_formatter:
       type: integer
     posterframe:
       type: string
+# Multiple JSON type / View Mode Mappings
+format_strawberryfield.viewmodemapping_settings:
+  type: config_object
+  label: 'Archipelago View Mode to JSON Type Key mapping Configurations'
+  mapping:
+    type_to_viewmode:
+      type: sequence
+      label: 'JSON type key to View Mode Mapping'
+      sequence:
+        type: format_strawberryfield.viewmodemapping_settings.mapping
+
+format_strawberryfield.viewmodemapping_settings.mapping:
+  type: mapping
+  label: 'JSON Type Key/ View Mode pair'
+  mapping:
+    jsontype:
+      type: string
+      label: 'JSON Type Key'
+    view_mode:
+      type: string
+      label: 'View mode'
+    active:
+      type: boolean
+      label: 'Whether this Config pair is enabled or not'
+    weight:
+      type: integer
+      label: 'Order in which this is evaluated'
+
+
+

--- a/format_strawberryfield.links.menu.yml
+++ b/format_strawberryfield.links.menu.yml
@@ -17,6 +17,13 @@ format_strawberryfield.iiif_admin_settings_form:
   description: 'Configure IIIF Server'
   parent: strawberryfield.group.admin
   weight: 99
+#Adds to Archipelago a global IIIF admin settings
+format_strawberryfield.view_mode_mapping_settings_form:
+  title: 'ADO type to View Mode Mapping Form'
+  route_name: format_strawberryfield.view_mode_mapping_settings_form
+  description: 'Configure how ADO type defined in your SBF JSON can be magically mapped to Drupal Content View Modes.'
+  parent: strawberryfield.group.admin
+  weight: 100
 #Adds to Archipelago Expose Metadata Config
 entity.metadataexpose_entity.collection:
   title: 'Configure Exposed Metadata Endpoints'

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -3,7 +3,8 @@
  * @file
  * Contains formater_strawberryfield.module.
  */
-
+use \Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityInterface;
 /**
  * Implements hook_page_attachments().
  *
@@ -24,4 +25,44 @@ function format_strawberryfield_page_attachments(array &$page) {
     $page['#attached']['library'][] = 'format_strawberryfield/iiif_openseadragon';
     $page['#attached']['library'][] = 'format_strawberryfield/iiif_iabookreader';
 
+}
+
+function format_strawberryfield_entity_view_mode_alter(&$view_mode, EntityInterface $entity, $context) {
+  if ($entity->getEntityTypeId() == 'node' && node_is_page($entity) && $view_mode == 'full') {
+    $adotype = [];
+    $original_view_mode = $view_mode;
+    /* @var \Drupal\Core\Config\ImmutableConfig $config */
+    if ($sbf_fields = \Drupal::service('strawberryfield.utility')->bearsStrawberryfield($entity)) {
+      foreach ($sbf_fields as $field_name) {
+        /* @var $field StrawberryFieldItem */
+        $field = $entity->get($field_name);
+        if (!$field->isEmpty()) {
+          foreach ($field->getIterator() as $delta => $itemfield) {
+            /** @var $itemfield \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem */
+            $flatvalues = (array) $itemfield->provideFlatten();
+            if (isset($flatvalues['type'])) {
+              $adotype = array_merge($adotype, (array) $flatvalues['type']);
+            }
+          }
+        }
+      }
+    }
+    if (!empty($adotype)) {
+      $config = \drupal::config(
+      'format_strawberryfield.viewmodemapping_settings'
+      );
+      $viewmodemappings = $config->get('type_to_viewmode');
+      usort($viewmodemappings, ['\Drupal\format_strawberryfield\Form\ViewModeMappingSettingsForm', 'sortSettings']);
+
+      foreach ($viewmodemappings as $viewmodemapping) {
+        if (($viewmodemapping['active'] == TRUE) && in_array($viewmodemapping['jsontype'],$adotype)) {
+          $view_mode = $viewmodemapping['view_mode'];
+          break;
+        }
+      }
+    }
+    // To be determined if we want to be dependat on ds module or not
+    // if so we really want to act on this alter and not the general one.
+    /* \Drupal::moduleHandler()->alter('ds_switch_view_mode', $view_mode, $original_view_mode, $entity); */
+  }
 }

--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -48,6 +48,7 @@ format_strawberryfield.metadatadisplay_settings:
     _title: 'Metadata Display Settings'
   requirements:
     _permission: 'administer metadatadisplay entity'
+
 # Direct File access for SBF managed files.
 format_strawberryfield.iiifbinary:
   path: '/do/{node}/iiif/{uuid}/full/full/0/{format}'
@@ -88,6 +89,16 @@ format_strawberryfield.iiif_admin_settings_form:
   defaults:
     _form: '\Drupal\format_strawberryfield\Form\IiifSettingsForm'
     _title: 'IIIF Server Settings Form'
+  requirements:
+    _permission: 'access administration pages'
+  options:
+    _admin_route: TRUE
+
+format_strawberryfield.view_mode_mapping_settings_form:
+  path: '/admin/config/archipelago/viewmode_mapping'
+  defaults:
+    _form: '\Drupal\format_strawberryfield\Form\ViewModeMappingSettingsForm'
+    _title: 'ADO Type to View Mode Mapping Form'
   requirements:
     _permission: 'access administration pages'
   options:

--- a/src/Form/ViewModeMappingSettingsForm.php
+++ b/src/Form/ViewModeMappingSettingsForm.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace Drupal\format_strawberryfield\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\search_api\Entity\Index;
+
+/**
+ * Class ViewModeMappingSettingsForm.
+ */
+class ViewModeMappingSettingsForm extends ConfigFormBase {
+
+  /**
+   * Constructs a \Drupal\system\ConfigFormBase object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->setConfigFactory($config_factory);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'format_strawberryfield.viewmodemapping_settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'format_strawberryfield_view_mode_mapping_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('format_strawberryfield.viewmodemapping_settings');
+    $form['info'] = [
+      '#markup' => $this->t('This Form allows you to map ADO (Archipelago Digital Object) "types" to existing Drupal View Mode Configurations.'),
+    ];
+
+    $form['type'] = [
+      '#type' => 'select',
+      '#options' => $this->getTypesFromSolr(),
+      '#title' => $this->t('The ADO Type'),
+      '#description' => $this->t('The value of a "type" Key as found in a SBF JSON of an ADO.'),
+      '#default_value' => '',
+      '#required' => TRUE,
+    ];
+    $form['viewmode'] = [
+      '#type' => 'select',
+      '#options' => $this->getViewModes(),
+      '#title' => $this->t('View Mode'),
+      '#description' => $this->t('A View Mode to be used when displaying a Node bearing SBF that contains in its JSON a "type" key with the first value.'),
+      '#default_value' => 'Default',
+      '#required' => TRUE,
+    ];
+
+    $form['actions']['add_more'] = [
+      '#type' => 'submit',
+      '#value' => t('Add'),
+    // No validation.
+      '#limit_validation_errors' => [['type'], ['viewmode']],
+    // #submit required.
+      '#submit' => ['::addPair'],
+      '#ajax' => [
+        'callback' => '::addmoreCallback',
+        'wrapper' => 'table-fieldset-wrapper',
+      ],
+
+    ];
+
+    $form['table-row'] = [
+      '#type' => 'table',
+      '#prefix' => '<div id="table-fieldset-wrapper">',
+      '#suffix' => '</div>',
+      '#header' => [
+        $this->t('JSON Type'),
+        $this->t('View Mode Name'),
+        $this->t('IS ACTIVE ?'),
+        $this->t('Actions'),
+        $this->t('Sort'),
+
+      ],
+      '#empty' => $this->t('Sorry, There are no items!'),
+      '#tabledrag' => [
+        [
+          'action' => 'order',
+          'relationship' => 'sibling',
+          'group' => 'table-sort-weight',
+        ],
+      ],
+    ];
+    $storedsettings = $config->get('type_to_viewmode');
+    if (empty($form_state->get('vmmappings')) && !empty($storedsettings) && !$form_state->isRebuilding()) {
+      // Prepopulate our $formstate vmmappings variable from stored settings;.
+      $form_state->set('vmmappings', $storedsettings);
+    }
+    $current_mappings = !empty($form_state->get('vmmappings')) ? $form_state->get('vmmappings') : [];
+    foreach ($current_mappings as $index => $mapping) {
+      $key = $index + 1;
+      $form['table-row'][$key]['#attributes']['class'][] = 'draggable';
+      $form['table-row'][$key]['#weight'] = isset($mapping['weight']) ? $mapping['weight'] : $key;
+
+      $form['table-row'][$key]['type'] = [
+        '#type' => 'textfield',
+        '#required' => TRUE,
+        '#default_value' => $mapping['jsontype'],
+      ];
+      $form['table-row'][$key]['vm'] = [
+        '#type' => 'textfield',
+        '#required' => TRUE,
+        '#default_value' => $mapping['view_mode'],
+      ];
+      $form['table-row'][$key]['active'] = [
+        '#type' => 'checkbox',
+        '#required' => FALSE,
+        '#default_value' => isset($mapping['active']) ? $mapping['active'] : TRUE,
+      ];
+      $form['table-row'][$key]['actions'] = [
+        '#type' => 'submit',
+        '#rowtodelete' => $key,
+        '#name' => 'deleteitem_' . $key,
+        '#value' => t('Remove'),
+      // No validation.
+        '#limit_validation_errors' => [['table-row']],
+      // #submit required if ajax!.
+        '#submit' => ['::deletePair'],
+        '#ajax' => [
+          'callback' => '::deleteoneCallback',
+          'wrapper' => 'table-fieldset-wrapper',
+        ],
+      ];
+      $form['table-row'][$key]['weight'] = [
+        '#type' => 'weight',
+        '#title' => $this->t('Weight for @title', ['@title' => $mapping['jsontype']]),
+        '#title_display' => 'invisible',
+        '#default_value' => isset($mapping['weight']) ? $mapping['weight'] : $key,
+        '#attributes' => ['class' => ['table-sort-weight']],
+      ];
+    }
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * Fetches ADO types from Solr.
+   *
+   * This needs a setting form too, since people could have types in other
+   * places.
+   */
+  protected function getTypesFromSolr() {
+    $options = [];
+    /** @var \Drupal\search_api\IndexInterface[] $indexes */
+    $indexes = \Drupal::entityTypeManager()
+      ->getStorage('search_api_index')
+      ->loadMultiple();
+
+    $facets = [
+      'type' => [
+        'field' => 'type_1',
+        'limit' => 50,
+        'operator' => 'AND',
+        'min_count' => 1,
+        'missing' => TRUE,
+      ],
+    ];
+
+    foreach ($indexes as $index) {
+      $index = Index::load($index->id());
+      /** @var \Drupal\search_api\Query\QueryInterface $query */
+      $query = $index->query();
+      // $query->setLanguages([LanguageInterface::LANGCODE_NOT_SPECIFIED]);.
+      $query->range(0, 0);
+
+      // Set additional options.
+      // (In this case, retrieve facets, if supported by the backend.)
+      $server = $index->getServerInstance();
+      if ($server->supportsFeature('search_api_facets')) {
+        $query->setOption('search_api_facets', $facets);
+      }
+      // Execute the search.
+      $results = $query->execute();
+
+      $facet_result = $results->getExtraData('search_api_facets', []);
+      if (isset($facet_result['type'])) {
+        foreach ($facet_result['type'] as $facet) {
+          $value = trim($facet['filter'], '"');
+          $options[$value] = $value;
+        }
+      }
+
+    }
+    return $options;
+  }
+
+  /**
+   * Fetches current enabled Drupal View Modes.
+   */
+  protected function getViewModes() {
+    $vm = \Drupal::service('entity_display.repository')->getViewModes('node');
+    $options = ['Default' => t('Default')];
+    // Careful here. Default is really '' But we want to enforce a value here.
+    // But once we apply this on Node render we need to convert back to nothing.
+    foreach ($vm as $key => $item) {
+      $options[$key] = $item['label'];
+    }
+    return $options;
+  }
+
+  /**
+   * Callback for both ajax-enabled buttons.
+   *
+   * Selects and returns the fieldset with the names in it.
+   */
+  public function addmoreCallback(array &$form, FormStateInterface $form_state) {
+    return $form['table-row'];
+  }
+
+  /**
+   * Callback for both ajax-enabled buttons.
+   *
+   * Selects and returns the fieldset with the names in it.
+   */
+  public function deleteoneCallback(array &$form, FormStateInterface $form_state) {
+    return $form['table-row'];
+  }
+
+  /**
+   * Submit handler for the "addmore" button.
+   *
+   * Adds Key and View Mode to the Table Drag  Table.
+   */
+  public function addPair(array &$form, FormStateInterface $form_state) {
+
+    $vmmappings = $form_state->get('vmmappings') ? $form_state->get('vmmappings') : [];
+    $vmmappings[] = ['jsontype' => $form_state->getValue('type'), 'view_mode' => $form_state->getValue('viewmode')];
+    $form_state->set('vmmappings', $vmmappings);
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Submit handler for the "deleteone" button.
+   *
+   * Adds Key and View Mode to the Table Drag  Table.
+   */
+  public function deletePair(array &$form, FormStateInterface $form_state) {
+
+    $triggering = $form_state->getTriggeringElement();
+    if (isset($triggering['#rowtodelete'])) {
+      $vmmappings = $form_state->get('vmmappings') ? $form_state->get('vmmappings') : [];
+      unset($vmmappings[$triggering['#rowtodelete'] - 1]);
+      $form_state->set('vmmappings', array_values($vmmappings));
+      $this->messenger()->addWarning('You have unsaved changes.');
+      $userinput = $form_state->getUserInput();
+      // Only way to get that tabble drag form to rebuild completely
+      // If not we get always the same table back with the last element
+      // removed.
+      unset($userinput["table-row"]);
+      $form_state->setUserInput($userinput);
+    }
+
+    $form_state->setRebuild();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $settings = [];
+    $rows = $form_state->getValue('table-row');
+    // When empty it will be a string!.
+    if (is_array($rows) && !empty($rows)) {
+      usort(
+        $rows,
+        [
+          '\Drupal\format_strawberryfield\Form\ViewModeMappingSettingsForm',
+          'sortSettings',
+        ]
+      );
+      foreach ($rows as $row) {
+        $settings['type_to_viewmode'][] = [
+          'jsontype' => $row['type'],
+          'view_mode' => $row['vm'],
+          'active' => $row['active'],
+          'weight' => $row['weight'],
+        ];
+      }
+      $this->config('format_strawberryfield.viewmodemapping_settings')->set(
+        'type_to_viewmode',
+        $settings['type_to_viewmode']
+      )->save();
+    }
+    else {
+      $this->config('format_strawberryfield.viewmodemapping_settings')->delete();
+    }
+    parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * Sorts Array by its weight associative index.
+   *
+   * @param array $a
+   *   Array to sort.
+   * @param array $b
+   *   Same Array to sort against.
+   *
+   * @return int
+   *   The new order
+   */
+  public static function sortSettings(array $a, array $b) {
+    return $a['weight'] - $b['weight'];
+
+  }
+
+}

--- a/src/Form/ViewModeMappingSettingsForm.php
+++ b/src/Form/ViewModeMappingSettingsForm.php
@@ -253,6 +253,7 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
 
     $vmmappings = $form_state->get('vmmappings') ? $form_state->get('vmmappings') : [];
     $vmmappings[] = ['jsontype' => $form_state->getValue('type'), 'view_mode' => $form_state->getValue('viewmode')];
+    $this->messenger()->addWarning('You have unsaved changes.');
     $form_state->set('vmmappings', $vmmappings);
     $form_state->setRebuild();
   }


### PR DESCRIPTION
# What is new?

See #33 

This pull implements a generalized solution for triggering existing Drupal View Modes based on mapped settings between those and **existing** JSON types values indexed already in Solr.
High emphasis on:  **existing** JSON types values indexed already in Solr.

# How?

The logic is quite simple:
1. An Archipelago Settings Form Endpoint where you can select a pair of Types (select box populated from already ingested types) and a View Mode.
  - The form allows to add more pairs without limiting (for now) having the same repeated (@TODO) a few times
 - People can reorder how those mappings are evaluated. Useful for defining general types like "image" as defaults when not other more specific TYPE matches. Note: Image, e.g comes from a deeper JSON structure, so really anything that has a file of type image will match that one! V/S Photograph, e.g, that will be the Media Type field selected by a user during ingest using a Webform.
- People can delete individual mappings
- People can deactivate, without deleting, mappings
- People of course can Save the settings

2.-  A Hook, in specific `hook_entity_view_mode_alter()` that checks if the node has no custom View Mode setup and the URL that triggered is the canonical (in our case /do/uuid but will also work for /node/somenumber) and if the Object contains one or more SBF  (Strawberryfield) fields and has a "type" field property in any of those Fields (future, when people, e.g have more SBFs for other type of metadata, who knows!). If nothing matches it will just use the Default, if something matches after checking if there is a config with a pair that matches, and the order of evaluation is right, it will change the View Mode on the fly.


# What is missing/can be improved here?

There are some TODOs that i will tackle on a second pull and don't affect function right now:
A. We are only allowing existing Types to be added. Maybe we want people to add Types are not even present yet? That can be done manually really via the form, as we expose textfields, but maybe we want to have another source of TYPES somewhere.
B. the Table drag is showing textfields and in particular for the View Mode, the Machine Name. That is also Ok, for now, but it would be prettier to change that to rendered User facing names with a hidden form element so submit/add/delete still works. Very reason i went for know for a full textfield
C. We have no validation. Not because its complex, but not sure if i want to validate here, since we could want to allow people to import settings or even have things setup upfront before the view modes or even the Types are present.
D. Triggering happens only on the canonical. Maybe we want the same on Revisions but mostly on the "Preview" while ingesting/editing an ADO too.
E. We could also want to "hint" powerusers that will have access to set manually a View Mode and enforce that, which one is the recommended one, by setting in the exposed DS View Mode Switch/setup field on the Entity Form any of our mappings as "preselected" or default. That way even Admins could benefit of this, specially if on the run and forget to set the right view mode, but still override if needed. Since during Ingest, type is not set yet until they press "Save Metadata", the change should probably happen there.

# What is next?

We need to ship a default mapping /configuration file with our archipelago-deployment

# Screenshots

Settings page:

![settings page](https://user-images.githubusercontent.com/6946023/68326742-0362ed80-009a-11ea-8673-dfe9333fbc89.jpg)

Export Config/sync page
![export settings page](https://user-images.githubusercontent.com/6946023/68326754-0b229200-009a-11ea-9774-64c10303ed8f.png)

# How to test?

Create any Digital Object, select some Media Type from the drop list, lets say a 3D Model. fill the form, add an Image and a .STL file, select "Default" from the Display Settings Fieldset 
![View-mode-selection](https://user-images.githubusercontent.com/6946023/68326908-5472e180-009a-11ea-8d1a-bb5f99c87ff8.png)
Set State to Published,
Save Metadata and then Save the Node. 

You should see an Image Viewer Instead of a 3D Viewer, since our current Default is setup to use the Open Seadragon Plugin.

Now fetch this branch. Clear Caches. Go to http://localhost:8001/admin/config/archipelago/viewmode_mapping
Add a new mapping between
ADO Type: 3DModel
and
View Mode: Digital Object with 3D Viewer. Press the "add button" at the bottom
Press Save button at the bottom

Now navigate to the Node/ADO just ingested. You should see now the 3D Viewer instead of default Openseadragon one.

@giancarlobi @marlo-longley @mitchellkeaney (last human tagged here: no need to act on this, just feel free to comment if what this does and how it happens is unclear)






