### PR TITLE
ISSUE-59: Allow 100% with for all formatters and some ++candy

### DIFF
--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -142,7 +142,7 @@ field.formatter.settings.strawberry_metadata_formatter:
     metadatadisplayentity_id:
       type: string
     metadatadisplayentity_uselabel:
-      type: string
+      type: integer
 field.formatter.settings.strawberry_paged_formatter:
   type: mapping
   label: 'Specific Config for strawberry_paged_formatter'
@@ -301,7 +301,7 @@ field.formatter.settings.strawberry_mirador_formatter:
     metadataexposeentity_source:
       type: string
       label: 'metadataexpose_entity machine name'
-    manifestnodelist_json_key_source:
+     manifestnodelist_json_key_source:
       type: string
       label: 'Strawberryfield/JSON key containing NODE ids or UUIDs from which to generate Manifest URLs'
     manifesturl_json_key_source:

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -350,4 +350,3 @@ ds.field_plugin.*:
     formatter:
       type: field.formatter.settings.[%parent.%parent.formatter]
       label: "Formatter settings for a generic ds.field plugin"
-

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -142,7 +142,7 @@ field.formatter.settings.strawberry_metadata_formatter:
     metadatadisplayentity_id:
       type: string
     metadatadisplayentity_uselabel:
-      type: integer
+      type: string
 field.formatter.settings.strawberry_paged_formatter:
   type: mapping
   label: 'Specific Config for strawberry_paged_formatter'

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -301,7 +301,7 @@ field.formatter.settings.strawberry_mirador_formatter:
     metadataexposeentity_source:
       type: string
       label: 'metadataexpose_entity machine name'
-     manifestnodelist_json_key_source:
+    manifestnodelist_json_key_source:
       type: string
       label: 'Strawberryfield/JSON key containing NODE ids or UUIDs from which to generate Manifest URLs'
     manifesturl_json_key_source:

--- a/css/sbfutils.css
+++ b/css/sbfutils.css
@@ -1,0 +1,13 @@
+.sbf-preloader {
+    border: 2rem solid #f3f3f3; /* Light grey */
+    border-top: 2rem solid #3498db; /* Blue */
+    border-radius: 50%;
+    width: 4rem;
+    height: 4rem;
+    animation: incircles 1500ms linear infinite;
+}
+
+@keyframes incircles {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}

--- a/css/sbfutils.css
+++ b/css/sbfutils.css
@@ -1,10 +1,14 @@
 .sbf-preloader {
-    border: 2rem solid #f3f3f3; /* Light grey */
-    border-top: 2rem solid #3498db; /* Blue */
+    border: 1rem solid #f3f3f3;
+    border-top: 1rem solid #4b82bf;
     border-radius: 50%;
-    width: 4rem;
-    height: 4rem;
-    animation: incircles 1500ms linear infinite;
+    width: 3rem;
+    height: 3rem;
+    animation: incircles 1200ms linear infinite;
+    position: absolute;
+    left: 50%;
+    top: 10%;
+    pointer-events: none;
 }
 
 @keyframes incircles {

--- a/format_strawberryfield.libraries.yml
+++ b/format_strawberryfield.libraries.yml
@@ -94,6 +94,9 @@ jsm_modeler:
 
 jsm_model_strawberry:
   version: 1.0
+  css:
+    component:
+      css/sbfutils.css: {}
   js:
     js/jsm-model_strawberry.js: {minified: false}
   dependencies:

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -86,3 +86,11 @@ function format_strawberryfield_theme() {
     ],
   ];
 }
+
+function format_strawberryfield_file_mimetype_mapping_alter(&$mapping) {
+  // Add relevant Repository Mimetypes missing from D8
+  $mapping['extensions']['obj'] = 'obj_model_mimetype';
+  // @see https://www.iana.org/assignments/media-types/media-types.xhtml
+  $mapping['mimetypes']['obj_model_mimetype'] = 'model/obj';
+
+}

