### PR TITLE
ISSUE-33: make UI consistent

### DIFF
--- a/src/Form/ViewModeMappingSettingsForm.php
+++ b/src/Form/ViewModeMappingSettingsForm.php
@@ -56,6 +56,9 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
     $form['info'] = [
       '#markup' => $this->t('This Form allows you to map ADO (Archipelago Digital Object) "types" to existing Drupal View Mode Configurations.'),
     ];
+
+    $view_mode_list = $this->getViewModes();
+
     $form['add_fieldset'] = [
       '#title' => $this->t('Add a new mapping'),
       '#type' => 'fieldset',
@@ -73,7 +76,7 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
     ];
     $form['add_fieldset']['viewmode'] = [
       '#type' => 'select',
-      '#options' => $this->getViewModes(),
+      '#options' => $view_mode_list,
       '#title' => $this->t('View Mode'),
       '#description' => $this->t('A View Mode to be used when displaying a Node bearing SBF that contains in its JSON a "type" key with the first value.'),
       '#default_value' => 'Default',
@@ -132,7 +135,8 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
         '#default_value' => $mapping['jsontype'],
       ];
       $form['table-row'][$key]['vm'] = [
-        '#type' => 'textfield',
+        '#prefix' => '<div>'.$view_mode_list[$mapping['view_mode']].'</div>',
+        '#type' => 'value',
         '#required' => TRUE,
         '#default_value' => $mapping['view_mode'],
       ];

--- a/src/Form/ViewModeMappingSettingsForm.php
+++ b/src/Form/ViewModeMappingSettingsForm.php
@@ -54,7 +54,9 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('format_strawberryfield.viewmodemapping_settings');
     $form['info'] = [
-      '#markup' => $this->t('This Form allows you to map ADO (Archipelago Digital Object) "types" to existing Drupal View Mode Configurations.'),
+      '#markup' => $this->t(
+        'This Form allows you to map ADO (Archipelago Digital Object) "types" to existing Drupal View Mode Configurations.'
+      ),
     ];
 
     $view_mode_list = $this->getViewModes();
@@ -64,13 +66,15 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
       '#type' => 'fieldset',
       '#collapsible' => FALSE,
       '#collapsed' => FALSE,
-      '#tree' => TRUE
+      '#tree' => TRUE,
     ];
     $form['add_fieldset']['type'] = [
       '#type' => 'select',
       '#options' => $this->getTypesFromSolr(),
       '#title' => $this->t('The ADO Type'),
-      '#description' => $this->t('The value of a "type" Key as found in a SBF JSON of an ADO.'),
+      '#description' => $this->t(
+        'The value of a "type" Key as found in a SBF JSON of an ADO.'
+      ),
       '#default_value' => '',
       '#required' => TRUE,
     ];
@@ -78,7 +82,9 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
       '#type' => 'select',
       '#options' => $view_mode_list,
       '#title' => $this->t('View Mode'),
-      '#description' => $this->t('A View Mode to be used when displaying a Node bearing SBF that contains in its JSON a "type" key with the first value.'),
+      '#description' => $this->t(
+        'A View Mode to be used when displaying a Node bearing SBF that contains in its JSON a "type" key with the first value.'
+      ),
       '#default_value' => 'Default',
       '#required' => TRUE,
     ];
@@ -86,9 +92,12 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
     $form['add_fieldset']['add_more'] = [
       '#type' => 'submit',
       '#value' => t('Add'),
-    // No validation.
-      '#limit_validation_errors' => [['add_fieldset','type'], ['add_fieldset','viewmode']],
-    // #submit required.
+      // No validation.
+      '#limit_validation_errors' => [
+        ['add_fieldset', 'type'],
+        ['add_fieldset', 'viewmode'],
+      ],
+      // #submit required.
       '#submit' => ['::addPair'],
       '#ajax' => [
         'callback' => '::addmoreCallback',
@@ -119,11 +128,19 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
       ],
     ];
     $storedsettings = $config->get('type_to_viewmode');
