### PR TITLE
ISSUE-47: Mini-mini-me-malist PDF Viewer  …

### DIFF
--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -166,6 +166,33 @@ format_strawberryfield.formatter.settings.strawberry_video_formatter:
       type: integer
     posterframe:
       type: string
+format_strawberryfield.formatter.settings.strawberry_pdf_formatter:
+  type: config_object
+  label: 'Specific Config for strawberry_pdf_formatter'
+  mapping:
+    iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
+    iiif_base_url_internal: format_strawberryfield.iiif_settings.int_server_url
+    json_key_source:
+      type: string
+      label: 'Strawberryfield/JSON key containing file URIs to display'
+    max_width:
+      type: string
+      label: 'Max with for the Viewer. Can be either a % or just a number'
+    max_height:
+      type: integer
+    use_iiif_globals:
+      type: boolean
+      label: 'Whether to use global IIIF settings or not.'
+    number_documents:
+      type: integer
+      label: 'Number of PDF Documents to load'
+    number_pages:
+      type: integer
+      label: 'Number of Pages to show per PDF'
+    initial_pages:
+      type: integer
+      label: 'First Page to display per PDF'
+
 # Multiple JSON type / View Mode Mappings
 format_strawberryfield.viewmodemapping_settings:
   type: config_object

--- a/format_strawberryfield.libraries.yml
+++ b/format_strawberryfield.libraries.yml
@@ -102,3 +102,22 @@ jsm_model_strawberry:
     - core/drupal
     - core/drupalSettings
     - format_strawberryfield/jsm_modeler