--- a/js/iiif-iabookreader_strawberry.js
+++ b/js/iiif-iabookreader_strawberry.js
@@ -8,11 +8,15 @@
                 .each(function (index, value) {
                     // Get the node uuid for this element
                     var element_id = $(this).attr("id");
+                    var default_width = drupalSettings.format_strawberryfield.iabookreader[element_id]['height'];
+                    var default_height = drupalSettings.format_strawberryfield.iabookreader[element_id]['width'];
+
                     // Check if we got some data passed via Drupal settings.
                     if (typeof(drupalSettings.format_strawberryfield.iabookreader[element_id]) != 'undefined') {
 
-                        $(this).height(drupalSettings.format_strawberryfield.iabookreader[element_id]['height']);
-                        $(this).width(drupalSettings.format_strawberryfield.iabookreader[element_id]['width']);
+                        $(this).height(default_height);
+                        $(this).css("width",default_width);
+
                         // Defines our basic options for IIIF.
                         var options = {
                             ui: 'full', // embed, full (responsive)

--- a/js/iiif-iabookreader_strawberry.js
+++ b/js/iiif-iabookreader_strawberry.js
@@ -8,8 +8,8 @@
                 .each(function (index, value) {
                     // Get the node uuid for this element
                     var element_id = $(this).attr("id");
-                    var default_width = drupalSettings.format_strawberryfield.iabookreader[element_id]['height'];
-                    var default_height = drupalSettings.format_strawberryfield.iabookreader[element_id]['width'];
+                    var default_width = drupalSettings.format_strawberryfield.iabookreader[element_id]['width'];
+                    var default_height = drupalSettings.format_strawberryfield.iabookreader[element_id]['height'];
 
                     // Check if we got some data passed via Drupal settings.
                     if (typeof(drupalSettings.format_strawberryfield.iabookreader[element_id]) != 'undefined') {

--- a/js/iiif-openseadragon_strawberry.js
+++ b/js/iiif-openseadragon_strawberry.js
@@ -10,10 +10,12 @@
             var showthumbs = false
             $('.strawberry-media-item[data-iiif-infojson]').once('attache_osd')
                 .each(function (index, value) {
-                    var default_width =  $(this).attr("width")>0 ? $(this).attr("width"): 320;
-                    var default_height = $(this).attr("height")>0 ? $(this).attr("height"): Math.round((default_width/4)*3);
+
                     // Get the node uuid for this element
                     var element_id = $(this).attr("id");
+                    var default_width = drupalSettings.format_strawberryfield.openseadragon[element_id]['height'];
+                    var default_height = drupalSettings.format_strawberryfield.openseadragon[element_id]['width'];
+
                     var group = $(this).data("iiif-group");
                     var infojson = $(this).data("iiif-infojson");
                     showthumbs = $(this).data("iiif-thumbnails");
@@ -23,8 +25,7 @@
                         groupsid[group] = element_id;
 
                         $(this).height(default_height);
-                        $(this).width(default_width);
-
+                        $(this).css("width",default_width);
 
                     }
                     else {

--- a/js/iiif-openseadragon_strawberry.js
+++ b/js/iiif-openseadragon_strawberry.js
@@ -13,9 +13,8 @@
 
                     // Get the node uuid for this element
                     var element_id = $(this).attr("id");
-                    var default_width = drupalSettings.format_strawberryfield.openseadragon[element_id]['height'];
-                    var default_height = drupalSettings.format_strawberryfield.openseadragon[element_id]['width'];
-
+                    var default_width = drupalSettings.format_strawberryfield.openseadragon[element_id]['width'];
+                    var default_height = drupalSettings.format_strawberryfield.openseadragon[element_id]['height'];
                     var group = $(this).data("iiif-group");
                     var infojson = $(this).data("iiif-infojson");
                     showthumbs = $(this).data("iiif-thumbnails");

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -35,6 +35,9 @@
                     // Get the node uuid for this element
                     var element_id = $(this).attr("id");
                     var $multiscene = drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('tour');
+                    var default_width = drupalSettings.format_strawberryfield.openseadragon[element_id]['height'];
+                    var default_height = drupalSettings.format_strawberryfield.openseadragon[element_id]['width'];
+
 
                     // Check if we got some data passed via Drupal settings.
                     if (typeof(drupalSettings.format_strawberryfield.pannellum[element_id]) != 'undefined') {
@@ -50,8 +53,8 @@
                                 hotspots.push(hotspotdata);
                             });
                         }
-                        $(this).height(520); //@TODO this needs to be a setting. C'mon
-                        $(this).css("width","100%");
+                        $(this).height(default_height); //@TODO this needs to be a setting. C'mon
+                        $(this).css("width",default_width);
 
                         console.log('Initializing Pannellum.')
                         // When loading a webform with an embeded Viewer

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -35,8 +35,8 @@
                     // Get the node uuid for this element
                     var element_id = $(this).attr("id");
                     var $multiscene = drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('tour');
-                    var default_width = drupalSettings.format_strawberryfield.pannellum[element_id]['height'];
-                    var default_height = drupalSettings.format_strawberryfield.pannellum[element_id]['width'];
+                    var default_width = drupalSettings.format_strawberryfield.pannellum[element_id]['width'];
+                    var default_height = drupalSettings.format_strawberryfield.pannellum[element_id]['height'];
 
 
                     // Check if we got some data passed via Drupal settings.
@@ -53,7 +53,7 @@
                                 hotspots.push(hotspotdata);
                             });
                         }
-                        $(this).height(default_height); //@TODO this needs to be a setting. C'mon
+                        $(this).height(default_height);
                         $(this).css("width",default_width);
 
                         console.log('Initializing Pannellum.')

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -35,8 +35,8 @@
                     // Get the node uuid for this element
                     var element_id = $(this).attr("id");
                     var $multiscene = drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('tour');
-                    var default_width = drupalSettings.format_strawberryfield.openseadragon[element_id]['height'];
-                    var default_height = drupalSettings.format_strawberryfield.openseadragon[element_id]['width'];
+                    var default_width = drupalSettings.format_strawberryfield.pannellum[element_id]['height'];
+                    var default_height = drupalSettings.format_strawberryfield.pannellum[element_id]['width'];
 
 
                     // Check if we got some data passed via Drupal settings.

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -10,7 +10,7 @@
                     var element_id = $(this).attr("id");
                     // Check if we got some data passed via Drupal settings.
                     var canvas = value;
-                    var canvasDom = $(this);
+                    var canvasDom = $(value);
                     var viewerSettings = {
                         cameraEyePosition: [-2.0, -1.5, 1.0],
                         cameraCenterPosition: [0.0, 0.0, 0.0],
@@ -28,11 +28,7 @@
                     function resizeCanvas ()
                     {
                         if (document.body.clientWidth < canvasDom.data("iiif-image-width")) {
-                            if (canvasDom instanceof (HTMLCanvasElement)) {
-                                canvasDom.width = document.body.clientWidth - 20;
-                            } else if (canvasDom instanceof (SVGSVGElement)) {
-                                canvasDom.setAttribute ('width', document.body.clientWidth - 20);
-                            }
+                                canvasDom.width(document.body.clientWidth - 20);
                         }
                     }
 

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -25,13 +25,10 @@
                     // If given width is less than window size, do nothing
                     // In any other case make it as width
                     // TODO. Deal with the parent container. noty
-                    function resizeCanvas (viewer)
-                    {
-                        console.log('resizing 3D canvas event called');
+                    function resizeCanvas () {
                         if (document.body.clientWidth < canvasDom.data("iiif-image-width")) {
                             canvasDom.width(document.body.clientWidth - 20);
-                            canvasDom.attr("width",document.body.clientWidth - 20);
-                            console.log('Actually resizing 3D canvas');
+                            canvasDom.attr("width", document.body.clientWidth - 20);
                         }
                     }
 

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -30,7 +30,6 @@
                         console.log('resizing 3D canvas event called');
                         if (document.body.clientWidth < canvasDom.data("iiif-image-width")) {
                                 canvasDom.width(document.body.clientWidth - 20);
-                                viewer.FitInWindow();
                                 console.log('Actually resizing 3D canvas');
                         }
                     }
@@ -75,19 +74,22 @@
                                             viewer.AdjustClippingPlanes(50.0);
                                             viewer.FitInWindow();
                                         }
+                                        console.log(viewer.renderer.domElement.toDataURL( 'image/png' ), 'screenshot');
                                         viewer.EnableDraw(true);
                                         viewer.Draw();
+                                        resizeCanvas();
+                                        $( window ).resize(function() {
+                                            resizeCanvas();
+                                            viewer.FitInWindow();
+                                        });
                                     }
                                 };
 
                                 var textureLoaded = function () {
                                     viewer.Draw();
-                                    console.log(viewer.renderer.domElement.toDataURL( 'image/png' ), 'screenshot');
                                 };
                                 JSM.ConvertJSONDataToThreeMeshes(jsonData, textureLoaded, environment);
-                                $( window ).resize(function(viewer) {
-                                    resizeCanvas(viewer);
-                                });
+
                             }
                         });
                     }

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -10,6 +10,7 @@
                     var element_id = $(this).attr("id");
                     // Check if we got some data passed via Drupal settings.
                     var canvas = value;
+                    var canvasDom = $(this);
                     var viewerSettings = {
                         cameraEyePosition: [-2.0, -1.5, 1.0],
                         cameraCenterPosition: [0.0, 0.0, 0.0],
@@ -27,11 +28,11 @@
                     function resizeCanvas ()
                     {
 
-                        if (canvas !== null && document.body.clientWidth < canvas.data("iiif-image-with")) {
-                            if (canvas instanceof (HTMLCanvasElement)) {
-                                canvas.width = document.body.clientWidth - 20;
-                            } else if (canvas instanceof (SVGSVGElement)) {
-                                canvas.setAttribute ('width', document.body.clientWidth - 20);
+                        if (canvasDom !== null && document.body.clientWidth < canvasDom.data("iiif-image-with")) {
+                            if (canvasDom instanceof (HTMLCanvasElement)) {
+                                canvasDom.width = document.body.clientWidth - 20;
+                            } else if (canvasDom instanceof (SVGSVGElement)) {
+                                canvasDom.setAttribute ('width', document.body.clientWidth - 20);
                             }
                         }
                     }

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -50,7 +50,7 @@
                             },
                             onReady: function (fileNames, jsonData) {
                                 var $div = $("<div>", {id: "jsm-preloader", "class": "sbf-preloader"});
-                                canvasDom.parent.append($div);
+                                canvasDom.parent().append($div);
                                 var viewer = new JSM.ThreeViewer();
                                 if (!viewer.Start(canvas, viewerSettings)) {
                                     console.log('Error initializing JSM Viewer' + element_id);

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -49,7 +49,7 @@
                                 return;
                             },
                             onReady: function (fileNames, jsonData) {
-                                var $div = $("<div>", {id: "jsm-preloader", "class": "ajax-progress-throbber throbber"});
+                                var $div = $("<div>", {id: "jsm-preloader", "class": "sbf-preloader"});
                                 canvasDom.append($div);
                                 var viewer = new JSM.ThreeViewer();
                                 if (!viewer.Start(canvas, viewerSettings)) {

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -49,7 +49,7 @@
                                 return;
                             },
                             onReady: function (fileNames, jsonData) {
-                                var $div = $("<div>", {id: "jsm-preloader", "class": "ajax-progress--throbber"});
+                                var $div = $("<div>", {id: "jsm-preloader", "class": "ajax-progress-throbber throbber"});
                                 canvasDom.append($div);
                                 var viewer = new JSM.ThreeViewer();
                                 if (!viewer.Start(canvas, viewerSettings)) {

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -66,6 +66,7 @@
 
                                 var textureLoaded = function () {
                                     viewer.Draw();
+                                    console.log(viewer.renderer.domElement.toDataURL( 'image/png' ), 'screenshot');
                                 };
                                 JSM.ConvertJSONDataToThreeMeshes(jsonData, textureLoaded, environment);
                             }

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -19,6 +19,23 @@
                     var sourceurl = $(value).data('iiif-model');
                     var browser_supported = JSM.IsWebGLEnabled() && JSM.IsFileApiEnabled();
 
+
+                    // Ajusts width to what ever is smallest.
+                    // If given width is less than window size, do nothing
+                    // In any other case make it as width
+                    // TODO. Deal with the parent container. noty
+                    function resizeCanvas ()
+                    {
+
+                        if (canvas !== null && document.body.clientWidth < canvas.data("iiif-image-with")) {
+                            if (canvas instanceof (HTMLCanvasElement)) {
+                                canvas.width = document.body.clientWidth - 20;
+                            } else if (canvas instanceof (SVGSVGElement)) {
+                                canvas.setAttribute ('width', document.body.clientWidth - 20);
+                            }
+                        }
+                    }
+
                     console.log('Initializing JSModeler')
                     if (browser_supported) {
                         var urls = sourceurl;
@@ -69,6 +86,7 @@
                                     console.log(viewer.renderer.domElement.toDataURL( 'image/png' ), 'screenshot');
                                 };
                                 JSM.ConvertJSONDataToThreeMeshes(jsonData, textureLoaded, environment);
+                                window.onresize = resizeCanvas();
                             }
                         });
                     }

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -25,10 +25,13 @@
                     // If given width is less than window size, do nothing
                     // In any other case make it as width
                     // TODO. Deal with the parent container. noty
-                    function resizeCanvas ()
+                    function resizeCanvas (viewer)
                     {
+                        console.log('resizing 3D canvas event called');
                         if (document.body.clientWidth < canvasDom.data("iiif-image-width")) {
                                 canvasDom.width(document.body.clientWidth - 20);
+                                viewer.FitInWindow();
+                                console.log('Actually resizing 3D canvas');
                         }
                     }
 
@@ -82,7 +85,7 @@
                                     console.log(viewer.renderer.domElement.toDataURL( 'image/png' ), 'screenshot');
                                 };
                                 JSM.ConvertJSONDataToThreeMeshes(jsonData, textureLoaded, environment);
