### PR TITLE
ISSUE-49: Small fix for IIIF entities generated from a node list

### DIFF
--- a/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
@@ -681,7 +681,7 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
     FieldItemInterface $item
   ) {
     $manifests = [];
-
+    $cleannodelist = [];
     if ($this->getSetting('manifestnodelist_json_key_source') && $this->getSetting('metadataexposeentity_source')) {
       $jsonkey = $this->getSetting('manifestnodelist_json_key_source');
       $entity = $this->entityTypeManager->getStorage(
@@ -699,23 +699,33 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
             }
           }
           else {
-            if (is_integer($jsondata[$jsonkey])){
+            if (is_integer($jsondata[$jsonkey])) {
               $cleannodelist[] = $jsondata[$jsonkey];
             }
           }
-        }
-        foreach ($this->entityTypeManager->getStorage('node')->loadMultiple(
-          $cleannodelist
-        ) as $node) {
-          $has_access = $access_manager->checkNamedRoute('format_strawberryfield.metadatadisplay_caster', ['node' => $node->uuid(), 'metadataexposeconfig_entity' => $entity->id(), 'format' => 'manifest.jsonld' ], $this->currentUser);
-          if ($has_access) {
-            $manifests[] = $entity->getUrlForItemFromNodeUUID($node->uuid(), TRUE);
+
+          foreach ($this->entityTypeManager->getStorage('node')->loadMultiple(
+            $cleannodelist
+          ) as $node) {
+            $has_access = $access_manager->checkNamedRoute(
+              'format_strawberryfield.metadatadisplay_caster',
+              [
+                'node' => $node->uuid(),
+                'metadataexposeconfig_entity' => $entity->id(),
+                'format' => 'manifest.jsonld'
+              ],
+              $this->currentUser
+            );
+            if ($has_access) {
+              $manifests[] = $entity->getUrlForItemFromNodeUUID(
+                $node->uuid(),
+                TRUE
+              );
+            }
           }
         }
       }
     }
     return $manifests;
   }
-
-
 }


### PR DESCRIPTION
# What is new?

Missed an edge (not so edge really) test case i was not handling correctly. If no JSON KEY for a node list exists and/or its empty, we try to load the entities anyway but` $cleannodelist`.list variable is not even initialised. Silly. Fix is simple

Just moves NODE loading into the IF jsonkey exists and initialize $cleannodelist. This deals with empty keys and non existing keys.