### PR TITLE
ISSUE-40: Add Media ordering to All formatters that need it

### DIFF
--- a/src/Controller/MetadataExposeDisplayController.php
+++ b/src/Controller/MetadataExposeDisplayController.php
@@ -19,6 +19,7 @@ use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Render\RenderContext;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Drupal\format_strawberryfield\Plugin\Field\FieldFormatter\StrawberryBaseFormatter;
 
 /**
  * A Wrapper Controller to access Twig processed JSON on a URL.
@@ -183,6 +184,12 @@ class MetadataExposeDisplayController extends ControllerBase {
                 "Sorry, we could not process metadata for this service"
               );
             }
+            // Preorder as:media by sequence
+            $ordersubkey = 'sequence';
+            foreach (StrawberryBaseFormatter::as_file_type as $key) {
+              $this->orderSequence($data, $key, $ordersubkey);
+            }
+
             if ($offset == 0) {
               $context['data'] = $data;
             }

--- a/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
@@ -167,6 +167,9 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
       }*/
       $i = 0;
       if (isset($jsondata[$key])) {
+        // Order 3D Models based on a given 'sequence' key
+        $ordersubkey = 'sequence';
+        $this->orderSequence($jsondata, $key, $ordersubkey);
         foreach ($jsondata[$key] as $mediaitem) {
           $i++;
           if ($i > $number_models) {

--- a/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
@@ -180,6 +180,9 @@ class StrawberryAudioFormatter extends StrawberryBaseFormatter {
       */
       $i = 0;
       if (isset($jsondata[$key])) {
+        // Order Audio based on a given 'sequence' key
+        $ordersubkey = 'sequence';
+        $this->orderSequence($jsondata, $key, $ordersubkey);
         foreach ($jsondata[$key] as $mediaitem) {
           $i++;
           if ($i > (int) $number_media) {

--- a/src/Plugin/Field/FieldFormatter/StrawberryBaseFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryBaseFormatter.php
@@ -17,6 +17,15 @@ use Drupal\Core\Access\AccessResult;
  */
 abstract class StrawberryBaseFormatter extends FormatterBase implements ContainerFactoryPluginInterface {
 
+  const as_file_type = [
+    'as:image',
+    'as:document',
+    'as:video',
+    'as:audio',
+    'as:application',
+    'as:text'
+  ];
+
   /**
    * The Config for getting default IIIF settings.
    *
@@ -246,6 +255,35 @@ abstract class StrawberryBaseFormatter extends FormatterBase implements Containe
    */
   protected function guessMimeForExternalUri(string $uripath) {
     return \Drupal::service('file.mime_type.guesser')->guess($uripath);
+  }
+
+  /**
+   * Sort passed as:media based on a sequence key integer
+   *
+   * @param array $jsondata
+   */
+  protected function orderSequence(
+    array &$jsondata,
+    $mainkey = 'as:image',
+    $orderkey = 'sequence'
+  ) {
+    if (!isset($jsondata[$mainkey])) {
+      return;
+    }
+    uasort(
+      $jsondata[$mainkey],
+      function ($a, $b) use ($orderkey) {
+        if ((array_key_exists($orderkey, $a)) && (array_key_exists(
+            $orderkey,
+            $b
+          ))) {
+          return (int) $a[$orderkey] <=> (int) $b[$orderkey];
+        }
+        else {
+          return 0;
+        }
+      }
+    );
   }
 
 }

--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -170,6 +170,9 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
       }*/
       $i = 0;
       if (isset($jsondata[$key])) {
+        // Order Images based on a given 'sequence' key
+        $ordersubkey = 'sequence';
+        $this->orderSequence($jsondata, $key, $ordersubkey);
         $iiifhelper = new IiifHelper($this->getIiifUrls()['public'], $this->getIiifUrls()['internal']);
         foreach ($jsondata[$key] as $mediaitem) {
           $i++;

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -172,6 +172,9 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
       $elements[$delta]['#attached']['library'][] = 'format_strawberryfield/iiif_openseadragon_strawberry';
 
       if (isset($jsondata[$key])) {
+        // Order Images based on a given 'sequence' key
+        $ordersubkey = 'sequence';
+        $this->orderSequence($jsondata, $key, $ordersubkey);
         $iiifhelper = new IiifHelper($this->getIiifUrls()['public'], $this->getIiifUrls()['internal']);
         foreach ($jsondata[$key] as $mediaitem) {
           $i++;

--- a/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
@@ -263,6 +263,15 @@ class StrawberryMetadataTwigFormatter extends FormatterBase implements Container
         // C) Embeded (but hidden JSON-LD, etc)
         // So we need to make sure People can "tag" that need.
 
+        // Order as: structures based on sequence key
+        // We will assume here people are using our automatic keys
+        // If they are using other ones, they will have to apply ordering
+        // Directly on their Twig Templates.
+        $ordersubkey = 'sequence';
+        foreach (StrawberryBaseFormatter::as_file_type as $key) {
+          $this->orderSequence($jsondata, $key, $ordersubkey);
+        }
+
         $templaterenderelement = [
           '#type' => 'inline_template',
           '#template' => $twigtemplate,

--- a/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
@@ -430,36 +430,6 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
   }
 
   /**
-   * Sort passed pages based on a sequence key integer
-   *
-   * @param array $jsondata
-   */
-  protected function orderPages(
-    array &$jsondata,
-    $mainkey = 'as:image',
-    $orderkey = 'sequence'
-  ) {
-    if (!isset($jsondata[$mainkey])) {
-      return;
-    }
-    uasort(
-      $jsondata[$mainkey],
-      function ($a, $b) use ($orderkey) {
-        if ((array_key_exists($orderkey, $a)) && (array_key_exists(
-            $orderkey,
-            $b
-          ))) {
-          return (int) $a[$orderkey] <=> (int) $b[$orderkey];
-        }
-        else {
-          return 0;
-        }
-      }
-    );
-  }
-
-
-  /**
    * Generates render element for a Twig generated manifest.
    *
    * @param int $delta
@@ -492,7 +462,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
         // @TODO add a config option for this key too.
         $mainkey = 'as:image';
         $ordersubkey = 'sequence';
-        $this->orderPages($jsondata, $mainkey, $ordersubkey);
+        $this->orderSequence($jsondata, $mainkey, $ordersubkey);
 
         $context = [
           'data' => $jsondata,

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -242,6 +242,9 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
           $this->getIiifUrls()['public'],
           $this->getIiifUrls()['internal']
         );
+        // Order Images based on a given 'sequence' key
+        $ordersubkey = 'sequence';
+        $this->orderSequence($jsondata, $key, $ordersubkey);
         foreach ($jsondata[$key] as $mediaitem) {
           $i++;
           if ($i > $number_images) {

--- a/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
@@ -208,6 +208,9 @@ class StrawberryVideoFormatter extends StrawberryBaseFormatter {
       */
       $i = 0;
       if (isset($jsondata[$key])) {
+        // Order Video based on a given 'sequence' key
+        $ordersubkey = 'sequence';
+        $this->orderSequence($jsondata, $key, $ordersubkey);
         foreach ($jsondata[$key] as $mediaitem) {
           $i++;
           if ($i > (int) $number_media) {


### PR DESCRIPTION
See #40 

# What are we adding here?

Sequence ordering of our as:media elements everywhere they are used in output/formatters.

This is based on @giancarlobi work on the `::orderPages` method. It just extends the same concept to every other formatter and Twig injecting process and moved methods to common classes.

@giancarlobi @marlo-longley 