-                                window.onresize = resizeCanvas();
+                                window.onresize = resizeCanvas(viewer);
                             }
                         });
                     }

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -43,17 +43,21 @@
                         var urlList = urls.split('|');
                         // This is in case we have material, textures, etc in the same URL.
                         //@TODO allow people to select default materials
+                        var $div = $("<div>", {id: "jsm-preloader", "class": "sbf-preloader"});
+                        canvasDom.parent().append($div);
                         JSM.ConvertURLListToJsonData(urlList, {
                             onError: function () {
                                 console.log('Could not convert file' + element_id);
+                                $(".sbf-preloader").fadeOut('fast');
                                 return;
                             },
                             onReady: function (fileNames, jsonData) {
-                                var $div = $("<div>", {id: "jsm-preloader", "class": "sbf-preloader"});
-                                canvasDom.parent().append($div);
+                                console.log('Loaded Materials');
+                                console.log(jsonData.materials);
                                 var viewer = new JSM.ThreeViewer();
                                 if (!viewer.Start(canvas, viewerSettings)) {
                                     console.log('Error initializing JSM Viewer' + element_id);
+                                    $(".sbf-preloader").fadeOut('fast');
                                     return;
                                 }
 

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -27,8 +27,7 @@
                     // TODO. Deal with the parent container. noty
                     function resizeCanvas ()
                     {
-
-                        if (canvasDom !== null && document.body.clientWidth < canvasDom.data("iiif-image-with")) {
+                        if (document.body.clientWidth < canvasDom.data("iiif-image-width")) {
                             if (canvasDom instanceof (HTMLCanvasElement)) {
                                 canvasDom.width = document.body.clientWidth - 20;
                             } else if (canvasDom instanceof (SVGSVGElement)) {

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -55,7 +55,7 @@
                                 console.log('Loaded Materials');
                                 console.log(jsonData.materials);
                                 // add a texture?
-                                jsonData.materials[0].texture  = 'http://bgfons.com/uploads/stone/stone_texture4718.jpg';
+                                jsonData.materials[0].texture  = 'http://localhost:8183/iiif/2/0d1%2Fimage-metcalfe-room-test-1-42dcddb6-bec9-4012-a6dc-5e153e99b701.jpg/1536,1024,512,512/512,/0/default.jpg';
                                 jsonData.materials[0].textureWidth = 1.0;
                                 jsonData.materials[0].textureHeight = 1.0;
                                 var viewer = new JSM.ThreeViewer();

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -76,12 +76,12 @@
                                         console.log(viewer.renderer.domElement.toDataURL( 'image/png' ), 'screenshot');
                                         viewer.EnableDraw(true);
                                         viewer.Draw();
+                                        $(".sbf-preloader").fadeOut('slow');
                                         resizeCanvas();
                                         $( window ).resize(function() {
                                             resizeCanvas();
                                             viewer.FitInWindow();
                                         });
-                                        $("jsm-preloader").fadeOut('slow');
                                     }
                                 };
 

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -55,9 +55,10 @@
                                 console.log('Loaded Materials');
                                 console.log(jsonData.materials);
                                 // add a texture?
-                                jsonData.materials[0].texture  = 'http://localhost:8183/iiif/2/0d1%2Fimage-metcalfe-room-test-1-42dcddb6-bec9-4012-a6dc-5e153e99b701.jpg/1536,1024,512,512/512,/0/default.jpg';
+                                /* jsonData.materials[0].texture  = 'http://localhost:8183/iiif/2/someid/1536,1024,512,512/512,/0/default.jpg';
                                 jsonData.materials[0].textureWidth = 1.0;
                                 jsonData.materials[0].textureHeight = 1.0;
+                                */
                                 var viewer = new JSM.ThreeViewer();
                                 if (!viewer.Start(canvas, viewerSettings)) {
                                     console.log('Error initializing JSM Viewer' + element_id);

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -85,7 +85,9 @@
                                     console.log(viewer.renderer.domElement.toDataURL( 'image/png' ), 'screenshot');
                                 };
                                 JSM.ConvertJSONDataToThreeMeshes(jsonData, textureLoaded, environment);
-                                window.onresize = resizeCanvas(viewer);
+                                $( window ).resize(function(viewer) {
+                                    resizeCanvas(viewer);
+                                });
                             }
                         });
                     }

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -29,8 +29,9 @@
                     {
                         console.log('resizing 3D canvas event called');
                         if (document.body.clientWidth < canvasDom.data("iiif-image-width")) {
-                                canvasDom.width(document.body.clientWidth - 20);
-                                console.log('Actually resizing 3D canvas');
+                            canvasDom.width(document.body.clientWidth - 20);
+                            canvasDom.attr("width",document.body.clientWidth - 20);
+                            console.log('Actually resizing 3D canvas');
                         }
                     }
 

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -54,6 +54,10 @@
                             onReady: function (fileNames, jsonData) {
                                 console.log('Loaded Materials');
                                 console.log(jsonData.materials);
+                                // add a texture?
+                                jsonData.materials[0].texture  = 'http://bgfons.com/uploads/stone/stone_texture4718.jpg';
+                                jsonData.materials[0].textureWidth = 1.0;
+                                jsonData.materials[0].textureHeight = 1.0;
                                 var viewer = new JSM.ThreeViewer();
                                 if (!viewer.Start(canvas, viewerSettings)) {
                                     console.log('Error initializing JSM Viewer' + element_id);

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -50,7 +50,7 @@
                             },
                             onReady: function (fileNames, jsonData) {
                                 var $div = $("<div>", {id: "jsm-preloader", "class": "sbf-preloader"});
-                                canvasDom.append($div);
+                                canvasDom.parent.append($div);
                                 var viewer = new JSM.ThreeViewer();
                                 if (!viewer.Start(canvas, viewerSettings)) {
                                     console.log('Error initializing JSM Viewer' + element_id);

--- a/js/jsm-model_strawberry.js
+++ b/js/jsm-model_strawberry.js
@@ -49,7 +49,8 @@
                                 return;
                             },
                             onReady: function (fileNames, jsonData) {
-
+                                var $div = $("<div>", {id: "jsm-preloader", "class": "ajax-progress--throbber"});
+                                canvasDom.append($div);
                                 var viewer = new JSM.ThreeViewer();
                                 if (!viewer.Start(canvas, viewerSettings)) {
                                     console.log('Error initializing JSM Viewer' + element_id);
@@ -80,6 +81,7 @@
                                             resizeCanvas();
                                             viewer.FitInWindow();
                                         });
+                                        $("jsm-preloader").fadeOut('slow');
                                     }
                                 };
 

--- a/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
@@ -52,6 +52,7 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
         '#type' => 'textfield',
         '#title' => t('JSON Key from where to fetch Media URLs'),
         '#default_value' => $this->getSetting('json_key_source'),
+        '#required' => TRUE
       ],
       'number_models' => [
         '#type' => 'number',
@@ -70,6 +71,7 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
         '#maxlength' => 5,
         '#field_suffix' => $this->t('pixels'),
         '#min' => 0,
+        '#required' => TRUE
       ],
       'max_height' => [
         '#type' => 'number',
@@ -79,6 +81,7 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
         '#maxlength' => 5,
         '#field_suffix' => $this->t('pixels'),
         '#min' => 0,
+        '#required' => TRUE
       ],
     ] + parent::settingsForm($form, $form_state);
   }
