### PR TITLE
ISSUE-40:Fixing media ordering

### DIFF
--- a/src/Controller/MetadataExposeDisplayController.php
+++ b/src/Controller/MetadataExposeDisplayController.php
@@ -19,7 +19,7 @@ use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Render\RenderContext;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Drupal\format_strawberryfield\Plugin\Field\FieldFormatter\StrawberryBaseFormatter;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
 
 /**
  * A Wrapper Controller to access Twig processed JSON on a URL.
@@ -169,7 +169,7 @@ class MetadataExposeDisplayController extends ControllerBase {
           /* @var $field StrawberryFieldItem[] */
           $field = $node->get($field_name);
           foreach ($field as $offset => $fielditem) {
-            $data = json_decode($fielditem->value, TRUE);
+            $jsondata = json_decode($fielditem->value, TRUE);
             $json_error = json_last_error();
             if ($json_error != JSON_ERROR_NONE) {
               $this->loggerFactory->get('format_strawberryfield')->error(
@@ -186,15 +186,15 @@ class MetadataExposeDisplayController extends ControllerBase {
             }
             // Preorder as:media by sequence
             $ordersubkey = 'sequence';
-            foreach (StrawberryBaseFormatter::as_file_type as $key) {
-              $this->orderSequence($data, $key, $ordersubkey);
+            foreach (StrawberryfieldJsonHelper::AS_FILE_TYPE as $key) {
+              StrawberryfieldJsonHelper::orderSequence($jsondata, $key, $ordersubkey);
             }
 
             if ($offset == 0) {
-              $context['data'] = $data;
+              $context['data'] = $jsondata;
             }
             else {
-              $context['data'][$offset] = $data;
+              $context['data'][$offset] = $jsondata;
             }
           }
 

--- a/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
@@ -13,6 +13,7 @@ use Drupal\strawberryfield\Tools\Ocfl\OcflHelper;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Url;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
 
 /**
  * Simplistic Strawberry 3D Field formatter.
@@ -169,7 +170,7 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
       if (isset($jsondata[$key])) {
         // Order 3D Models based on a given 'sequence' key
         $ordersubkey = 'sequence';
-        $this->orderSequence($jsondata, $key, $ordersubkey);
+        StrawberryfieldJsonHelper::orderSequence($jsondata, $key, $ordersubkey);
         foreach ($jsondata[$key] as $mediaitem) {
           $i++;
           if ($i > $number_models) {

--- a/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
@@ -14,6 +14,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Url;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
 
 /**
  * Simplistic Audio Strawberry Field formatter.
@@ -182,7 +183,7 @@ class StrawberryAudioFormatter extends StrawberryBaseFormatter {
       if (isset($jsondata[$key])) {
         // Order Audio based on a given 'sequence' key
         $ordersubkey = 'sequence';
-        $this->orderSequence($jsondata, $key, $ordersubkey);
+        StrawberryfieldJsonHelper::orderSequence($jsondata, $key, $ordersubkey);
         foreach ($jsondata[$key] as $mediaitem) {
           $i++;
           if ($i > (int) $number_media) {

--- a/src/Plugin/Field/FieldFormatter/StrawberryBaseFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryBaseFormatter.php
@@ -17,15 +17,6 @@ use Drupal\Core\Access\AccessResult;
  */
 abstract class StrawberryBaseFormatter extends FormatterBase implements ContainerFactoryPluginInterface {
 
-  const as_file_type = [
-    'as:image',
-    'as:document',
-    'as:video',
-    'as:audio',
-    'as:application',
-    'as:text'
-  ];
-
   /**
    * The Config for getting default IIIF settings.
    *
@@ -255,35 +246,6 @@ abstract class StrawberryBaseFormatter extends FormatterBase implements Containe
    */
   protected function guessMimeForExternalUri(string $uripath) {
     return \Drupal::service('file.mime_type.guesser')->guess($uripath);
-  }
-
-  /**
-   * Sort passed as:media based on a sequence key integer
-   *
-   * @param array $jsondata
-   */
-  protected function orderSequence(
-    array &$jsondata,
-    $mainkey = 'as:image',
-    $orderkey = 'sequence'
-  ) {
-    if (!isset($jsondata[$mainkey])) {
-      return;
-    }
-    uasort(
-      $jsondata[$mainkey],
-      function ($a, $b) use ($orderkey) {
-        if ((array_key_exists($orderkey, $a)) && (array_key_exists(
-            $orderkey,
-            $b
-          ))) {
-          return (int) $a[$orderkey] <=> (int) $b[$orderkey];
-        }
-        else {
-          return 0;
-        }
-      }
-    );
   }
 
 }

--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -13,6 +13,7 @@ use Drupal\strawberryfield\Tools\Ocfl\OcflHelper;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\format_strawberryfield\Tools\IiifHelper;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
 
 /**
  * Simplistic Strawberry Field formatter.
@@ -172,7 +173,7 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
       if (isset($jsondata[$key])) {
         // Order Images based on a given 'sequence' key
         $ordersubkey = 'sequence';
-        $this->orderSequence($jsondata, $key, $ordersubkey);
+        StrawberryfieldJsonHelper::orderSequence($jsondata, $key, $ordersubkey);
         $iiifhelper = new IiifHelper($this->getIiifUrls()['public'], $this->getIiifUrls()['internal']);
         foreach ($jsondata[$key] as $mediaitem) {
           $i++;

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -12,6 +12,7 @@ use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\strawberryfield\Tools\Ocfl\OcflHelper;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\format_strawberryfield\Tools\IiifHelper;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
 /**
  * Simplistic Strawberry Field formatter.
  *
@@ -174,7 +175,7 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
       if (isset($jsondata[$key])) {
         // Order Images based on a given 'sequence' key
         $ordersubkey = 'sequence';
-        $this->orderSequence($jsondata, $key, $ordersubkey);
+        StrawberryfieldJsonHelper::orderSequence($jsondata, $key, $ordersubkey);
         $iiifhelper = new IiifHelper($this->getIiifUrls()['public'], $this->getIiifUrls()['internal']);
         foreach ($jsondata[$key] as $mediaitem) {
           $i++;

--- a/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
@@ -19,6 +19,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Template\TwigEnvironment;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
 use Twig_Error_Syntax;
 use Twig_Environment;
 use Twig_Error_Runtime;
@@ -268,8 +269,8 @@ class StrawberryMetadataTwigFormatter extends FormatterBase implements Container
         // If they are using other ones, they will have to apply ordering
         // Directly on their Twig Templates.
         $ordersubkey = 'sequence';
-        foreach (StrawberryBaseFormatter::as_file_type as $key) {
-          $this->orderSequence($jsondata, $key, $ordersubkey);
+        foreach (StrawberryfieldJsonHelper::AS_FILE_TYPE as $key) {
+          StrawberryfieldJsonHelper::orderSequence($jsondata, $key, $ordersubkey);
         }
 
         $templaterenderelement = [

--- a/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
@@ -20,6 +20,7 @@ use Drupal\Core\Session\AccountInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Template\TwigEnvironment;
 use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
 use stdClass;
 use Twig_Error_Syntax;
 use Twig_Environment;
@@ -462,7 +463,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
         // @TODO add a config option for this key too.
         $mainkey = 'as:image';
         $ordersubkey = 'sequence';
-        $this->orderSequence($jsondata, $mainkey, $ordersubkey);
+        StrawberryfieldJsonHelper::orderSequence($jsondata, $mainkey, $ordersubkey);
 
         $context = [
           'data' => $jsondata,

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -14,6 +14,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\format_strawberryfield\Tools\IiifHelper;
 use Drupal\file\FileInterface;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
 
 /**
  * Simplistic Strawberry Field formatter.
@@ -244,7 +245,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
         );
         // Order Images based on a given 'sequence' key
         $ordersubkey = 'sequence';
-        $this->orderSequence($jsondata, $key, $ordersubkey);
+        StrawberryfieldJsonHelper::orderSequence($jsondata, $key, $ordersubkey);
         foreach ($jsondata[$key] as $mediaitem) {
           $i++;
           if ($i > $number_images) {

--- a/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
@@ -8,7 +8,6 @@
 
 namespace Drupal\format_strawberryfield\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\strawberryfield\Tools\Ocfl\OcflHelper;
 use Drupal\Core\Entity\EntityInterface;
@@ -17,6 +16,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Url;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
 
 /**
  * Simplistic Video Strawberry Field formatter.
@@ -210,7 +210,7 @@ class StrawberryVideoFormatter extends StrawberryBaseFormatter {
       if (isset($jsondata[$key])) {
         // Order Video based on a given 'sequence' key
         $ordersubkey = 'sequence';
-        $this->orderSequence($jsondata, $key, $ordersubkey);
+        StrawberryfieldJsonHelper::orderSequence($jsondata, $key, $ordersubkey);
         foreach ($jsondata[$key] as $mediaitem) {
           $i++;
           if ($i > (int) $number_media) {


### PR DESCRIPTION
See #41 and #40 

# Bug fix

Pull #41 introduced a bug that escaped my sleepy radar and some other folks radar too. This fixes it.
Requires https://github.com/esmero/strawberryfield/pull/63 to be merged/testing.

basically moves sequence ordering to our JSON Helper class and makes it static. Also renames the constant to uppercase (good practice) and cleans `MetadataExposeDisplayController` from being dependant on a formatter base class, never ever a good idea in the first place.

@marlo-longley please test as soon as possible. This is quite annoying!