### PR TITLE
ISSUE-33: Small fix for empty Viewmode mapping configs

### DIFF
--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -52,6 +52,7 @@ function format_strawberryfield_entity_view_mode_alter(&$view_mode, EntityInterf
       'format_strawberryfield.viewmodemapping_settings'
       );
       $viewmodemappings = $config->get('type_to_viewmode');
+      $viewmodemappings = !empty($viewmodemappings) ? (array) $viewmodemappings : [];
       usort($viewmodemappings, ['\Drupal\format_strawberryfield\Form\ViewModeMappingSettingsForm', 'sortSettings']);
 
       foreach ($viewmodemappings as $viewmodemapping) {


### PR DESCRIPTION
# What is new?

When we have no mappings yet, the alter hook throws some errors. Make sure mappings, even when empty are always an array() . Thanks @mitchellkeaney for testing and catching this

# How to test?

With existing mapping all should work as before, with an empty config, no error should appear.