@@ -100,31 +103,14 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
         '%number' => $this->getSetting('number_models'),
       ]);
     }
-    if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
-      $summary[] = $this->t(
+    $summary[] = $this->t(
         'Maximum size: %max_width x %max_height',
         [
           '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-          '%max_height' => $this->getSetting('max_height') . 'pixels',
-        ]
-      );
-    }
-    elseif ($this->getSetting('max_width')) {
-      $summary[] = $this->t(
-        'Maximum width: %max_width',
-        [
-          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-        ]
-      );
-    }
-    elseif ($this->getSetting('max_height')) {
-      $summary[] = $this->t(
-        'Maximum height: %max_height',
-        [
           '%max_height' => $this->getSetting('max_height') . ' pixels',
         ]
       );
-    }
+
 
     return $summary;
   }

--- a/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
@@ -100,20 +100,29 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
       ]);
     }
     if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
-      $summary[] = $this->t('Maximum size: %max_width x %max_height pixels', [
-        '%max_width' => $this->getSetting('max_width'),
-        '%max_height' => $this->getSetting('max_height'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum size: %max_width x %max_height',
+        [
+          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+          '%max_height' => $this->getSetting('max_height') . 'pixels',
+        ]
+      );
     }
     elseif ($this->getSetting('max_width')) {
-      $summary[] = $this->t('Maximum width: %max_width pixels', [
-        '%max_width' => $this->getSetting('max_width'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum width: %max_width',
+        [
+          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+        ]
+      );
     }
     elseif ($this->getSetting('max_height')) {
-      $summary[] = $this->t('Maximum height: %max_height pixels', [
-        '%max_height' => $this->getSetting('max_height'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum height: %max_height',
+        [
+          '%max_height' => $this->getSetting('max_height') . ' pixels',
+        ]
+      );
     }
 
     return $summary;
@@ -126,6 +135,7 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
     $max_width = $this->getSetting('max_width');
+    $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
     $max_height = $this->getSetting('max_height');
     $number_models =  $this->getSetting('number_models');
     /* @var \Drupal\file\FileInterface[] $files */
@@ -219,10 +229,7 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
                       'class' => ['field-iiif', 'strawberry-3d-item'],
                       'id' => $htmlid,
                       'data-iiif-model' => $publicurl->toString(),
-                      'data-iiif-image-width' => $max_width,
-                      'data-iiif-image-height' => $max_height,
-                      'height' => $max_height,
-                      'width' => $max_width
+                      'style' => "width:{$max_width_css}; height:{$max_height}px"
                      ],
                     '#title' => $this->t(
                       '3D Model for @label',

--- a/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
@@ -64,6 +64,7 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
       'max_width' => [
         '#type' => 'number',
         '#title' => $this->t('Maximum width'),
+        '#description' => $this->t('Use 0 to force 100% width'),
         '#default_value' => $this->getSetting('max_width'),
         '#size' => 5,
         '#maxlength' => 5,
@@ -136,6 +137,8 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
     $elements = [];
     $max_width = $this->getSetting('max_width');
     $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
+    // Because canvases can not be dynamic. But we can make them scale with JS?
+    $max_width = empty($max_width) || $max_width == 0 ? 720 : $max_width ;
     $max_height = $this->getSetting('max_height');
     $number_models =  $this->getSetting('number_models');
     /* @var \Drupal\file\FileInterface[] $files */
@@ -229,6 +232,10 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
                       'class' => ['field-iiif', 'strawberry-3d-item'],
                       'id' => $htmlid,
                       'data-iiif-model' => $publicurl->toString(),
+                      'data-iiif-image-width' => $max_width,
+                      'data-iiif-image-height' => $max_height,
+                      'height' => $max_height,
+                      'width' => $max_width,
                       'style' => "width:{$max_width_css}; height:{$max_height}px"
                      ],
                     '#title' => $this->t(

--- a/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
@@ -54,6 +54,7 @@ class StrawberryAudioFormatter extends StrawberryBaseFormatter {
         '#type' => 'textfield',
         '#title' => t('JSON Key from where to fetch Media URLs'),
         '#default_value' => $this->getSetting('json_key_source'),
+        '#required' => TRUE
       ],
       'number_media' => [
         '#type' => 'number',
@@ -71,6 +72,7 @@ class StrawberryAudioFormatter extends StrawberryBaseFormatter {
         '#maxlength' => 5,
         '#field_suffix' => $this->t('pixels'),
         '#min' => 0,
+        '#required' => TRUE
       ],
       'max_height' => [
         '#type' => 'number',
@@ -80,6 +82,7 @@ class StrawberryAudioFormatter extends StrawberryBaseFormatter {
         '#maxlength' => 5,
         '#field_suffix' => $this->t('pixels'),
         '#min' => 0,
+        '#required' => TRUE
       ],
     ];
   }
@@ -101,31 +104,13 @@ class StrawberryAudioFormatter extends StrawberryBaseFormatter {
         '%number' => $this->getSetting('number_media'),
       ]);
     }
-    if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
-      $summary[] = $this->t(
-        'Maximum size: %max_width x %max_height',
-        [
-          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-          '%max_height' => $this->getSetting('max_height') . 'pixels',
-        ]
-      );
-    }
-    elseif ($this->getSetting('max_width')) {
-      $summary[] = $this->t(
-        'Maximum width: %max_width',
-        [
-          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-        ]
-      );
-    }
-    elseif ($this->getSetting('max_height')) {
-      $summary[] = $this->t(
-        'Maximum height: %max_height',
-        [
-          '%max_height' => $this->getSetting('max_height') . ' pixels',
-        ]
-      );
-    }
+    $summary[] = $this->t(
+      'Maximum size: %max_width x %max_height',
+      [
+        '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+        '%max_height' => $this->getSetting('max_height') . ' pixels',
+      ]
+    );
 
     return $summary;
   }

--- a/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
@@ -102,20 +102,29 @@ class StrawberryAudioFormatter extends StrawberryBaseFormatter {
       ]);
     }
     if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
