### PR TITLE
ISSUE-54: Fix for good the ds.field schema issue related to formatters 

### DIFF
--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -13,8 +13,12 @@ field.formatter.settings.strawberry_audio_formatter:
   type: mapping
   label: 'Specific config for strawberry_audio_formatter'
   mapping:
-    iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
-    iiif_base_url_internal: format_strawberryfield.iiif_settings.int_server_url
+    iiif_base_url:
+      type: string
+      label: 'Custom Public IIIF Server URL'
+    iiif_base_url_internal:
+      type: string
+      label: 'Custom internal IIIF Server URL'
     json_key_source:
       type: string
       label: 'Strawberryfield/JSON key containing file URIs to display'
@@ -33,8 +37,12 @@ field.formatter.settings.strawberry_image_formatter:
   type: mapping
   label: 'Specific Config for strawberry_image_formatter'
   mapping:
-    iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
-    iiif_base_url_internal: format_strawberryfield.iiif_settings.int_server_url
+    iiif_base_url:
+      type: string
+      label: 'Custom Public IIIF Server URL'
+    iiif_base_url_internal:
+      type: string
+      label: 'Custom internal IIIF Server URL'
     json_key_source:
       type: string
       label: 'Strawberryfield/JSON key containing file URIs to display'
@@ -55,8 +63,12 @@ field.formatter.settings.strawberry_media_formatter:
   type: mapping
   label: 'Specific Config for strawberry_media_formatter'
   mapping:
-    iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
-    iiif_base_url_internal: format_strawberryfield.iiif_settings.int_server_url
+    iiif_base_url:
+      type: string
+      label: 'Custom Public IIIF Server URL'
+    iiif_base_url_internal:
+      type: string
+      label: 'Custom internal IIIF Server URL'
     json_key_source:
       type: string
       label: 'Strawberryfield/JSON key containing file URIs to display'
@@ -76,8 +88,12 @@ field.formatter.settings.strawberry_metadata_formatter:
   type: mapping
   label: 'Specific Config for strawberry_metadata_formatter using Twig'
   mapping:
-    iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
-    iiif_base_url_internal: format_strawberryfield.iiif_settings.int_server_url
+    iiif_base_url:
+      type: string
+      label: 'Custom Public IIIF Server URL'
+    iiif_base_url_internal:
+      type: string
+      label: 'Custom internal IIIF Server URL'
     json_key_source:
       type: string
       label: 'Strawberryfield/JSON key containing file URIs to display'
@@ -101,6 +117,12 @@ field.formatter.settings.strawberry_paged_formatter:
   type: mapping
   label: 'Specific Config for strawberry_paged_formatter'
   mapping:
+    iiif_base_url:
+      type: string
+      label: 'Custom Public IIIF Server URL'
+    iiif_base_url_internal:
+      type: string
+      label: 'Custom internal IIIF Server URL'
     iiif_group:
       type: boolean
       label: 'Whether multiple media sources should use a single IIIF viewer or not.'
@@ -114,8 +136,12 @@ field.formatter.settings.strawberry_pannellum_formatter:
   type: mapping
   label: 'Specific Config for strawberry_pannellum_formatter'
   mapping:
-    iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
-    iiif_base_url_internal: format_strawberryfield.iiif_settings.int_server_url
+    iiif_base_url:
+      type: string
+      label: 'Custom Public IIIF Server URL'
+    iiif_base_url_internal:
+      type: string
+      label: 'Custom internal IIIF Server URL'
     json_key_source:
       type: string
       label: 'Strawberryfield/JSON key containing file URIs to display'
@@ -146,8 +172,12 @@ field.formatter.settings.settings.strawberry_video_formatter:
   type: mapping
   label: 'Specific Config for strawberry_video_formatter'
   mapping:
-    iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
-    iiif_base_url_internal: format_strawberryfield.iiif_settings.int_server_url
+    iiif_base_url:
+      type: string
+      label: 'Custom Public IIIF Server URL'
+    iiif_base_url_internal:
+      type: string
+      label: 'Custom internal IIIF Server URL'
     json_key_source:
       type: string
       label: 'Strawberryfield/JSON key containing file URIs to display'
@@ -170,8 +200,12 @@ field.formatter.settings.settings.strawberry_pdf_formatter:
   type: mapping
   label: 'Specific Config for strawberry_pdf_formatter'
   mapping:
-    iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
-    iiif_base_url_internal: format_strawberryfield.iiif_settings.int_server_url
+    iiif_base_url:
+      type: string
+      label: 'Custom Public IIIF Server URL'
+    iiif_base_url_internal:
+      type: string
+      label: 'Custom internal IIIF Server URL'
     json_key_source:
       type: string
       label: 'Strawberryfield/JSON key containing file URIs to display'
@@ -196,8 +230,12 @@ field.formatter.settings.settings.strawberry_mirador_formatter:
   type: mapping
   label: 'Specific Config for strawberry_pdf_formatter'
   mapping:
-    iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
-    iiif_base_url_internal: format_strawberryfield.iiif_settings.int_server_url
+    iiif_base_url:
+      type: string
+      label: 'Custom Public IIIF Server URL'
+    iiif_base_url_internal:
+      type: string
+      label: 'Custom internal IIIF Server URL'
     mediasource:
       type: sequence
       label: 'Sources for IIIF URL'

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -264,7 +264,7 @@ field.formatter.settings.strawberry_mirador_formatter:
     metadataexposeentity_source:
       type: string
       label: 'metadataexpose_entity machine name'
-     manifestnodelist_json_key_source:
+    manifestnodelist_json_key_source:
       type: string
       label: 'Strawberryfield/JSON key containing NODE ids or UUIDs from which to generate Manifest URLs'
     manifesturl_json_key_source:

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -168,7 +168,7 @@ field.formatter.settings.strawberry_pannellum_formatter:
       type: string
     autoLoad:
       type: boolean
-field.formatter.settings.settings.strawberry_video_formatter:
+field.formatter.settings.strawberry_video_formatter:
   type: mapping
   label: 'Specific Config for strawberry_video_formatter'
   mapping:
@@ -196,7 +196,7 @@ field.formatter.settings.settings.strawberry_video_formatter:
       type: integer
     posterframe:
       type: string
-field.formatter.settings.settings.strawberry_pdf_formatter:
+field.formatter.settings.strawberry_pdf_formatter:
   type: mapping
   label: 'Specific Config for strawberry_pdf_formatter'
   mapping:
@@ -226,7 +226,7 @@ field.formatter.settings.settings.strawberry_pdf_formatter:
     initial_pages:
       type: integer
       label: 'First Page to display per PDF'
-field.formatter.settings.settings.strawberry_mirador_formatter:
+field.formatter.settings.strawberry_mirador_formatter:
   type: mapping
   label: 'Specific Config for strawberry_pdf_formatter'
   mapping:
@@ -290,5 +290,8 @@ format_strawberryfield.viewmodemapping_settings.mapping:
       type: integer
       label: 'Order in which this is evaluated'
 
+# Given any DS field plugin formatter key a type
+ds.field_plugin.*.formatter:
+  type: field.formatter.settings.[%parent.%parent.formatter]
 
 

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -83,7 +83,31 @@ field.formatter.settings.strawberry_media_formatter:
       type: boolean
       label: 'Whether multiple media sources should use a single IIIF viewer or not.'
     thumbnails:
-      type: boolean
+      type:
+field.formatter.settings.strawberry_3d_formatter:
+  type: mapping
+  label: 'Specific Config for strawberry_3d_formatter'
+  mapping:
+    iiif_base_url:
+      type: string
+      label: 'Custom Public IIIF Server URL'
+    iiif_base_url_internal:
+      type: string
+      label: 'Custom internal IIIF Server URL'
+    json_key_source:
+      type: string
+      label: 'Strawberryfield/JSON key containing file URIs to display'
+    max_width:
+      type: string
+    max_height:
+      type: string
+    use_iiif_globals:
+      type: string
+      label: 'Whether to use global IIIF settings or not.'
+    number_models:
+      type: integer
+      label: 'Number of 3D Models to load from JSON'
+
 field.formatter.settings.strawberry_metadata_formatter:
   type: mapping
   label: 'Specific Config for strawberry_metadata_formatter using Twig'

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -51,7 +51,7 @@ field.formatter.settings.strawberry_image_formatter:
     max_height:
       type: string
     use_iiif_globals:
-      type: boolean
+      type: string
       label: 'Whether to use global IIIF settings or not.'
     number_images:
       type: integer
