### PR TITLE
ISSUE-54: Schema fixes

### DIFF
--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -144,16 +144,6 @@ field.formatter.settings.strawberry_metadata_formatter:
       type: string
     metadatadisplayentity_uselabel:
       type: string
-    mediasource:
-      type: string
-    main_mediasource:
-      type: string
-    metadataexposeentity_source:
-      type: string
-    manifesturl_json_key_source:
-      type: string
-    manifestnodelist_json_key_source:
-      type: string
 field.formatter.settings.strawberry_paged_formatter:
   type: mapping
   label: 'Specific Config for strawberry_paged_formatter'
@@ -297,15 +287,15 @@ field.formatter.settings.strawberry_mirador_formatter:
       type: mapping
       label: 'Sources for IIIF URL'
       mapping:
-      manifestnodelist:
-        type: string
-        label: 'If manifestnodelist is being used'
-      metadataexposeentity:
-        type: string
-        label: 'If metadataexposeentity is being used'
-      manifesturl:
-        type: string
-        label: 'If manifesturl is being used'
+        manifestnodelist:
+          type: string
+          label: 'If manifestnodelist is being used'
+        metadataexposeentity:
+          type: string
+          label: 'If metadataexposeentity is being used'
+        manifesturl:
+          type: string
+          label: 'If manifesturl is being used'
     main_mediasource:
       type: string
       label: 'Primary IIIF URL Source used'
@@ -326,6 +316,10 @@ field.formatter.settings.strawberry_mirador_formatter:
     use_iiif_globals:
       type: string
       label: 'Whether to use global IIIF settings or not.'
+    specs:
+      type: string
+    metadatadisplayentity_id:
+      type: string
 # Multiple JSON type / View Mode Mappings
 format_strawberryfield.viewmodemapping_settings:
   type: config_object

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -33,8 +33,7 @@ field.formatter.settings.strawberry_audio_formatter:
       type: string
     number_media:
       type: integer
-    number_audios:
-      type: integer
+
 field.formatter.settings.strawberry_image_formatter:
   type: mapping
   label: 'Specific Config for strawberry_image_formatter'
@@ -316,10 +315,6 @@ field.formatter.settings.strawberry_mirador_formatter:
     use_iiif_globals:
       type: string
       label: 'Whether to use global IIIF settings or not.'
-    specs:
-      type: string
-    metadatadisplayentity_id:
-      type: string
 # Multiple JSON type / View Mode Mappings
 format_strawberryfield.viewmodemapping_settings:
   type: config_object


### PR DESCRIPTION
This pull fixes mistakes I produced in #56 

## What is new
Remove extra mirador settings under metadata_formatter
Fix indentation for mirador_formatter mapping

I was able to address the problem of mirador and metadata formatter settings being saved to other formatters by going deeper into the form, and re-saving the formatter options, as well as the overall Manage Display form for a certain View Mode.