-      $summary[] = $this->t('Maximum size: %max_width x %max_height pixels', [
-        '%max_width' => $this->getSetting('max_width'),
-        '%max_height' => $this->getSetting('max_height'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum size: %max_width x %max_height',
+        [
+          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+          '%max_height' => $this->getSetting('max_height') . 'pixels',
+        ]
+      );
     }
     elseif ($this->getSetting('max_width')) {
-      $summary[] = $this->t('Maximum width: %max_width pixels', [
-        '%max_width' => $this->getSetting('max_width'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum width: %max_width',
+        [
+          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+        ]
+      );
     }
     elseif ($this->getSetting('max_height')) {
-      $summary[] = $this->t('Maximum height: %max_height pixels', [
-        '%max_height' => $this->getSetting('max_height'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum height: %max_height',
+        [
+          '%max_height' => $this->getSetting('max_height') . ' pixels',
+        ]
+      );
     }
 
     return $summary;
@@ -128,6 +137,7 @@ class StrawberryAudioFormatter extends StrawberryBaseFormatter {
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
     $max_width = $this->getSetting('max_width');
+    $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
     $max_height = $this->getSetting('max_height');
     $number_media =  $this->getSetting('number_media');
     /* @var \Drupal\file\FileInterface[] $files */
@@ -241,14 +251,13 @@ class StrawberryAudioFormatter extends StrawberryBaseFormatter {
                     '#attributes' => [
                       'class' => ['field-av', 'audio-av'],
                       'id' => 'audio_' . $uniqueid,
-                      'controls' => TRUE
+                      'controls' => TRUE,
+                      'style' => "width:{$max_width_css}; height:{$max_height}px",
                     ],
                     '#alt' => $this->t(
                       'Audio for @label',
                       ['@label' => $items->getEntity()->label()]
                     ),
-                    '#width' => $max_width,
-                    '#height' => $max_height,
                     'source' => [
                       '#type' => 'html_tag',
                       '#tag' => 'source',

--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -104,20 +104,29 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
       ]);
     }
     if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
-      $summary[] = $this->t('Maximum size: %max_width x %max_height pixels', [
-        '%max_width' => $this->getSetting('max_width'),
-        '%max_height' => $this->getSetting('max_height'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum size: %max_width x %max_height',
+        [
+          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+          '%max_height' => $this->getSetting('max_height') . 'pixels',
+        ]
+      );
     }
     elseif ($this->getSetting('max_width')) {
-      $summary[] = $this->t('Maximum width: %max_width pixels', [
-        '%max_width' => $this->getSetting('max_width'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum width: %max_width',
+        [
+          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+        ]
+      );
     }
     elseif ($this->getSetting('max_height')) {
-      $summary[] = $this->t('Maximum height: %max_height pixels', [
-        '%max_height' => $this->getSetting('max_height'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum height: %max_height',
+        [
+          '%max_height' => $this->getSetting('max_height') . ' pixels',
+        ]
+      );
     }
 
     return $summary;
@@ -130,6 +139,7 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
     $max_width = $this->getSetting('max_width');
+    $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
     $max_height = $this->getSetting('max_height');
     $number_images =  $this->getSetting('number_images');
     /* @var \Drupal\file\FileInterface[] $files */

--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -57,6 +57,7 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
         '#type' => 'textfield',
         '#title' => t('JSON Key from where to fetch Media URLs'),
         '#default_value' => $this->getSetting('json_key_source'),
+        '#required' => TRUE
       ],
       'number_images' => [
         '#type' => 'number',
@@ -74,6 +75,7 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
         '#maxlength' => 5,
         '#field_suffix' => $this->t('pixels'),
         '#min' => 0,
+        '#required' => TRUE
       ],
       'max_height' => [
         '#type' => 'number',
@@ -83,6 +85,7 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
         '#maxlength' => 5,
         '#field_suffix' => $this->t('pixels'),
         '#min' => 0,
+        '#required' => TRUE
       ],
     ] + parent::settingsForm($form, $form_state);
   }
@@ -103,31 +106,13 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
         '%number' => $this->getSetting('number_images'),
       ]);
     }
-    if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
-      $summary[] = $this->t(
-        'Maximum size: %max_width x %max_height',
-        [
-          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-          '%max_height' => $this->getSetting('max_height') . 'pixels',
-        ]
-      );
-    }
-    elseif ($this->getSetting('max_width')) {
-      $summary[] = $this->t(
-        'Maximum width: %max_width',
-        [
-          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-        ]
-      );
-    }
-    elseif ($this->getSetting('max_height')) {
-      $summary[] = $this->t(
-        'Maximum height: %max_height',
-        [
-          '%max_height' => $this->getSetting('max_height') . ' pixels',
-        ]
-      );
-    }
+    $summary[] = $this->t(
+      'Maximum size: %max_width x %max_height',
+      [
+        '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+        '%max_height' => $this->getSetting('max_height') . ' pixels',
+      ]
+    );
 
     return $summary;
   }

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -65,6 +65,7 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
       'max_width' => [
         '#type' => 'number',
         '#title' => $this->t('Maximum width'),
+        '#description' => $this->t('Use 0 to force 100% width'),
         '#default_value' => $this->getSetting('max_width'),
         '#size' => 5,
         '#maxlength' => 5,
@@ -106,20 +107,29 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
       ]);
     }
     if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
-      $summary[] = $this->t('Maximum size: %max_width x %max_height pixels', [
-        '%max_width' => $this->getSetting('max_width'),
-        '%max_height' => $this->getSetting('max_height'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum size: %max_width x %max_height',
+        [
+          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+          '%max_height' => $this->getSetting('max_height') . 'pixels',
+        ]
+      );
     }
     elseif ($this->getSetting('max_width')) {
-      $summary[] = $this->t('Maximum width: %max_width pixels', [
-        '%max_width' => $this->getSetting('max_width'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum width: %max_width',
+        [
+          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+        ]
+      );
     }
     elseif ($this->getSetting('max_height')) {
-      $summary[] = $this->t('Maximum height: %max_height pixels', [
-        '%max_height' => $this->getSetting('max_height'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum height: %max_height',
+        [
+          '%max_height' => $this->getSetting('max_height') . ' pixels',
+        ]
+      );
     }
 
     return $summary;
@@ -132,6 +142,7 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
     $max_width = $this->getSetting('max_width');
+    $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
     $max_height = $this->getSetting('max_height');
     $grouped = $this->getSetting('iiif_group');
     $thumbnails = $this->getSettings('thumbnails');
@@ -221,8 +232,7 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
                     'data-iiif-infojson' => $iiifpublicinfojson,
                     'data-iiif-group' => $grouped ? $groupid : $uniqueid,
                     'data-iiif-thumbnails' => $thumbnails,
-                    'width' => $max_width,
-                    'height' => $max_height,
+                    'style' => "width:{$max_width_css}; height:{$max_height}px",
                   ],
                 ];
                 if (isset($item->_attributes)) {
@@ -244,6 +254,11 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
                 // @TODO probably better to use uuid() or the node id() instead of $uniqueid
                 $elements[$delta]['media'.$i]['#attributes']['data-iiif-infojson'] = $iiifpublicinfojson;
                 $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon']['innode'][$uniqueid] = $nodeuuid;
+                $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['width'] = $max_width_css;
+                $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['height'] = max(
+                  $max_height,
+                  480
+                );
               }
             } elseif (isset($mediaitem['url'])) {
               $elements[$delta]['media'.$i] = [

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -131,7 +131,7 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
     $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
     $max_height = $this->getSetting('max_height');
     $grouped = $this->getSetting('iiif_group');
-    $thumbnails = $this->getSettings('thumbnails');
+    $thumbnails = $this->getSetting('thumbnails');
 
     /* @var \Drupal\file\FileInterface[] $files */
     // Fixing the key to extract while coding to 'Media'

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -61,6 +61,7 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
         '#type' => 'textfield',
         '#title' => t('JSON Key from where to fetch Media URLs'),
         '#default_value' => $this->getSetting('json_key_source'),
+        '#required' => TRUE
       ],
       'max_width' => [
         '#type' => 'number',
@@ -71,6 +72,7 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
         '#maxlength' => 5,
         '#field_suffix' => $this->t('pixels'),
         '#min' => 0,
+        '#required' => TRUE
       ],
       'max_height' => [
         '#type' => 'number',
@@ -80,6 +82,7 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
         '#maxlength' => 5,
         '#field_suffix' => $this->t('pixels'),
         '#min' => 0,
+        '#required' => TRUE
       ],
     ] + parent::settingsForm($form, $form_state);
   }
@@ -106,31 +109,14 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
         '%json_key_source' => $this->getSetting('json_key_source'),
       ]);
     }
-    if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
-      $summary[] = $this->t(
-        'Maximum size: %max_width x %max_height',
-        [
-          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-          '%max_height' => $this->getSetting('max_height') . 'pixels',
-        ]
-      );
-    }
-    elseif ($this->getSetting('max_width')) {
-      $summary[] = $this->t(
-        'Maximum width: %max_width',
-        [
-          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-        ]
-      );
-    }
-    elseif ($this->getSetting('max_height')) {
-      $summary[] = $this->t(
-        'Maximum height: %max_height',
-        [
-          '%max_height' => $this->getSetting('max_height') . ' pixels',
-        ]
-      );
-    }
+    $summary[] = $this->t(
+      'Maximum size: %max_width x %max_height',
+      [
+        '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+        '%max_height' => $this->getSetting('max_height') . ' pixels',
+      ]
+    );
+
 
     return $summary;
   }

--- a/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
@@ -422,26 +422,26 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
 
     if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
       $summary[] = $this->t(
-        'Maximum size: %max_width x %max_height pixels',
+        'Maximum size: %max_width x %max_height',
         [
-          '%max_width' => $this->getSetting('max_width'),
-          '%max_height' => $this->getSetting('max_height'),
+          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+          '%max_height' => $this->getSetting('max_height') . 'pixels',
         ]
       );
     }
     elseif ($this->getSetting('max_width')) {
       $summary[] = $this->t(
-        'Maximum width: %max_width pixels',
+        'Maximum width: %max_width',
         [
-          '%max_width' => $this->getSetting('max_width'),
+          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
         ]
       );
     }
     elseif ($this->getSetting('max_height')) {
       $summary[] = $this->t(
-        'Maximum height: %max_height pixels',
+        'Maximum height: %max_height',
         [
-          '%max_height' => $this->getSetting('max_height'),
+          '%max_height' => $this->getSetting('max_height') . ' pixels',
         ]
       );
     }

--- a/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
@@ -294,6 +294,7 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
           '#maxlength' => 5,
           '#field_suffix' => $this->t('pixels'),
           '#min' => 0,