@@ -77,7 +77,7 @@ field.formatter.settings.strawberry_media_formatter:
     max_height:
       type: string
     use_iiif_globals:
-      type: boolean
+      type: string
       label: 'Whether to use global IIIF settings or not.'
     iiif_group:
       type: boolean
@@ -111,7 +111,7 @@ field.formatter.settings.strawberry_metadata_formatter:
     metadatadisplayentity_id:
       type: string
     metadatadisplayentity_uselabel:
-      type: string
+      type: integer
 field.formatter.settings.strawberry_paged_formatter:
   type: mapping
   label: 'Specific Config for strawberry_paged_formatter'
@@ -130,7 +130,7 @@ field.formatter.settings.strawberry_paged_formatter:
     max_height:
       type: string
     use_iiif_globals:
-      type: boolean
+      type: string
       label: 'Whether to use global IIIF settings or not.'
     mediasource:
       type: string
@@ -242,19 +242,29 @@ field.formatter.settings.strawberry_mirador_formatter:
     iiif_base_url_internal:
       type: string
       label: 'Custom internal IIIF Server URL'
+    metadataexposeentity:
+      type: string
+      label: 'Machine name of the exposed Metadata Config Entity endpoint'
     mediasource:
-      type: sequence
+      type: mapping
       label: 'Sources for IIIF URL'
-    sequence:
-        type: string
-        label: 'Source for IIIF URL'
+      mapping:
+        manifestnodelist:
+          type: string
+          label: 'If manifestnodelist is being used'
+        metadataexposeentity:
+          type: string
+          label: 'If metadataexposeentity is being used'
+        manifesturl:
+          type: string
+          label: 'If manifesturl is being used'
     main_mediasource:
       type: string
       label: 'Primary IIIF URL Source used'
     metadataexposeentity_source:
       type: string
       label: 'metadataexpose_entity machine name'
-    manifestnodelist_json_key_source:
+     manifestnodelist_json_key_source:
       type: string
       label: 'Strawberryfield/JSON key containing NODE ids or UUIDs from which to generate Manifest URLs'
     manifesturl_json_key_source:
@@ -266,7 +276,7 @@ field.formatter.settings.strawberry_mirador_formatter:
     max_height:
       type: string
     use_iiif_globals:
-      type: boolean
+      type: string
       label: 'Whether to use global IIIF settings or not.'
 # Multiple JSON type / View Mode Mappings
 format_strawberryfield.viewmodemapping_settings:

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -111,7 +111,7 @@ field.formatter.settings.strawberry_metadata_formatter:
     metadatadisplayentity_id:
       type: string
     metadatadisplayentity_uselabel:
-      type: integer
+      type: string
 field.formatter.settings.strawberry_paged_formatter:
   type: mapping
   label: 'Specific Config for strawberry_paged_formatter'

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -33,6 +33,8 @@ field.formatter.settings.strawberry_audio_formatter:
       type: string
     number_media:
       type: integer
+    number_audios:
+      type: integer
 field.formatter.settings.strawberry_image_formatter:
   type: mapping
   label: 'Specific Config for strawberry_image_formatter'
@@ -55,6 +57,8 @@ field.formatter.settings.strawberry_image_formatter:
       label: 'Whether to use global IIIF settings or not.'
     number_images:
       type: integer
+    images_type:
+      type: string
     quality:
       type: string
     rotation:
@@ -85,7 +89,9 @@ field.formatter.settings.strawberry_media_formatter:
     thumbnails:
       type: boolean
       label: 'TNs?'
-
+    number_images:
+      type: integer
+      label: 'Number of images'
 field.formatter.settings.strawberry_3d_formatter:
   type: mapping
   label: 'Specific Config for strawberry_3d_formatter'
@@ -138,6 +144,16 @@ field.formatter.settings.strawberry_metadata_formatter:
       type: string
     metadatadisplayentity_uselabel:
       type: string
+    mediasource:
+      type: string
+    main_mediasource:
+      type: string
+    metadataexposeentity_source:
+      type: string
+    manifesturl_json_key_source:
+      type: string
+    manifestnodelist_json_key_source:
+      type: string
 field.formatter.settings.strawberry_paged_formatter:
   type: mapping
   label: 'Specific Config for strawberry_paged_formatter'
