### PR TITLE
ISSUE-38: Add a Temp file route with IIIF pattern

### DIFF
--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -8,9 +8,10 @@ format_strawberryfield.iiif_settings:
     int_server_url:
       type: string
       label: 'Internal IIIF server URL'
-format_strawberryfield.formatter.*:
-  type: config_entity
-  label: 'Formatter config for strawberry field formatters'
+
+format_strawberryfield.formatter.strawberry_audio_formatter:
+  type: config_object
+  label: 'Specific config for strawberry_audio_formatter'
   mapping:
     iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
     iiif_base_url_internal: format_strawberryfield.iiif_settings.int_server_url
@@ -24,12 +25,6 @@ format_strawberryfield.formatter.*:
     use_iiif_globals:
       type: boolean
       label: 'Whether to use global IIIF settings or not.'
-    formatter_config:
-      type: format_strawberryfield.formatter.[%parent.type]
-format_strawberryfield.formatter.strawberry_audio_formatter:
-  type: config_object
-  label: 'Specific config for strawberry_audio_formatter'
-  mapping:
     audio_type:
       type: string
     number_media:
@@ -38,6 +33,18 @@ format_strawberryfield.formatter.strawberry_image_formatter:
   type: config_object
   label: 'Specific Config for strawberry_image_formatter'
   mapping:
+    iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
+    iiif_base_url_internal: format_strawberryfield.iiif_settings.int_server_url
+    json_key_source:
+      type: string
+      label: 'Strawberryfield/JSON key containing file URIs to display'
+    max_width:
+      type: integer
+    max_height:
+      type: integer
+    use_iiif_globals:
+      type: boolean
+      label: 'Whether to use global IIIF settings or not.'
     number_images:
       type: integer
     quality:
@@ -48,6 +55,18 @@ format_strawberryfield.formatter.strawberry_media_formatter:
   type: config_object
   label: 'Specific Config for strawberry_media_formatter'
   mapping:
+    iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
+    iiif_base_url_internal: format_strawberryfield.iiif_settings.int_server_url
+    json_key_source:
+      type: string
+      label: 'Strawberryfield/JSON key containing file URIs to display'
+    max_width:
+      type: integer
+    max_height:
+      type: integer
+    use_iiif_globals:
+      type: boolean
+      label: 'Whether to use global IIIF settings or not.'
     iiif_group:
       type: boolean
       label: 'Whether multiple media sources should use a single IIIF viewer or not.'
@@ -57,6 +76,18 @@ format_strawberryfield.formatter.strawberry_metadata_formatter:
   type: config_object
   label: 'Specific Config for strawberry_metadata_formatter using Twig'
   mapping:
+    iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
+    iiif_base_url_internal: format_strawberryfield.iiif_settings.int_server_url
+    json_key_source:
+      type: string
+      label: 'Strawberryfield/JSON key containing file URIs to display'
+    max_width:
+      type: integer
+    max_height:
+      type: integer
+    use_iiif_globals:
+      type: boolean
+      label: 'Whether to use global IIIF settings or not.'
     label:
       type: string
     specs:
@@ -70,23 +101,38 @@ format_strawberryfield.formatter.strawberry_paged_formatter:
   type: config_object
   label: 'Specific Config for strawberry_paged_formatter'
   mapping:
-    type: boolean
-    label: 'Whether multiple media sources should use a single IIIF viewer or not.'
-  mediasource:
-    type: string
-  metadatadisplayentity_source:
-    type: string
-  manifesturl_source:
-    type: string
+    iiif_group:
+      type: boolean
+      label: 'Whether multiple media sources should use a single IIIF viewer or not.'
+    mediasource:
+      type: string
+    metadatadisplayentity_source:
+      type: string
+    manifesturl_source:
+      type: string
 format_strawberryfield.formatter.strawberry_pannellum_formatter:
   type: config_object
   label: 'Specific Config for strawberry_pannellum_formatter'
   mapping:
+    iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
+    iiif_base_url_internal: format_strawberryfield.iiif_settings.int_server_url
+    json_key_source:
+      type: string
+      label: 'Strawberryfield/JSON key containing file URIs to display'
+    max_width:
+      type: integer
+    max_height:
+      type: integer
+    use_iiif_globals:
+      type: boolean
+      label: 'Whether to use global IIIF settings or not.'
     hotSpotDebug:
       type: boolean
     image_type:
       type: string
     json_key_hotspots:
+      type: string
+    json_key_multiscene:
       type: string
     panorama_type:
       type: integer
@@ -94,10 +140,24 @@ format_strawberryfield.formatter.strawberry_pannellum_formatter:
       type: string
     rotation:
       type: string
+    autoLoad:
+      type: boolean
 format_strawberryfield.formatter.settings.strawberry_video_formatter:
   type: config_object
   label: 'Specific Config for strawberry_video_formatter'
   mapping:
+    iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
+    iiif_base_url_internal: format_strawberryfield.iiif_settings.int_server_url
+    json_key_source:
+      type: string
+      label: 'Strawberryfield/JSON key containing file URIs to display'
+    max_width:
+      type: integer
+    max_height:
+      type: integer
+    use_iiif_globals:
+      type: boolean
+      label: 'Whether to use global IIIF settings or not.'
     audio_type:
       type: string
     json_key_source_for_poster:

--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -65,6 +65,16 @@ format_strawberryfield.iiifbinary:
     format: .+
     _entity_access: 'node.view'
 
+# Direct File access for SBF managed files.
+format_strawberryfield.directiiifbinary:
+  path: '/domedia/iiif/{uuid}/full/full/0/{format}'
+  methods: [GET]
+  defaults:
+    _controller: '\Drupal\format_strawberryfield\Controller\IiifBinaryController::servetempfile'
+  requirements:
+    uuid: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    format: .+
+
 # Direct access to Metadata display processed json using Metadata Expose Config Entity.
 format_strawberryfield.metadatadisplay_caster:
   path: '/do/{node}/metadata/{metadataexposeconfig_entity}/{format}'

--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -74,6 +74,7 @@ format_strawberryfield.tempiiifbinary:
   requirements:
     uuid: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
     format: .+
+    _permission: 'access content'
 
 # Direct access to Metadata display processed json using Metadata Expose Config Entity.
 format_strawberryfield.metadatadisplay_caster:

--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -65,8 +65,8 @@ format_strawberryfield.iiifbinary:
     format: .+
     _entity_access: 'node.view'
 
-# Direct File access for SBF managed files.
-format_strawberryfield.directiiifbinary:
+# Direct File access for owner to Temporary files.
+format_strawberryfield.tempiiifbinary:
   path: '/domedia/iiif/{uuid}/full/full/0/{format}'
   methods: [GET]
   defaults:

--- a/src/Controller/IiifBinaryController.php
+++ b/src/Controller/IiifBinaryController.php
@@ -207,7 +207,7 @@ class IiifBinaryController extends ControllerBase {
       $fileentity = current($fileentityarray);
     }
 
-    if (($fileentity->getOwnerId() ==  $this->currentUser()) &&  $fileentity->isTemporary()){
+    if (($fileentity->getOwnerId() ==  $this->currentUser()->id()) &&  $fileentity->isTemporary()){
       $uri = $fileentity->getFileUri();
       $filename = $fileentity->getFilename();
 

--- a/src/Entity/MetadataExposeConfigEntity.php
+++ b/src/Entity/MetadataExposeConfigEntity.php
@@ -6,6 +6,7 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
 use Drupal\format_strawberryfield\MetadataConfigInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Config\Entity\ConfigEntityInterface;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 
 /**
  * Defines the MetadataExposeConfigEntity entity.*.
@@ -55,6 +56,7 @@ use Drupal\Core\Config\Entity\ConfigEntityInterface;
  */
 class MetadataExposeConfigEntity extends ConfigEntityBase implements MetadataConfigInterface {
 
+  use DependencySerializationTrait;
   /**
    * The ID of the Metadata Config Entity.
    *


### PR DESCRIPTION
See #38 

# What is new?

We expose now, for logged in users, a direct endpoint to temporary files (e.g uploaded during a Webform ingest/edit workflow). This is needed to allow other modules to show/preview files are not persisted yet and our IIIF server can not reach yet to serve.

This pull also deals with #37 (hopefully) because i'm running out of time to make multiple pulls for everything that requires my attention. Citing myself 
`"Pino, Diego ; mapping: boolean? That was a weird one!"`