+          '#required' => TRUE
         ],
         'max_height' => [
           '#type' => 'number',
@@ -303,6 +304,7 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
           '#maxlength' => 5,
           '#field_suffix' => $this->t('pixels'),
           '#min' => 0,
+          '#required' => TRUE
         ],
       ] + parent::settingsForm($form, $form_state);
     if (empty($options_for_mainsource)) {
@@ -420,31 +422,15 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
       $summary[] = $this->t('This formatter still needs to be setup');
     }
 
-    if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
-      $summary[] = $this->t(
-        'Maximum size: %max_width x %max_height',
-        [
-          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-          '%max_height' => $this->getSetting('max_height') . 'pixels',
-        ]
-      );
-    }
-    elseif ($this->getSetting('max_width')) {
-      $summary[] = $this->t(
-        'Maximum width: %max_width',
-        [
-          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-        ]
-      );
-    }
-    elseif ($this->getSetting('max_height')) {
-      $summary[] = $this->t(
-        'Maximum height: %max_height',
-        [
-          '%max_height' => $this->getSetting('max_height') . ' pixels',
-        ]
-      );
-    }
+    $summary[] = $this->t(
+      'Maximum size: %max_width x %max_height',
+      [
+        '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+        '%max_height' => $this->getSetting('max_height') . ' pixels',
+      ]
+    );
+
+
 
     return array_merge($summary, parent::settingsSummary());
   }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
@@ -242,6 +242,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
           '#maxlength' => 5,
           '#field_suffix' => $this->t('pixels'),
           '#min' => 0,
+          '#required' => TRUE
         ],
         'max_height' => [
           '#type' => 'number',
@@ -251,6 +252,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
           '#maxlength' => 5,
           '#field_suffix' => $this->t('pixels'),
           '#min' => 0,
+          '#required' => TRUE
         ],
       ] + parent::settingsForm($form, $form_state);
   }
@@ -302,31 +304,13 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
       }
     }
 
-    if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
-      $summary[] = $this->t(
-        'Maximum size: %max_width x %max_height',
-        [
-          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-          '%max_height' => $this->getSetting('max_height') . 'pixels',
-        ]
-      );
-    }
-    elseif ($this->getSetting('max_width')) {
-      $summary[] = $this->t(
-        'Maximum width: %max_width',
-        [
-          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-        ]
-      );
-    }
-    elseif ($this->getSetting('max_height')) {
-      $summary[] = $this->t(
-        'Maximum height: %max_height',
-        [
-          '%max_height' => $this->getSetting('max_height') . ' pixels',
-        ]
-      );
-    }
+    $summary[] = $this->t(
+      'Maximum size: %max_width x %max_height',
+      [
+        '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+        '%max_height' => $this->getSetting('max_height') . ' pixels',
+      ]
+    );
 
     return $summary;
   }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
@@ -236,6 +236,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
         'max_width' => [
           '#type' => 'number',
           '#title' => $this->t('Maximum width'),
+          '#description' => $this->t('Use 0 to force 100% width'),
           '#default_value' => $this->getSetting('max_width'),
           '#size' => 5,
           '#maxlength' => 5,
@@ -303,26 +304,26 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
 
     if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
       $summary[] = $this->t(
-        'Maximum size: %max_width x %max_height pixels',
+        'Maximum size: %max_width x %max_height',
         [
-          '%max_width' => $this->getSetting('max_width'),
-          '%max_height' => $this->getSetting('max_height'),
+          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+          '%max_height' => $this->getSetting('max_height') . 'pixels',
         ]
       );
     }
     elseif ($this->getSetting('max_width')) {
       $summary[] = $this->t(
-        'Maximum width: %max_width pixels',
+        'Maximum width: %max_width',
         [
-          '%max_width' => $this->getSetting('max_width'),
+          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
         ]
       );
     }
     elseif ($this->getSetting('max_height')) {
       $summary[] = $this->t(
-        'Maximum height: %max_height pixels',
+        'Maximum height: %max_height',
         [
-          '%max_height' => $this->getSetting('max_height'),
+          '%max_height' => $this->getSetting('max_height') . ' pixels',
         ]
       );
     }
@@ -336,10 +337,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
-    $max_width = $this->getSetting('max_width');
-    $max_height = $this->getSetting('max_height');
     $pagestrategy = $this->getSetting('mediasource');
-
 
     /* @var \Drupal\file\FileInterface[] $files */
     // Fixing the key to extract while coding to 'Media'
@@ -395,7 +393,6 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
           break;
       }
 
-
       /* Expected structure of an Media item inside JSON
       "as:images": {
          "s3:\/\/f23\/new-metadata-en-image-58455d91acf7290275c1cab77531b7f561a11a84.jpg": {
@@ -450,6 +447,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
     $entity = NULL;
     $nodeuuid = $item->getEntity()->uuid();
     $max_width = $this->getSetting('max_width');
+    $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
     $max_height = $this->getSetting('max_height');
 
     if ($this->getSetting('metadatadisplayentity_source')) {
@@ -493,6 +491,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
               'field-iiif',
               'container',
             ],
+            'style' => "width:{$max_width_css}; height:{$max_height}px",
             'data-iiif-infojson' => '',
             'width' => $max_width,
             'height' => $max_height,
@@ -544,6 +543,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
     $entity = NULL;
     $nodeuuid = $item->getEntity()->uuid();
     $max_width = $this->getSetting('max_width');
+    $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
     $max_height = $this->getSetting('max_height');
 
     if ($this->getSetting('manifesturl_source')) {

--- a/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
@@ -477,8 +477,6 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
             ],
             'style' => "width:{$max_width_css}; height:{$max_height}px",
             'data-iiif-infojson' => '',
-            'width' => $max_width,
-            'height' => $max_height,
           ],
         ];
         if (isset($item->_attributes)) {
@@ -493,13 +491,10 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
         $element['media']['#attached']['drupalSettings']['format_strawberryfield']['iabookreader'][$htmlid]['manifest'] = json_decode(
           $manifest
         );
-        $element['media']['#attached']['drupalSettings']['format_strawberryfield']['iabookreader'][$htmlid]['width'] = max(
-          $max_width,
-          400
-        );
+        $element['media']['#attached']['drupalSettings']['format_strawberryfield']['iabookreader'][$htmlid]['width'] = $max_width_css;
         $element['media']['#attached']['drupalSettings']['format_strawberryfield']['iabookreader'][$htmlid]['height'] = max(
           $max_height,
-          320
+          520
         );
       }
     }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
@@ -545,8 +545,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
                 'container',
               ],
               'data-iiif-infojson' => '',
-              'width' => $max_width,
-              'height' => $max_height,
+              'style' => "width:{$max_width_css}; height:{$max_height}px",
             ],
           ];
           if (isset($item->_attributes)) {
@@ -559,13 +558,10 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
           $element['media']['#attributes']['data-iiif-infojson'] = '';
           $element['media']['#attached']['drupalSettings']['format_strawberryfield']['iabookreader'][$htmlid]['nodeuuid'] = $nodeuuid;
           $element['media']['#attached']['drupalSettings']['format_strawberryfield']['iabookreader'][$htmlid]['manifesturl'] = $manifest_url;
-          $element['media']['#attached']['drupalSettings']['format_strawberryfield']['iabookreader'][$htmlid]['width'] = max(
-            $max_width,
-            400
-          );
+          $element['media']['#attached']['drupalSettings']['format_strawberryfield']['iabookreader'][$htmlid]['width'] = $max_width_css;
           $element['media']['#attached']['drupalSettings']['format_strawberryfield']['iabookreader'][$htmlid]['height'] = max(
             $max_height,
-            320
+            520
           );
         }
       }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -90,6 +90,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
         'max_width' => [
           '#type' => 'number',
           '#title' => $this->t('Maximum width'),
+          '#description' => $this->t('Use 0 to force 100% width'),
           '#default_value' => $this->getSetting('max_width'),
           '#size' => 5,
           '#maxlength' => 5,
@@ -139,26 +140,26 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
     }
     if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
       $summary[] = $this->t(
-        'Maximum size: %max_width x %max_height pixels',
+        'Maximum size: %max_width x %max_height',
         [
-          '%max_width' => $this->getSetting('max_width'),
-          '%max_height' => $this->getSetting('max_height'),
+          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+          '%max_height' => $this->getSetting('max_height') . 'pixels',
         ]
       );
     }
     elseif ($this->getSetting('max_width')) {
       $summary[] = $this->t(
-        'Maximum width: %max_width pixels',
+        'Maximum width: %max_width',
         [
-          '%max_width' => $this->getSetting('max_width'),
+          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
         ]
       );
     }
     elseif ($this->getSetting('max_height')) {
       $summary[] = $this->t(
-        'Maximum height: %max_height pixels',
+        'Maximum height: %max_height',
         [
-          '%max_height' => $this->getSetting('max_height'),
+          '%max_height' => $this->getSetting('max_height') . ' pixels',
         ]
       );
     }
@@ -173,6 +174,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
     $max_width = $this->getSetting('max_width');
+    $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
     $max_height = $this->getSetting('max_height');
     $number_images = $this->getSetting('number_images');
     /* @var \Drupal\file\FileInterface[] $files */
