### PR TITLE
Issue-54: Figure out schema format for display_field_copy settings

### DIFF
--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -258,7 +258,10 @@ format_strawberryfield.viewmodemapping_settings.mapping:
       label: 'Order in which this is evaluated'
 
 # todo: not working, for other copy fields as well (static, image)
-# if I can figure out the display field copy schema issues it will solve the majority of errors
+# this is the way to fixing all the core.entity_view_display errors (most of the errors)
+# problem is missing schema for ds.field_plugin.display_field_copy:node-formatted_metadata (or any of the other 2 copyfields) SETTINGS
+# if I can figure out the display field copy settings schema issues it will solve the majority of errors
+# this example is just dealing with strawberry_metadata_formatter but there are errors with many other formatter settings as well
 #'ds.field_plugin.display_field_copy:node-formatted_metadata':
 #  type: mapping
 #  label: 'Settings'

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -72,6 +72,12 @@ format_strawberryfield.formatter.strawberry_media_formatter:
       label: 'Whether multiple media sources should use a single IIIF viewer or not.'
     thumbnails:
       type: boolean
+    specs:
+      type: string
+      label: 'Specs'
+    metadatadisplayentity_id:
+      type: string
+      label: 'Metadata Display ID'
 format_strawberryfield.formatter.strawberry_metadata_formatter:
   type: config_object
   label: 'Specific Config for strawberry_metadata_formatter using Twig'
@@ -234,7 +240,6 @@ format_strawberryfield.viewmodemapping_settings:
       label: 'JSON type key to View Mode Mapping'
       sequence:
         type: format_strawberryfield.viewmodemapping_settings.mapping
-
 format_strawberryfield.viewmodemapping_settings.mapping:
   type: mapping
   label: 'JSON Type Key/ View Mode pair'
@@ -252,5 +257,15 @@ format_strawberryfield.viewmodemapping_settings.mapping:
       type: integer
       label: 'Order in which this is evaluated'
 
-
+# todo: not working, for other copy fields as well (static, image)
+# if I can figure out the display field copy schema issues it will solve the majority of errors
+#'ds.field_plugin.display_field_copy:node-formatted_metadata':
+#  type: mapping
+#  label: 'Settings'
+#  mapping:
+#    settings:
+#      type: mapping
+#      mapping:
+#        formatter:
+#          type: format_strawberryfield.formatter.strawberry_metadata_formatter
 


### PR DESCRIPTION
! Work in Progress ! addressing #54 

@DiegoPino I could use some guidance.

Most of our errors are related to core.entity_view_display, and when you dig deeper there are missing schema for copy fields
![Screen Shot 2020-02-18 at 8 12 45 PM](https://user-images.githubusercontent.com/1328900/74801318-12595e80-528b-11ea-821d-0185f3a2c838.png)

For example
`third_party_settings.ds.fields.display_field_copy:node-static_media.settings` (missing schema)

I looked into file `ds.entity_display.schema.yml` where I found the following:
```
    fields:
      type: sequence
      label: 'The Display Suite field plugins'
      sequence:
        - type: mapping
          label: 'A Display Suite field plugin'
          mapping:
            plugin_id:
              type: string
              label: 'The plugin ID of the field'
            weight:
              type: integer
              label: 'The weight of the field'
            label:
              type: string
              label: 'The position of the label'
            formatter:
              type: string
              label: 'The formatter of the field'
            settings:
              type: ds.field_plugin.[%parent.plugin_id]
            ft:
              type: ds.field_template.settings
```
And based on that you can see what I tried in the pull (commented out).
This works to fix missing schema on settings, but introduces a missing schema for formatter, so I am obviously missing the mark. If you have a suggestion I can likely take it to fix the rest of the errors. Thanks!