-    if (empty($form_state->get('vmmappings')) && !empty($storedsettings) && !$form_state->isRebuilding()) {
+    if (empty(
+      $form_state->get(
+        'vmmappings'
+      )
+      ) && !empty($storedsettings) && !$form_state->isRebuilding()) {
       // Prepopulate our $formstate vmmappings variable from stored settings;.
       $form_state->set('vmmappings', $storedsettings);
     }
-    $current_mappings = !empty($form_state->get('vmmappings')) ? $form_state->get('vmmappings') : [];
+    $current_mappings = !empty(
+    $form_state->get(
+      'vmmappings'
+    )
+    ) ? $form_state->get('vmmappings') : [];
     foreach ($current_mappings as $index => $mapping) {
       $key = $index + 1;
       $form['table-row'][$key]['#attributes']['class'][] = 'draggable';
@@ -134,12 +151,29 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
         '#required' => TRUE,
         '#default_value' => $mapping['jsontype'],
       ];
-      $form['table-row'][$key]['vm'] = [
-        '#prefix' => '<div>'.$view_mode_list[$mapping['view_mode']].'</div>',
-        '#type' => 'value',
-        '#required' => TRUE,
-        '#default_value' => $mapping['view_mode'],
-      ];
+      $view_mode_mapping_for_this_row = isset($view_mode_list[$mapping['view_mode']]) ? $view_mode_list[$mapping['view_mode']] : t(
+        'View mode @view_mode does not exist! Please select a new one.',
+        ['@view_mode' => $mapping['view_mode']]
+      );
+
+      if (isset($view_mode_list[$mapping['view_mode']])) {
+        $form['table-row'][$key]['vm'] = [
+          '#prefix' => '<div>' . $view_mode_mapping_for_this_row . '</div>',
+          '#type' => 'value',
+          '#required' => TRUE,
+          '#default_value' => $mapping['view_mode'],
+        ];
+      }
+      else {
+        // The View Mode saved in our settings is not longer available, show a select box
+        $form['table-row'][$key]['vm'] = [
+          '#prefix' => '<div>' . $view_mode_mapping_for_this_row . '</div>',
+          '#type' => 'select',
+          '#options' => $view_mode_list,
+          '#required' => TRUE,
+          '#default_value' => 'default',
+        ];
+      }
       $form['table-row'][$key]['active'] = [
         '#type' => 'checkbox',
         '#required' => FALSE,
@@ -150,9 +184,9 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
         '#rowtodelete' => $key,
         '#name' => 'deleteitem_' . $key,
         '#value' => t('Remove'),
-      // No validation.
+        // No validation.
         '#limit_validation_errors' => [['table-row']],
-      // #submit required if ajax!.
+        // #submit required if ajax!.
         '#submit' => ['::deletePair'],
         '#ajax' => [
           'callback' => '::deleteoneCallback',
@@ -161,7 +195,10 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
       ];
       $form['table-row'][$key]['weight'] = [
         '#type' => 'weight',
-        '#title' => $this->t('Weight for @title', ['@title' => $mapping['jsontype']]),
+        '#title' => $this->t(
+          'Weight for @title',
+          ['@title' => $mapping['jsontype']]
+        ),
         '#title_display' => 'invisible',
         '#default_value' => isset($mapping['weight']) ? $mapping['weight'] : $key,
         '#attributes' => ['class' => ['table-sort-weight']],
@@ -241,7 +278,10 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
    *
    * Selects and returns the fieldset with the names in it.
    */
-  public function addmoreCallback(array &$form, FormStateInterface $form_state) {
+  public function addmoreCallback(
+    array &$form,
+    FormStateInterface $form_state
+  ) {
     return $form['table-row'];
   }
 
@@ -250,7 +290,10 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
    *
    * Selects and returns the fieldset with the names in it.
    */
-  public function deleteoneCallback(array &$form, FormStateInterface $form_state) {
+  public function deleteoneCallback(
+    array &$form,
+    FormStateInterface $form_state
+  ) {
     return $form['table-row'];
   }
 
@@ -261,8 +304,15 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
    */
   public function addPair(array &$form, FormStateInterface $form_state) {
 
-    $vmmappings = $form_state->get('vmmappings') ? $form_state->get('vmmappings') : [];
-    $vmmappings[] = ['jsontype' => $form_state->getValue(['add_fieldset','type']), 'view_mode' => $form_state->getValue(['add_fieldset','viewmode'])];
+    $vmmappings = $form_state->get('vmmappings') ? $form_state->get(
+      'vmmappings'
+    ) : [];
+    $vmmappings[] = [
+      'jsontype' => $form_state->getValue(
+        ['add_fieldset', 'type']
+      ),
+      'view_mode' => $form_state->getValue(['add_fieldset', 'viewmode']),
+    ];
     $this->messenger()->addWarning('You have unsaved changes.');
     $form_state->set('vmmappings', $vmmappings);
     $form_state->setRebuild();
@@ -277,7 +327,9 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
 
     $triggering = $form_state->getTriggeringElement();
     if (isset($triggering['#rowtodelete'])) {
-      $vmmappings = $form_state->get('vmmappings') ? $form_state->get('vmmappings') : [];
+      $vmmappings = $form_state->get('vmmappings') ? $form_state->get(
+        'vmmappings'
+      ) : [];
       unset($vmmappings[$triggering['#rowtodelete'] - 1]);
       $form_state->set('vmmappings', array_values($vmmappings));
       $this->messenger()->addWarning('You have unsaved changes.');
@@ -321,7 +373,8 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
       )->save();
     }
     else {
-      $this->config('format_strawberryfield.viewmodemapping_settings')->delete();
+      $this->config('format_strawberryfield.viewmodemapping_settings')->delete(
+      );
     }
     parent::submitForm($form, $form_state);
   }

--- a/src/Form/ViewModeMappingSettingsForm.php
+++ b/src/Form/ViewModeMappingSettingsForm.php
@@ -56,8 +56,14 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
     $form['info'] = [
       '#markup' => $this->t('This Form allows you to map ADO (Archipelago Digital Object) "types" to existing Drupal View Mode Configurations.'),
     ];
-
-    $form['type'] = [
+    $form['add_fieldset'] = [
+      '#title' => $this->t('Add a new mapping'),
+      '#type' => 'fieldset',
+      '#collapsible' => FALSE,
+      '#collapsed' => FALSE,
+      '#tree' => TRUE
+    ];
+    $form['add_fieldset']['type'] = [
       '#type' => 'select',
       '#options' => $this->getTypesFromSolr(),
       '#title' => $this->t('The ADO Type'),
@@ -65,7 +71,7 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
       '#default_value' => '',
       '#required' => TRUE,
     ];
-    $form['viewmode'] = [
+    $form['add_fieldset']['viewmode'] = [
       '#type' => 'select',
       '#options' => $this->getViewModes(),
       '#title' => $this->t('View Mode'),
@@ -74,11 +80,11 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
       '#required' => TRUE,
     ];
 
-    $form['actions']['add_more'] = [
+    $form['add_fieldset']['add_more'] = [
       '#type' => 'submit',
       '#value' => t('Add'),
     // No validation.
-      '#limit_validation_errors' => [['type'], ['viewmode']],
+      '#limit_validation_errors' => [['add_fieldset','type'], ['add_fieldset','viewmode']],
     // #submit required.
       '#submit' => ['::addPair'],
       '#ajax' => [
@@ -252,7 +258,7 @@ class ViewModeMappingSettingsForm extends ConfigFormBase {
   public function addPair(array &$form, FormStateInterface $form_state) {
 
     $vmmappings = $form_state->get('vmmappings') ? $form_state->get('vmmappings') : [];
-    $vmmappings[] = ['jsontype' => $form_state->getValue('type'), 'view_mode' => $form_state->getValue('viewmode')];
+    $vmmappings[] = ['jsontype' => $form_state->getValue(['add_fieldset','type']), 'view_mode' => $form_state->getValue(['add_fieldset','viewmode'])];
     $this->messenger()->addWarning('You have unsaved changes.');
     $form_state->set('vmmappings', $vmmappings);
     $form_state->setRebuild();


### PR DESCRIPTION
# What is new?

See #33 for context

After getting more feedback during a call on Friday i decided to address the fact that our "add" new mapping button for the ADO type to View Mode Form was on the bottom (unexpected) and not just right by the select boxes. This pull fixes that. It also changes the way we display the already selected View Modes and deals (sort of) with the fact that people could have deleted a view mode after we saved the mappings. If that happens, on load we replace the View Mode Label colum with a select box allow the Admin to fix its mistake. I also did some code rearranging (to avoid long lines, nothing really impressive there but adds some clutter to the pull, sorry!)

# How to test

Fetch branches, switch to this, clear caches, check your form.

If you want to test the behavior on a broken View Mode, you can either import a wrong Config (Note. i had to re-ident the config file after exporting, not sure why... but i had to. It did not change the syntax but maybe i made an error on the schema declaration? Weirdly all internal checks and flags/things pass) or delete a view mode and check. You should get a Select Box to select a new view mode and a mostly harmless message, that maybe could need an alert CSS class or something to make it more "dangerous" to the UI aficionado.

@giancarlobi @marlo-longley 