@@ -339,8 +341,12 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
                       'class' => ['field-iiif', 'strawberry-panorama-item'],
                       'id' => $htmlid,
                       'data-iiif-image' => $iiifserverimg,
-                      'data-iiif-image-width' => $max_width,
-                      'data-iiif-image-height' => $max_height,
+                      'data-iiif-image-width' => $max_width_css,
+                      'data-iiif-image-height' => max(
+                        $max_height,
+                        520
+                      ),
+                      'style' => "width:{$max_width_css}; height:{$max_height}px",
                     ],
                     '#title' => $this->t(
                       'Panorama for @label',
@@ -353,6 +359,11 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
                     'autoLoad' => $settings_autoload,
                   ];
                   $elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'][$htmlid]['nodeuuid'] = $nodeuuid;
+                  $elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'][$htmlid]['width'] = $max_width_css;
+                  $elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'][$htmlid]['height'] = max(
+                    $max_height,
+                    520
+                  );
                   $elements[$delta]['#attached']['library'][] = 'format_strawberryfield/iiif_pannellum_strawberry';
                   // Hotspots are a list of objects in the form of
                   /*{

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -63,6 +63,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
           '#type' => 'textfield',
           '#title' => t('JSON Key from where to fetch Media URLs'),
           '#default_value' => $this->getSetting('json_key_source'),
+          '#required' => TRUE
         ],
         'json_key_hotspots' => [
           '#type' => 'textfield',
@@ -96,6 +97,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
           '#maxlength' => 5,
           '#field_suffix' => $this->t('pixels'),
           '#min' => 0,
+          '#required' => TRUE
         ],
         'max_height' => [
           '#type' => 'number',
@@ -105,6 +107,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
           '#maxlength' => 5,
           '#field_suffix' => $this->t('pixels'),
           '#min' => 0,
+          '#required' => TRUE
         ],
         'autoLoad' => [
           '#type' => 'checkbox',
@@ -138,31 +141,13 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
         ]
       );
     }
-    if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
-      $summary[] = $this->t(
-        'Maximum size: %max_width x %max_height',
-        [
-          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-          '%max_height' => $this->getSetting('max_height') . 'pixels',
-        ]
-      );
-    }
-    elseif ($this->getSetting('max_width')) {
-      $summary[] = $this->t(
-        'Maximum width: %max_width',
-        [
-          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-        ]
-      );
-    }
-    elseif ($this->getSetting('max_height')) {
-      $summary[] = $this->t(
-        'Maximum height: %max_height',
-        [
-          '%max_height' => $this->getSetting('max_height') . ' pixels',
-        ]
-      );
-    }
+    $summary[] = $this->t(
+      'Maximum size: %max_width x %max_height',
+      [
+        '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+        '%max_height' => $this->getSetting('max_height') . ' pixels',
+      ]
+    );
 
     return $summary;
   }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
@@ -86,15 +86,16 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
         'max_width' => [
           '#type' => 'textfield',
           '#title' => $this->t('Maximum width'),
-          '#description' => $this->t('Set to 100% for full with of just a number for pixels'),
+          '#description' => $this->t('Use 0 to force 100% width'),
           '#default_value' => $this->getSetting('max_width'),
           '#size' => 5,
           '#maxlength' => 5,
+          '#field_suffix' => $this->t('pixels'),
           '#min' => 0,
         ],
         'max_height' => [
           '#type' => 'number',
-          '#title' => $this->t('Maximum height in pi'),
+          '#title' => $this->t('Maximum height in pixels'),
           '#default_value' => $this->getSetting('max_height'),
           '#size' => 5,
           '#maxlength' => 5,
@@ -126,20 +127,29 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
       ]);
     }
     if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
-      $summary[] = $this->t('Maximum size: %max_width x %max_height', [
-        '%max_width' => $this->getSetting('max_width'),
-        '%max_height' => $this->getSetting('max_height'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum size: %max_width x %max_height',
+        [
+          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+          '%max_height' => $this->getSetting('max_height') . 'pixels',
+        ]
+      );
     }
     elseif ($this->getSetting('max_width')) {
-      $summary[] = $this->t('Maximum width: %max_width', [
-        '%max_width' => $this->getSetting('max_width'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum width: %max_width',
+        [
+          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+        ]
+      );
     }
     elseif ($this->getSetting('max_height')) {
-      $summary[] = $this->t('Maximum height: %max_height', [
-        '%max_height' => $this->getSetting('max_height'),
-      ]);
+      $summary[] = $this->t(
+        'Maximum height: %max_height',
+        [
+          '%max_height' => $this->getSetting('max_height') . ' pixels',
+        ]
+      );
     }
 
     return $summary;
@@ -152,6 +162,7 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
     $max_width = $this->getSetting('max_width');
+    $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
     $max_height = $this->getSetting('max_height');
     $number_pages =  $this->getSetting('number_pages');
     $number_documents =  $this->getSetting('number_documents');
@@ -251,13 +262,11 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
                   '#attributes' => [
                       'class' => ['field-pdf-canvas','strawberry-document-item'],
                       'id' => 'document_' . $uniqueid,
-                      'style' => "max-width:{$max_width}px;height:{$max_height}",
+                      'style' => "width:{$max_width_css}; height:{$max_height}px",
                       'data-iiif-document' =>  $publicurl->toString(),
                       'data-iiif-initialpage' => $initial_page,
-                      'data-iiif-document-width' => $max_width,
-                      'data-iiif-document-height' => $max_height,
                       'data-iiif-pages' => $number_pages,
-                    ],
+                  ],
                    '#alt' => $this->t(
                       'PDF @name for  @label',
                       [

--- a/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
@@ -96,6 +96,7 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
         'max_height' => [
           '#type' => 'number',
           '#title' => $this->t('Maximum height in pixels'),
+          '#description' => $this->t('Use 0 to force automatic proportional height'),
           '#default_value' => $this->getSetting('max_height'),
           '#size' => 5,
           '#maxlength' => 5,
@@ -147,7 +148,7 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
       $summary[] = $this->t(
         'Maximum height: %max_height',
         [
-          '%max_height' => $this->getSetting('max_height') . ' pixels',
+          '%max_height' => (int) $this->getSetting('max_height') == 0 ? 'automatic' : $this->getSetting('max_height') . ' pixels',
         ]
       );
     }
@@ -256,13 +257,24 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
                     'id' =>  'document_' . $uniqueid,
                   ]
                 ];
+
+
+                if ($max_height == 0) {
+                  $css_style = "width:{$max_width_css};height:auto";
+                } else {
+                  $css_style = "width:{$max_width_css}; height:{$max_height}px";
+                }
+
+
+
+
                 $elements[$delta]['pdf' . $i] = [
                   '#type' => 'html_tag',
                   '#tag' => 'canvas',
                   '#attributes' => [
                       'class' => ['field-pdf-canvas','strawberry-document-item'],
                       'id' => 'document_' . $uniqueid,
-                      'style' => "width:{$max_width_css}; height:{$max_height}px",
+                      'style' => $css_style,
                       'data-iiif-document' =>  $publicurl->toString(),
                       'data-iiif-initialpage' => $initial_page,
                       'data-iiif-pages' => $number_pages,

--- a/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
@@ -92,6 +92,7 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
           '#maxlength' => 5,
           '#field_suffix' => $this->t('pixels'),
           '#min' => 0,
+          '#required' => TRUE
         ],
         'max_height' => [
           '#type' => 'number',
@@ -102,6 +103,7 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
           '#maxlength' => 5,
           '#field_suffix' => $this->t('pixels'),
           '#min' => 0,
+          '#required' => TRUE
         ],
       ] + parent::settingsForm($form, $form_state);
   }
@@ -127,31 +129,15 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
         '%number' => $this->getSetting('initial_page'),
       ]);
     }
-    if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
-      $summary[] = $this->t(
-        'Maximum size: %max_width x %max_height',
-        [
-          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-          '%max_height' => $this->getSetting('max_height') . 'pixels',
-        ]
-      );
-    }
-    elseif ($this->getSetting('max_width')) {
-      $summary[] = $this->t(
-        'Maximum width: %max_width',
-        [
-          '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-        ]
-      );
-    }
-    elseif ($this->getSetting('max_height')) {
-      $summary[] = $this->t(
-        'Maximum height: %max_height',
-        [
-          '%max_height' => (int) $this->getSetting('max_height') == 0 ? 'automatic' : $this->getSetting('max_height') . ' pixels',
-        ]
-      );
-    }
+    $summary[] = $this->t(
+      'Maximum size: %max_width x %max_height',
+      [
+        '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+        '%max_height' => (int) $this->getSetting('max_height') == 0 ? 'auto' : $this->getSetting('max_height') . ' pixels',
+      ]
+    );
+
+
 
     return $summary;
   }

--- a/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
@@ -155,6 +155,7 @@ class StrawberryVideoFormatter extends StrawberryBaseFormatter {
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
     $max_width = $this->getSetting('max_width');
+    $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
     $max_height = $this->getSetting('max_height');
     $number_media =  $this->getSetting('number_media');
     /* @var \Drupal\file\FileInterface[] $files */