@@ -151,6 +167,9 @@ field.formatter.settings.strawberry_paged_formatter:
     iiif_group:
       type: boolean
       label: 'Whether multiple media sources should use a single IIIF viewer or not.'
+    json_key_source:
+      type: string
+      label: 'Strawberryfield/JSON key containing file URIs to display'
     max_width:
       type: string
     max_height:
@@ -200,6 +219,9 @@ field.formatter.settings.strawberry_pannellum_formatter:
       type: string
     autoLoad:
       type: boolean
+    number_images:
+      type: integer
+      label: "Number of Images"
 field.formatter.settings.strawberry_video_formatter:
   type: mapping
   label: 'Specific Config for strawberry_video_formatter'
@@ -275,15 +297,15 @@ field.formatter.settings.strawberry_mirador_formatter:
       type: mapping
       label: 'Sources for IIIF URL'
       mapping:
-        manifestnodelist:
-          type: string
-          label: 'If manifestnodelist is being used'
-        metadataexposeentity:
-          type: string
-          label: 'If metadataexposeentity is being used'
-        manifesturl:
-          type: string
-          label: 'If manifesturl is being used'
+      manifestnodelist:
+        type: string
+        label: 'If manifestnodelist is being used'
+      metadataexposeentity:
+        type: string
+        label: 'If metadataexposeentity is being used'
+      manifesturl:
+        type: string
+        label: 'If manifesturl is being used'
     main_mediasource:
       type: string
       label: 'Primary IIIF URL Source used'
@@ -339,6 +361,4 @@ ds.field_plugin.*:
     formatter:
       type: field.formatter.settings.[%parent.%parent.formatter]
       label: "Formatter settings for a generic ds.field plugin"
-
-
 

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -255,7 +255,7 @@ field.formatter.settings.strawberry_pdf_formatter:
     number_pages:
       type: integer
       label: 'Number of Pages to show per PDF'
-    initial_pages:
+    initial_page:
       type: integer
       label: 'First Page to display per PDF'
 field.formatter.settings.strawberry_mirador_formatter:

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -33,8 +33,7 @@ field.formatter.settings.strawberry_audio_formatter:
       type: string
     number_media:
       type: integer
-    number_audios:
-      type: integer
+
 field.formatter.settings.strawberry_image_formatter:
   type: mapping
   label: 'Specific Config for strawberry_image_formatter'
@@ -143,16 +142,6 @@ field.formatter.settings.strawberry_metadata_formatter:
     metadatadisplayentity_id:
       type: string
     metadatadisplayentity_uselabel:
-      type: string
-    mediasource:
-      type: string
-    main_mediasource:
-      type: string
-    metadataexposeentity_source:
-      type: string
-    manifesturl_json_key_source:
-      type: string
-    manifestnodelist_json_key_source:
       type: string
 field.formatter.settings.strawberry_paged_formatter:
   type: mapping
@@ -297,15 +286,15 @@ field.formatter.settings.strawberry_mirador_formatter:
       type: mapping
       label: 'Sources for IIIF URL'
       mapping:
-      manifestnodelist:
-        type: string
-        label: 'If manifestnodelist is being used'
-      metadataexposeentity:
-        type: string
-        label: 'If metadataexposeentity is being used'
-      manifesturl:
-        type: string
-        label: 'If manifesturl is being used'
+        manifestnodelist:
+          type: string
+          label: 'If manifestnodelist is being used'
+        metadataexposeentity:
+          type: string
+          label: 'If metadataexposeentity is being used'
+        manifesturl:
+          type: string
+          label: 'If manifesturl is being used'
     main_mediasource:
       type: string
       label: 'Primary IIIF URL Source used'

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -83,7 +83,9 @@ field.formatter.settings.strawberry_media_formatter:
       type: boolean
       label: 'Whether multiple media sources should use a single IIIF viewer or not.'
     thumbnails:
-      type:
+      type: boolean
+      label: 'TNs?'
+
 field.formatter.settings.strawberry_3d_formatter:
   type: mapping
   label: 'Specific Config for strawberry_3d_formatter'

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -9,7 +9,7 @@ format_strawberryfield.iiif_settings:
       type: string
       label: 'Internal IIIF server URL'
 