+
+pdfs_mozilla:
+  version: 2.2.228
+  license:
+    name: Apache
+    url: //raw.githubusercontent.com/mozilla/pdf.js/master/LICENSE
+    gpl-compatible: true
+  js:
+    https://cdn.jsdelivr.net/npm/pdfjs-dist@2.2.228/build/pdf.min.js: { external: true, minified: true, preprocess: false}
+
+pdfs_strawberry:
+  version: 1.0
+  js:
+    js/pdfs_strawberry.js: {minified: false}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/drupalSettings
+    - format_strawberryfield/pdfs_mozilla

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -33,7 +33,7 @@ function format_strawberryfield_page_attachments(array &$page) {
 }
 
 function format_strawberryfield_entity_view_mode_alter(&$view_mode, EntityInterface $entity, $context) {
-  if ($entity->getEntityTypeId() == 'node' && node_is_page($entity) && $view_mode == 'full') {
+  if ($entity->getEntityTypeId() == 'node' && $view_mode == 'full') {
     $adotype = [];
     $original_view_mode = $view_mode;
     /* @var \Drupal\Core\Config\ImmutableConfig $config */

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -72,3 +72,17 @@ function format_strawberryfield_entity_view_mode_alter(&$view_mode, EntityInterf
     /* \Drupal::moduleHandler()->alter('ds_switch_view_mode', $view_mode, $original_view_mode, $entity); */
   }
 }
+
+/**
+ * Implements hook_theme().
+ */
+function format_strawberryfield_theme() {
+  return [
+    'format_strawberryfield_pdfs' => [
+      'variables' => [
+        'item' => NULL
+      ],
+      'template' => 'format-strawberryfield-pdfs'
+    ],
+  ];
+}

--- a/js/pdfs_strawberry.js
+++ b/js/pdfs_strawberry.js
@@ -1,0 +1,140 @@
+(function ($, Drupal, drupalSettings, pdfjsLib, pdfjsWorker) {
+    'use strict';
+    Drupal.behaviors.format_strawberryfield_pdfjs = {
+        attach: function(context, settings) {
+            // The workerSrc property is a must!
+            // @TODO: Would love to simply push ther 'worker' property since we already have it loaded
+            // but i lack enough understanding of the API.
+            // See here https://github.com/mozilla/pdf.js/blob/master/src/display/api.js#L218
+            // Probably (have to check) passing an Object with that key instead of a string to pdfjsLib.getDocument($doc)
+            //  and worker being the global window['pdfjs-dist/build/pdf.worker'] should work
+            // basically doc.src='url' and doc.worker = window['pdfjs-dist/build/pdf.worker' ?
+            $('.strawberry-document-item[data-iiif-document]').once('attache_pdf')
+                .each(function (index, value) {
+                    var $document = $(this).data("iiif-document");
+                    var $theid = $(this).attr("id");
+                    var $initialpage = $(this).data("iiif-initialpage");
+                    pdfjsLib.GlobalWorkerOptions.workerSrc = '//cdn.jsdelivr.net/npm/pdfjs-dist@2.2.228/build/pdf.worker.min.js';
+
+                    /**
+                     * Single Page render
+                     * Could be used for thumbnails?
+                     */
+                    function singlePageRender() {
+                        // Asynchronous download of PDF
+                        var loadingTask = pdfjsLib.getDocument($document);
+                        loadingTask.promise.then(function (pdf) {
+                            console.log('PDF loaded');
+                            // Fetch the first page
+                            var pageNumber = 1;
+                            pdf.getPage(pageNumber).then(function (page) {
+                                console.log('Page loaded');
+
+                                var scale = 1.5;
+                                var viewport = page.getViewport({scale: scale});
+
+                                // Prepare canvas using PDF page dimensions
+                                var canvas = document.getElementById($theid);
+                                var ctx = canvas.getContext('2d');
+                                canvas.height = viewport.height;
+                                canvas.width = viewport.width;
+
+                                // Render PDF page into canvas context
+                                var renderContext = {
+                                    canvasContext: ctx,
+                                    viewport: viewport
+                                };
+                                var renderTask = page.render(renderContext);
+                                renderTask.promise.then(function () {
+                                    console.log('Page rendered');
+                                });
+                            });
+                        }, function (reason) {
+                            // PDF loading error
+                            console.error(reason);
+                        });
+                    }
+
+                    var pdfDoc = null,
+                        pageNum = $initialpage,
+                        pageRendering = false,
+                        pageNumPending = null,
+                        scale = 1.5,
+                        canvas = document.getElementById($theid),
+                        ctx = canvas.getContext('2d');
+
+                    /**
+                     * Get page info, resize and render.
+                     * @param num Page number.
+                     */
+                    function renderPage(num) {
+                        pageRendering = true;
+                        // Using promise to fetch the page
+                        pdfDoc.getPage(num).then(function(page) {
+                            var viewport = page.getViewport({scale: scale});
+                            canvas.height = viewport.height;
+                            canvas.width = viewport.width;
+
+                            var renderContext = {
+                                canvasContext: ctx,
+                                viewport: viewport
+                            };
+                            var renderTask = page.render(renderContext);
+
+                            renderTask.promise.then(function() {
+                                pageRendering = false;
+                                if (pageNumPending !== null) {
+                                    renderPage(pageNumPending);
+                                    pageNumPending = null;
+                                }
+                            });
+                        });
+                        // Update page counters
+                        document.getElementById($theid+'-pagenum').textContent = num;
+                    }
+
+                    function queueRenderPage(num) {
+                        if (pageRendering) {
+                            pageNumPending = num;
+                        } else {
+                            renderPage(num);
+                        }
+                    }
+
+                    /**
+                     * Displays prev. page.
+                     */
+                    function onPrevPage() {
+                        if (pageNum <= 1) {
+                            return;
+                        }
+                        pageNum--;
+                        queueRenderPage(pageNum);
+                    }
+                    document.getElementById($theid+'-prev').addEventListener('click', onPrevPage);
+
+                    /**
+                     * Displays next page.
+                     */
+                    function onNextPage() {
+                        if (pageNum >= pdfDoc.numPages) {
+                            return;
+                        }
+                        pageNum++;
+                        queueRenderPage(pageNum);
+                    }
+                    document.getElementById($theid+'-next').addEventListener('click', onNextPage);
+
+                    /**
+                     * Asynchronously downloads PDF.
+                     */
+                    pdfjsLib.getDocument($document).promise.then(function(pdfDoc_) {
+                        pdfDoc = pdfDoc_;
+                        document.getElementById($theid+'-pagecount').textContent = pdfDoc.numPages;
+                        renderPage(pageNum);
+                    });
+
+                });
+        }
+    };
+})(jQuery, Drupal, drupalSettings, window.pdfjsLib, window.pdfjsWorker);

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -197,6 +197,7 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
                 $iiifidentifier = urlencode(
                   file_uri_target($file->getFileUri())
                 );
+                //@TODO replace with  \Drupal::service('stream_wrapper_manager')->getTarget()
                 if ($iiifidentifier == NULL || empty($iiifidentifier)) {
                   continue;
                 }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
@@ -1,0 +1,303 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 9/18/18
+ * Time: 8:56 PM
+ */
+
+namespace Drupal\format_strawberryfield\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\strawberryfield\Tools\Ocfl\OcflHelper;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
+
+/**
+ * Simplistic PDF Strawberry Field formatter.
+ *
+ * @FieldFormatter(
+ *   id = "strawberry_pdf_formatter",
+ *   label = @Translation("Strawberry Field PDF Formatter for IIIF served PDFs"),
+ *   class = "\Drupal\format_strawberryfield\Plugin\Field\FieldFormatter\StrawberryPdfFormatter",
+ *   field_types = {
+ *     "strawberryfield_field"
+ *   },
+ *   quickedit = {
+ *     "editor" = "disabled"
+ *   }
+ * )
+ */
+class StrawberryPdfFormatter extends StrawberryBaseFormatter {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return
+      parent::defaultSettings() + [
+        'json_key_source' => 'as:document',
+        'max_width' => '100%',
+        'max_height' => 0,
+        'initial_page' => 1,
+        'number_pages' => 1,
+        'quality' => 'default',
+        'rotation' => '0',
+      ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    return [
+        'json_key_source' => [
+          '#type' => 'textfield',
+          '#title' => t('JSON Key from where to fetch Document URLs'),
+          '#default_value' => $this->getSetting('json_key_source'),
+        ],
+        'number_documents' => [
+          '#type' => 'number',
+          '#title' => $this->t('Number of Documents to extract for Key'),
+          '#description' => $this->t('Set to 0 for all Documents'),
+          '#default_value' => $this->getSetting('number_documents'),
+          '#size' => 2,
+          '#maxlength' => 4,
+          '#min' => 0,
+        ],
+        'number_pages' => [
+          '#type' => 'number',
+          '#title' => $this->t('Number of Pages'),
+          '#description' => $this->t('Set to 0 for all pages'),
+          '#default_value' => $this->getSetting('number_pages'),
+          '#size' => 2,
+          '#maxlength' => 4,
+          '#min' => 0,
+        ],
+        'initial_page' => [
+          '#type' => 'number',
+          '#title' => $this->t('Initial Page'),
+          '#default_value' => $this->getSetting('initial_page'),
+          '#size' => 2,
+          '#maxlength' => 4,
+          '#min' => 0,
+        ],
+        'max_width' => [
+          '#type' => 'textfield',
+          '#title' => $this->t('Maximum width'),
+          '#description' => $this->t('Set to 100% for full with of just a number for pixels'),
+          '#default_value' => $this->getSetting('max_width'),
+          '#size' => 5,
+          '#maxlength' => 5,
+          '#min' => 0,
+        ],
+        'max_height' => [
+          '#type' => 'number',
+          '#title' => $this->t('Maximum height in pi'),
+          '#default_value' => $this->getSetting('max_height'),
+          '#size' => 5,
+          '#maxlength' => 5,
+          '#field_suffix' => $this->t('pixels'),
+          '#min' => 0,
+        ],
+      ] + parent::settingsForm($form, $form_state);
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = parent::settingsSummary();
+    if ($this->getSetting('json_key_source')) {
+      $summary[] = $this->t('Document fetched from JSON "%json_key_source" key', [
+        '%json_key_source' => $this->getSetting('json_key_source'),
+      ]);
+    }
+    if ($this->getSetting('number_pages')) {
+      $summary[] = $this->t('Number of pages: "%number"', [
+        '%number' => $this->getSetting('number_images'),
+      ]);
+    }
+    if ($this->getSetting('initial_page')) {
+      $summary[] = $this->t('Initial page: "%number"', [
+        '%number' => $this->getSetting('initial_page'),
+      ]);
+    }
+    if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
+      $summary[] = $this->t('Maximum size: %max_width x %max_height', [
+        '%max_width' => $this->getSetting('max_width'),
+        '%max_height' => $this->getSetting('max_height'),
+      ]);
+    }
+    elseif ($this->getSetting('max_width')) {
+      $summary[] = $this->t('Maximum width: %max_width', [
+        '%max_width' => $this->getSetting('max_width'),
+      ]);
+    }
+    elseif ($this->getSetting('max_height')) {
+      $summary[] = $this->t('Maximum height: %max_height', [
+        '%max_height' => $this->getSetting('max_height'),
+      ]);
+    }
+
+    return $summary;
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    $max_width = $this->getSetting('max_width');
+    $max_height = $this->getSetting('max_height');
+    $number_pages =  $this->getSetting('number_pages');
+    $number_documents =  $this->getSetting('number_documents');
+    $initial_page =  $this->getSetting('initial_page');
+    /* @var \Drupal\file\FileInterface[] $files */
+    // Fixing the key to extract while coding to 'Media'
+    $key = $this->getSetting('json_key_source');
+
+    $nodeuuid = $items->getEntity()->uuid();
+    $nodeid = $items->getEntity()->id();
+    $fieldname = $items->getName();
+    foreach ($items as $delta => $item) {
+      $main_property = $item->getFieldDefinition()->getFieldStorageDefinition()->getMainPropertyName();
+      $value = $item->{$main_property};
+
+      if (empty($value)) {
+        continue;
+      }
+
+      $jsondata = json_decode($item->value, true);
+      // @TODO use future flatversion precomputed at field level as a property
+      $json_error = json_last_error();
+      if ($json_error != JSON_ERROR_NONE) {
+        $message= $this->t('We could had an issue decoding as JSON your metadata for node @id, field @field',
+          [
+            '@id' => $nodeid,
+            '@field' => $items->getName(),
+          ]);
+        $this->messenger()->addWarning($message);
+        return $elements[$delta] = ['#markup' => $this->t('ERROR')];
+      }
+      /* Expected structure of an Media item inside JSON
+       "as:document": {
+        "urn:uuid:0da2da57-1634-4170-9899-06e324b8307f": {
+            "url": "s3:\/\/0f5\/application-0f582308ac94e102a682a3edb6272412-0da2da57-1634-4170-9899-06e324b8307f.pdf",
+            "name": "0f582308ac94e102a682a3edb6272412.pdf",
+            "tags": [],
+            "type": "Document",
+            "dr:fid": 105,
+            "dr:for": "documents",
+            "dr:uuid": "0da2da57-1634-4170-9899-06e324b8307f",
+            "checksum": "0f582308ac94e102a682a3edb6272412",
+            "sequence": 1,
+            "crypHashFunc": "md5"
+        }
+      },
+      }*/
+      $i = 0;
+      if (isset($jsondata[$key])) {
+        // Order Documents based on a given 'sequence' key
+        $ordersubkey = 'sequence';
+        StrawberryfieldJsonHelper::orderSequence($jsondata, $key, $ordersubkey);
+        foreach ($jsondata[$key] as $mediaitem) {
+          $i++;
+          if ($i > $number_documents && (int)$number_documents !=0) {
+            break;
+          }
+          if (isset($mediaitem['type']) && $mediaitem['type'] == 'Document') {
+            if (isset($mediaitem['dr:fid'])) {
+              // @TODO check if loading the entity is really needed to check access.
+              // @TODO we can refactor a lot here and move it to base methods
+              $file = OcflHelper::resolvetoFIDtoURI(
+                $mediaitem['dr:fid']
+              );
+              if (!$file) {
+                continue;
+              }
+              //@TODO if no Document key to file loading was possible
+              // means we have a broken/missing media reference
+              // we should inform to logs and continue
+              // Also check if user has access and the mimeType is of an PDF.
+              if ($this->checkAccess($file) && $file->getMimeType() == 'application/pdf') {
+                $documenturl = $file->getFileUri();
+                // We assume here file could not be accessible publicly
+                $route_parameters = [
+                  'node' => $nodeid,
+                  'uuid' => $file->uuid(),
+                  'format' => 'default.'. pathinfo($file->getFilename(), PATHINFO_EXTENSION)
+                ];
+                $publicurl = Url::fromRoute('format_strawberryfield.iiifbinary', $route_parameters);
+                $uniqueid =
+                  'pdf-' . $items->getName(
+                  ) . '-' . $nodeuuid . '-' . $delta . '-document' . $i;
+
+                //@TODO make a select component that is ajax driven.
+                // If we have more than a single Document, simply rebuild and reload the given $delta instead of rendering
+                // Multiple deltas as i do here.
+                $elements[$delta]['controller' . $i] = [
+                  '#theme' => 'format_strawberryfield_pdfs',
+                  '#item' =>  [
+                    'id' =>  'document_' . $uniqueid,
+                  ]
+                ];
+                $elements[$delta]['pdf' . $i] = [
+                  '#type' => 'html_tag',
+                  '#tag' => 'canvas',
+                  '#attributes' => [
+                      'class' => ['field-pdf-canvas','strawberry-document-item'],
+                      'id' => 'document_' . $uniqueid,
+                      'style' => "max-width:{$max_width}px;height:{$max_height}",
+                      'data-iiif-document' =>  $publicurl->toString(),
+                      'data-iiif-initialpage' => $initial_page,
+                      'data-iiif-document-width' => $max_width,
+                      'data-iiif-document-height' => $max_height,
+                      'data-iiif-pages' => $number_pages,
+                    ],
+                   '#alt' => $this->t(
+                      'PDF @name for  @label',
+                      [
+                        '@label' => $items->getEntity()->label(),
+                        '@name' => $file->getFilename()
+                      ]),
+                  ];
+
+                  $elements[$delta]['pdf'.$i]['#attached']['drupalSettings']['format_strawberryfield']['pdf']['innode'][$uniqueid] = $nodeuuid;
+                  $elements[$delta]['#attached']['library'][] = 'format_strawberryfield/pdfs_strawberry';
+
+              }
+              else {
+                // @TODO Deal with no access here
+                // Should we put a thumb? Just hide?
+                // @TODO we can bring a plugin here and there that deals with
+                $elements[$delta]['pdf'.$i] = [
+                  '#markup' => '<i class="fas fa-times-circle"></i>',
+                  '#prefix' => '<span>',
+                  '#suffix' => '</span>',
+                ];
+              }
+            } elseif (isset($mediaitem['url'])) {
+              // TODO. We can serve non mananged by US PDFS directly here
+              // We would just have less data. But that is all
+              $elements[$delta]['[pdf'.$i] = [
+                '#markup' => 'Non managed '.$mediaitem['url'],
+                '#prefix' => '<pre>',
+                '#suffix' => '</pre>',
+              ];
+            }
+
+          }
+        }
+      }
+      // Get rid of empty #attributes key to avoid render error
+      if (isset( $elements[$delta]["#attributes"]) && empty( $elements[$delta]["#attributes"])) {
+        unset($elements[$delta]["#attributes"]);
+      }
+    }
+    return $elements;
+  }
+}

--- a/templates/format-strawberryfield-pdfs.html.twig
+++ b/templates/format-strawberryfield-pdfs.html.twig
@@ -1,0 +1,5 @@
+<div class="format-strawberryfield-pdfs-controller">
+    <div class="pages">Pages: <span id="{{ item.id }}-pagenum">1</span>&nbsp;of <span id="{{ item.id }}-pagecount"></span></div>
+    <button id="{{ item.id }}-next" type="button" title="{{ 'Next'|t }}">Next</button>
+    <button id="{{ item.id }}-prev" type="button" title="{{ 'Previous'|t }}">Previous</button>
+</div>


### PR DESCRIPTION
# Whats this?

Well it took me more hours of course to get this quite basic PDF viewer going.

Since Mozilla encourages (ask please) to people to **NOT use their Viewer directly** without modifying, and re-skinning (and some folks _i know_ have been not reading that well..), lets help Mozilla and go minimal. So i went the minimal, but we can can then extend. Its using PDF.js core only, with async loading of pages and next/prev buttons via a theme hook.

There is quite some work to do to make this look Pro, like when we have more than a single PDF we should show a select button and reload JS based on that.

Also, we need to implement, at least! the Search/highlighter. Option one would be through https://github.com/mozilla/pdf.js/blob/93aa613db7a874e6ed964f394241605d5586c142/web/pdf_find_controller.js but seems quite easier to go reusing the viewer.js[1] component an theming/reducing it, at least simpler than what i did here!

[1] https://github.com/mozilla/pdf.js/blob/master/examples/components/simpleviewer.js#L58

Also:

## Make our Display Mode mappings universally kick-ass  …

Now we enforce our rule (own rules) based rdf/json key type mapper to kick a particulat `View mode` only when looking at an Object in its native/own URL, a.k.a as landing page. 

But hey, what if i remove a condition and this happens everytime the default (named 'full') display mode is present and we actually have a mapping set up? Would that not be great? Well here you have it.

Side note: i really like the function `node_is_page()`, i will forget about his `existence` once i merge this. Live well `node_is_page`. We will meet again some day.