@@ -164,6 +165,7 @@ class StrawberryVideoFormatter extends StrawberryBaseFormatter {
     $nodeuuid = $items->getEntity()->uuid();
     $nodeid = $items->getEntity()->id();
     $fieldname = $items->getName();
+    //@TODO posterframe is not being used. Make it used.
     foreach ($items as $delta => $item) {
       $main_property = $item->getFieldDefinition()->getFieldStorageDefinition()->getMainPropertyName();
       $value = $item->{$main_property};
@@ -269,14 +271,14 @@ class StrawberryVideoFormatter extends StrawberryBaseFormatter {
                       'class' => ['field-av', 'video-av'],
                       'id' => 'video_' . $uniqueid,
                       'controls' => TRUE,
-                      'poster' => ''
+                      'poster' => '',
+                      'style' => "width:{$max_width_css}; height:{$max_height}px",
+
                     ],
                     '#alt' => $this->t(
                       'Video for @label',
                       ['@label' => $items->getEntity()->label()]
                     ),
-                    '#width' => $max_width,
-                    '#height' => $max_height,
                     'source' => [
                       '#type' => 'html_tag',
                       '#tag' => 'source',

--- a/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
@@ -81,6 +81,7 @@ class StrawberryVideoFormatter extends StrawberryBaseFormatter {
       'max_height' => [
         '#type' => 'number',
         '#title' => $this->t('Maximum height'),
+        '#description' => $this->t('Use 0 to force automatic proportional height'),
         '#default_value' => $this->getSetting('max_height'),
         '#size' => 5,
         '#maxlength' => 5,
@@ -135,7 +136,7 @@ class StrawberryVideoFormatter extends StrawberryBaseFormatter {
       'Maximum size: %max_width x %max_height',
       [
         '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
-        '%max_height' => $this->getSetting('max_height') . ' pixels',
+        '%max_height' => (int) $this->getSetting('max_height') == 0 ? 'auto' : $this->getSetting('max_height') . ' pixels',
       ]
     );
 
@@ -151,6 +152,8 @@ class StrawberryVideoFormatter extends StrawberryBaseFormatter {
     $max_width = $this->getSetting('max_width');
     $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
     $max_height = $this->getSetting('max_height');
+    $max_height_css = empty($max_height) || $max_height == 0 ? 'auto' : $max_height .'px';
+
     $number_media =  $this->getSetting('number_media');
     /* @var \Drupal\file\FileInterface[] $files */
     // Fixing the key to extract while coding to 'Media'
@@ -266,7 +269,7 @@ class StrawberryVideoFormatter extends StrawberryBaseFormatter {
                       'id' => 'video_' . $uniqueid,
                       'controls' => TRUE,
                       'poster' => '',
-                      'style' => "width:{$max_width_css}; height:{$max_height}px",
+                      'style' => "width:{$max_width_css}; height:{$max_height_css}",
 
                     ],
                     '#alt' => $this->t(

--- a/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
@@ -42,7 +42,6 @@ class StrawberryVideoFormatter extends StrawberryBaseFormatter {
       'json_key_source' => 'as:video',
       'max_width' => 720,
       'max_height' => 240,
-      'audio_type' => 'mp4',
       'number_media' => 1,
       'posterframe' => 'iiif',
       'json_key_source_for_poster' => 'as:image'
@@ -58,6 +57,7 @@ class StrawberryVideoFormatter extends StrawberryBaseFormatter {
         '#type' => 'textfield',
         '#title' => t('JSON Key from where to fetch Media URLs'),
         '#default_value' => $this->getSetting('json_key_source'),
+        '#required' => TRUE
       ],
       'number_media' => [
         '#type' => 'number',
@@ -71,10 +71,12 @@ class StrawberryVideoFormatter extends StrawberryBaseFormatter {
         '#type' => 'number',
         '#title' => $this->t('Maximum width'),
         '#default_value' => $this->getSetting('max_width'),
+        '#description' => $this->t('Use 0 to force 100% width'),
         '#size' => 5,
         '#maxlength' => 5,
         '#field_suffix' => $this->t('pixels'),
         '#min' => 0,
+        '#required' => TRUE
       ],
       'max_height' => [
         '#type' => 'number',
@@ -84,6 +86,7 @@ class StrawberryVideoFormatter extends StrawberryBaseFormatter {
         '#maxlength' => 5,
         '#field_suffix' => $this->t('pixels'),
         '#min' => 0,
+        '#required' => TRUE
       ],
       'posterframe' => [
         '#type' => 'select',
@@ -128,22 +131,13 @@ class StrawberryVideoFormatter extends StrawberryBaseFormatter {
         '%number' => $this->getSetting('number_media'),
       ]);
     }
-    if ($this->getSetting('max_width') && $this->getSetting('max_height')) {
-      $summary[] = $this->t('Maximum size: %max_width x %max_height pixels', [
-        '%max_width' => $this->getSetting('max_width'),
-        '%max_height' => $this->getSetting('max_height'),
-      ]);
-    }
-    elseif ($this->getSetting('max_width')) {
-      $summary[] = $this->t('Maximum width: %max_width pixels', [
-        '%max_width' => $this->getSetting('max_width'),
-      ]);
-    }
-    elseif ($this->getSetting('max_height')) {
-      $summary[] = $this->t('Maximum height: %max_height pixels', [
-        '%max_height' => $this->getSetting('max_height'),
-      ]);
-    }
+    $summary[] = $this->t(
+      'Maximum size: %max_width x %max_height',
+      [
+        '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+        '%max_height' => $this->getSetting('max_height') . ' pixels',
+      ]
+    );
 
     return $summary;
   }


### PR DESCRIPTION
See #59 

# What is new?

All(well almost) formatters now support '0' width option to be used as a stub for 100% width.

The others, like some formatters that depend on Canvases (which need to have a fixed pixel size)e.g 3D one have an extra sizing functionality via JS that contracts the given canvas size in pixel to whatever is smaller (screen smaller than fixed with? We shrink to screen and redraw. Awesome!).
Also, other Formatters that totally need to have control over aspect ratio like PDF and Video allow to set '0' to force an `auto` height on a given `fixed` width. Great for avoiding squeezed video and PDFs like from 1997 when i was alive...and coding..

# What else is new?

So JS improvements, like a `CSS` based preloader for our `3D Viewer` (who wants to wait looking at a white screen for a 3D skull of 10 Mbytes to render? Not me !)

Also all  Formatter summaries in the Display Mode configs reflect this many options. Either `pixel X pixel`, `% x pixel` or `% by auto`. Cool!

We can now render a single frame of 3D into a base64 encoded Image! Well, with some little more code (like an html div and an img src where to put that data, not really code right! We can generate on the fly thumbnails for 3D. (no iiif for that... there is no iiif for 3d, even when there are `3 x is` in iiif)

I also added an extra mime type of `model/obj` Did you kids know Drupal8 ships with not so many useful mime types of us repo users?

I had to rebase a few times so some things could look weird. Will squash when done to cover my strange rebase (if any.. am i a good re-baser?...)