-format_strawberryfield.formatter.strawberry_audio_formatter:
+field.formatter.settings.strawberry_audio_formatter:
   type: config_object
   label: 'Specific config for strawberry_audio_formatter'
   mapping:
@@ -29,7 +29,7 @@ format_strawberryfield.formatter.strawberry_audio_formatter:
       type: string
     number_media:
       type: integer
-format_strawberryfield.formatter.strawberry_image_formatter:
+field.formatter.settings.strawberry_image_formatter:
   type: config_object
   label: 'Specific Config for strawberry_image_formatter'
   mapping:
@@ -51,7 +51,7 @@ format_strawberryfield.formatter.strawberry_image_formatter:
       type: string
     rotation:
       type: string
-format_strawberryfield.formatter.strawberry_media_formatter:
+field.formatter.settings.strawberry_media_formatter:
   type: config_object
   label: 'Specific Config for strawberry_media_formatter'
   mapping:
@@ -72,7 +72,7 @@ format_strawberryfield.formatter.strawberry_media_formatter:
       label: 'Whether multiple media sources should use a single IIIF viewer or not.'
     thumbnails:
       type: boolean
-format_strawberryfield.formatter.strawberry_metadata_formatter:
+field.formatter.settings.strawberry_metadata_formatter:
   type: config_object
   label: 'Specific Config for strawberry_metadata_formatter using Twig'
   mapping:
@@ -97,7 +97,7 @@ format_strawberryfield.formatter.strawberry_metadata_formatter:
       type: string
     metadatadisplayentity_uselabel:
       type: boolean
-format_strawberryfield.formatter.strawberry_paged_formatter:
+field.formatter.settings.strawberry_paged_formatter:
   type: config_object
   label: 'Specific Config for strawberry_paged_formatter'
   mapping:
@@ -110,7 +110,7 @@ format_strawberryfield.formatter.strawberry_paged_formatter:
       type: string
     manifesturl_source:
       type: string
-format_strawberryfield.formatter.strawberry_pannellum_formatter:
+field.formatter.settings.strawberry_pannellum_formatter:
   type: config_object
   label: 'Specific Config for strawberry_pannellum_formatter'
   mapping:
@@ -142,7 +142,7 @@ format_strawberryfield.formatter.strawberry_pannellum_formatter:
       type: string
     autoLoad:
       type: boolean
-format_strawberryfield.formatter.settings.strawberry_video_formatter:
+field.formatter.settings.settings.strawberry_video_formatter:
   type: config_object
   label: 'Specific Config for strawberry_video_formatter'
   mapping:
@@ -166,7 +166,7 @@ format_strawberryfield.formatter.settings.strawberry_video_formatter:
       type: integer
     posterframe:
       type: string
-format_strawberryfield.formatter.settings.strawberry_pdf_formatter:
+field.formatter.settings.settings.strawberry_pdf_formatter:
   type: config_object
   label: 'Specific Config for strawberry_pdf_formatter'
   mapping:
@@ -192,7 +192,7 @@ format_strawberryfield.formatter.settings.strawberry_pdf_formatter:
     initial_pages:
       type: integer
       label: 'First Page to display per PDF'
-format_strawberryfield.formatter.settings.strawberry_mirador_formatter:
+field.formatter.settings.settings.strawberry_mirador_formatter:
   type: config_object
   label: 'Specific Config for strawberry_pdf_formatter'
   mapping:

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -23,11 +23,11 @@ field.formatter.settings.strawberry_audio_formatter:
       type: string
       label: 'Strawberryfield/JSON key containing file URIs to display'
     max_width:
-      type: integer
+      type: string
     max_height:
-      type: integer
+      type: string
     use_iiif_globals:
-      type: boolean
+      type: string
       label: 'Whether to use global IIIF settings or not.'
     audio_type:
       type: string
@@ -47,9 +47,9 @@ field.formatter.settings.strawberry_image_formatter:
       type: string
       label: 'Strawberryfield/JSON key containing file URIs to display'
     max_width:
-      type: integer
+      type: string
     max_height:
-      type: integer
+      type: string
     use_iiif_globals:
       type: boolean
       label: 'Whether to use global IIIF settings or not.'
@@ -73,9 +73,9 @@ field.formatter.settings.strawberry_media_formatter:
       type: string
       label: 'Strawberryfield/JSON key containing file URIs to display'
     max_width:
-      type: integer
+      type: string
     max_height:
-      type: integer
+      type: string
     use_iiif_globals:
       type: boolean
       label: 'Whether to use global IIIF settings or not.'
@@ -102,17 +102,16 @@ field.formatter.settings.strawberry_metadata_formatter:
     max_height:
       type: integer
     use_iiif_globals:
-      type: boolean
+      type: string
       label: 'Whether to use global IIIF settings or not.'
     label:
       type: string
     specs:
-      type: url
-    # todo: Can you check metadatadisplayentity_id? not sure the id right now is a string but a number (since its the entity->id(). If we move to UUID i guess we can use string but we should also look at who/what natively exists to use uuid as a type
+      type: string
     metadatadisplayentity_id:
       type: string
     metadatadisplayentity_uselabel:
-      type: boolean
+      type: string
 field.formatter.settings.strawberry_paged_formatter:
   type: mapping
   label: 'Specific Config for strawberry_paged_formatter'
@@ -126,6 +125,13 @@ field.formatter.settings.strawberry_paged_formatter:
     iiif_group:
       type: boolean
       label: 'Whether multiple media sources should use a single IIIF viewer or not.'
+    max_width:
+      type: string
+    max_height:
+      type: string
+    use_iiif_globals:
+      type: boolean
+      label: 'Whether to use global IIIF settings or not.'
     mediasource:
       type: string
     metadatadisplayentity_source:
@@ -146,11 +152,11 @@ field.formatter.settings.strawberry_pannellum_formatter:
       type: string
       label: 'Strawberryfield/JSON key containing file URIs to display'
     max_width:
-      type: integer
+      type: string
     max_height:
-      type: integer
+      type: string
     use_iiif_globals:
-      type: boolean
+      type: string
       label: 'Whether to use global IIIF settings or not.'
     hotSpotDebug:
       type: boolean
@@ -182,11 +188,11 @@ field.formatter.settings.strawberry_video_formatter:
       type: string
       label: 'Strawberryfield/JSON key containing file URIs to display'
     max_width:
-      type: integer
+      type: string
     max_height:
-      type: integer
+      type: string
     use_iiif_globals:
-      type: boolean
+      type: string
       label: 'Whether to use global IIIF settings or not.'
     audio_type:
       type: string
@@ -213,9 +219,9 @@ field.formatter.settings.strawberry_pdf_formatter:
       type: string
       label: 'Max with for the Viewer. Can be either a % or just a number'
     max_height:
-      type: integer
+      type: string
     use_iiif_globals:
-      type: boolean
+      type: string
       label: 'Whether to use global IIIF settings or not.'
     number_documents:
       type: integer
@@ -258,7 +264,7 @@ field.formatter.settings.strawberry_mirador_formatter:
       type: string
       label: 'Max with for the Viewer. Can be either a % or just a number'
     max_height:
-      type: integer
+      type: string
     use_iiif_globals:
       type: boolean
       label: 'Whether to use global IIIF settings or not.'
@@ -291,7 +297,12 @@ format_strawberryfield.viewmodemapping_settings.mapping:
       label: 'Order in which this is evaluated'
 
 # Given any DS field plugin formatter key a type
-ds.field_plugin.*.formatter:
-  type: field.formatter.settings.[%parent.%parent.formatter]
+ds.field_plugin.*:
+  type: mapping
+  mapping:
+    formatter:
+      type: field.formatter.settings.[%parent.%parent.formatter]
+      label: "Formatter settings for a generic ds.field plugin"
+
 
 

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -10,7 +10,7 @@ format_strawberryfield.iiif_settings:
       label: 'Internal IIIF server URL'
 
 field.formatter.settings.strawberry_audio_formatter:
-  type: config_object
+  type: mapping
   label: 'Specific config for strawberry_audio_formatter'
   mapping:
     iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
@@ -30,7 +30,7 @@ field.formatter.settings.strawberry_audio_formatter:
     number_media:
       type: integer
 field.formatter.settings.strawberry_image_formatter:
-  type: config_object
+  type: mapping
   label: 'Specific Config for strawberry_image_formatter'
   mapping:
     iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
@@ -52,7 +52,7 @@ field.formatter.settings.strawberry_image_formatter:
     rotation:
       type: string
 field.formatter.settings.strawberry_media_formatter:
-  type: config_object
+  type: mapping
   label: 'Specific Config for strawberry_media_formatter'
   mapping:
     iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
@@ -73,7 +73,7 @@ field.formatter.settings.strawberry_media_formatter:
     thumbnails:
       type: boolean
 field.formatter.settings.strawberry_metadata_formatter:
-  type: config_object
+  type: mapping
   label: 'Specific Config for strawberry_metadata_formatter using Twig'
   mapping:
     iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
@@ -98,7 +98,7 @@ field.formatter.settings.strawberry_metadata_formatter:
     metadatadisplayentity_uselabel:
       type: boolean
 field.formatter.settings.strawberry_paged_formatter:
-  type: config_object
+  type: mapping
   label: 'Specific Config for strawberry_paged_formatter'
   mapping:
     iiif_group:
@@ -111,7 +111,7 @@ field.formatter.settings.strawberry_paged_formatter:
     manifesturl_source:
       type: string
 field.formatter.settings.strawberry_pannellum_formatter:
-  type: config_object
+  type: mapping
   label: 'Specific Config for strawberry_pannellum_formatter'
   mapping:
     iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
@@ -143,7 +143,7 @@ field.formatter.settings.strawberry_pannellum_formatter:
     autoLoad:
       type: boolean
 field.formatter.settings.settings.strawberry_video_formatter:
-  type: config_object
+  type: mapping
   label: 'Specific Config for strawberry_video_formatter'
   mapping:
     iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
@@ -167,7 +167,7 @@ field.formatter.settings.settings.strawberry_video_formatter:
     posterframe:
       type: string
 field.formatter.settings.settings.strawberry_pdf_formatter:
-  type: config_object
+  type: mapping
   label: 'Specific Config for strawberry_pdf_formatter'
   mapping:
     iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url
@@ -193,7 +193,7 @@ field.formatter.settings.settings.strawberry_pdf_formatter:
       type: integer
       label: 'First Page to display per PDF'
 field.formatter.settings.settings.strawberry_mirador_formatter:
-  type: config_object
+  type: mapping
   label: 'Specific Config for strawberry_pdf_formatter'
   mapping:
     iiif_base_url: format_strawberryfield.iiif_settings.pub_server_url


### PR DESCRIPTION
See #55 and #54 

# What is happening here?

So pull #19 introduced a lot of regression. Errors where not noticable since all our Archipelagos had already saved settings but the schema committed was not even visible, the naming convention matched nothing. I can't list all the errors, this was just too much.

This pull does the following:
- Normalizes back the names and fills the gap of missing formatter setting schemas, removes value? assignment when this is just a schema and also non-native types (seems like URL does not even exists?)
- [Uses a wild card](https://github.com/esmero/format_strawberryfield/commit/08718694f3d62721af2f3c0d8e378895288fc27f) to escape this non-sense  from drupal/ds module and solves #55 
```YAML
           label: 'The field name'
    fields:
      type: sequence
      label: 'The Display Suite field plugins'
      sequence:
        - type: mapping
          label: 'A Display Suite field plugin'
          mapping:
            plugin_id:
              type: string
              label: 'The plugin ID of the field'
            weight:
              type: integer
              label: 'The weight of the field'
            label:
              type: string
              label: 'The position of the label'
            formatter:
              type: string
              label: 'The formatter of the field'
            settings:
              type: ds.field_plugin.[%parent.plugin_id]
            ft:
              type: ds.field_template.settings
```
Which basically means, we have to know upfront what copyfields people will want, and gosh, those are UI driven decisions!

So we override a thing with a wildcard here and use %parent.%parent.formatter inheritance to give our formatter settings a proper schema type

@marlo-longley. I need you TO TEST this. Means:
checkout this branch. Clear cache. Go to Display Mode and save manually every Formatter we provide have (it needs to be the official archipelago-deployment as of today Febr. 20 2020) . Why? Because without schema in place we got a lot of stuff casted into Strings, when they could have been booleans/integers, etc.

After that check again your report and notify me here of what needs to be moved from one basic core type to another.
This will give you of course new errors, but all of them SO simple to resolve. No a week long work anymore. 

Please report back, this has waited too long and got here because of a TOO large, silly going back and forth pull, i failed to test. Thanks!





