### PR TITLE
Issue-54: Finally schemas are fixed and we have linked Thumbnails

### DIFF
--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -55,13 +55,15 @@ field.formatter.settings.strawberry_image_formatter:
       type: string
       label: 'Whether to use global IIIF settings or not.'
     number_images:
-      type: integer
-    images_type:
+      type: string
+    image_type:
       type: string
     quality:
       type: string
     rotation:
       type: string
+    image_link:
+      type: boolean
 field.formatter.settings.strawberry_media_formatter:
   type: mapping
   label: 'Specific Config for strawberry_media_formatter'

--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -20,7 +20,7 @@ use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
  *
  * @FieldFormatter(
  *   id = "strawberry_image_formatter",
- *   label = @Translation("Strawberry Field Image Formatter for IIIF media"),
+ *   label = @Translation("Strawberry Field Simple Image Formatter using IIIF"),
  *   class = "\Drupal\format_strawberryfield\Plugin\Field\FieldFormatter\StrawberryImageFormatter",
  *   field_types = {
  *     "strawberryfield_field"
@@ -247,15 +247,14 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
                   }
 
                   $iiifserverthumb = "{$this->getIiifUrls()['public']}/{$iiifidentifier}"."/full/{$max_width},/0/default.jpg";
-                  $elements[$delta]['media_thumb' . $i] = [
-                    '#theme' => 'image_formatter',
+                  $image_render_array = [
+                    '#theme' => 'image',
                     '#attributes' => [
                       'class' => ['field-iiif', 'image-iiif'],
                       'id' => 'thumb_' . $uniqueid,
+                      'src' => $iiifserverthumb,
+
                     ],
-                    '#item' => [
-                      'uri' => $iiifserverthumb,
-                      ],
                     '#alt' => $this->t(
                       'Thumbnail for @label',
                       ['@label' => $items->getEntity()->label()]
@@ -264,8 +263,17 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
                     '#height' => $max_height,
                   ];
 
+                  // With Link
                   if (boolval($this->getSetting('image_link')) === TRUE) {
-                    $elements[$delta]['media_thumb' . $i]['#url'] = $items->getEntity()->toUrl()->toString();
+                    $elements[$delta]['media_thumb' . $i] = [
+                      '#type' => 'link',
+                      '#title' => $image_render_array,
+                      '#url' => $items->getEntity()->toUrl(),
+                      '#title' => $items->getEntity->label(),
+                      ];
+                  }
+                  else {
+                    $elements[$delta]['media_thumb' . $i] = $image_render_array;
                   }
 
                   if (isset($item->_attributes)) {
@@ -275,33 +283,20 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
                     // formatter output and should not be rendered in the field template.
                     unset($item->_attributes);
                   }
-                  // @TODO deal with a lot of Media single strawberryfield
-                  // Idea would be to allow a setting that says, A) all same viewer(aggregate)
-                  // B) individual viewers for each?
-                  // C) only first one?
-                  // We will assign a group based on the UUID of the node containing this
-                  // to idenfity all the divs that we will create. And only first one will be the container in case of many?
-                  // so a jquery selector that uses that group as filter for a search.
-                  // Drupal JS settings get accumulated. So in a single search results site we will have for each
-                  // Formatter one passed. Reason we use 'innode' array using our $uniqueid
-                  // @TODO probably better to use uuid() or the node id() instead of $uniqueid
-                  $elements[$delta]['media'.$i]['#attributes']['data-iiif-infojson'] = $iiifpublicinfojson;
-                  $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon']['innode'][$uniqueid] = $nodeuuid;
                 }
-
               }
               else {
                 // @TODO Deal with no access here
                 // Should we put a thumb? Just hide?
                 // @TODO we can bring a plugin here and there that deals with
-                $elements[$delta]['media'.$i] = [
+                $elements[$delta]['media_thumb'.$i] = [
                   '#markup' => '<i class="fas fa-times-circle"></i>',
                   '#prefix' => '<span>',
                   '#suffix' => '</span>',
                 ];
               }
             } elseif (isset($mediaitem['url'])) {
-              $elements[$delta]['media'.$i] = [
+              $elements[$delta]['media_thumb'.$i] = [
                 '#markup' => 'Non managed '.$mediaitem['url'],
                 '#prefix' => '<pre>',
                 '#suffix' => '</pre>',

--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -248,13 +248,14 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
 
                   $iiifserverthumb = "{$this->getIiifUrls()['public']}/{$iiifidentifier}"."/full/{$max_width},/0/default.jpg";
                   $elements[$delta]['media_thumb' . $i] = [
-                    '#theme' => 'image',
+                    '#theme' => 'image_formatter',
                     '#attributes' => [
                       'class' => ['field-iiif', 'image-iiif'],
                       'id' => 'thumb_' . $uniqueid,
-                      'src' => $iiifserverthumb,
-
                     ],
+                    '#item' => [
+                      'uri' => $iiifserverthumb,
+                      ],
                     '#alt' => $this->t(
                       'Thumbnail for @label',
                       ['@label' => $items->getEntity()->label()]
@@ -264,7 +265,7 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
                   ];
 
                   if (boolval($this->getSetting('image_link')) === TRUE) {
-                    $elements[$delta]['media_thumb' . $i]['#uri'] = $items->getEntity()->toUrl()->toString();
+                    $elements[$delta]['media_thumb' . $i]['#url'] = $items->getEntity()->toUrl()->toString();
                   }
 
                   if (isset($item->_attributes)) {

--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -269,7 +269,6 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
                       '#type' => 'link',
                       '#title' => $image_render_array,
                       '#url' => $items->getEntity()->toUrl(),
-                      '#title' => $items->getEntity()->label(),
                       ];
                   }
                   else {

--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -264,12 +264,12 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
                   ];
 
                   // With Link
-                  if (boolval($this->getSetting('image_link')) === TRUE) {
+                  if (boolval($this->getSetting('image_link')) === TRUE && !$items->getEntity()->isNew()) {
                     $elements[$delta]['media_thumb' . $i] = [
                       '#type' => 'link',
                       '#title' => $image_render_array,
                       '#url' => $items->getEntity()->toUrl(),
-                      '#title' => $items->getEntity->label(),
+                      '#title' => $items->getEntity()->label(),
                       ];
                   }
                   else {

--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -264,7 +264,7 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
                   ];
 
                   if (boolval($this->getSetting('image_link')) === TRUE) {
-                    $elements[$delta]['media_thumb' . $i]['#uri'] = $items->getEntity()->toUrl();
+                    $elements[$delta]['media_thumb' . $i]['#uri'] = $items->getEntity()->toUrl()->toString();
                   }
 
                   if (isset($item->_attributes)) {

--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -264,7 +264,7 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
                   ];
 
                   if (boolval($this->getSetting('image_link')) === TRUE) {
-                    $elements[$delta]['media_thumb' . $i]['#url'] = $items->getEntity()->toUrl();
+                    $elements[$delta]['media_thumb' . $i]['#uri'] = $items->getEntity()->toUrl();
                   }
 
                   if (isset($item->_attributes)) {

--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -269,6 +269,9 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
                       '#type' => 'link',
                       '#title' => $image_render_array,
                       '#url' => $items->getEntity()->toUrl(),
+                      '#attributes' => [
+                        'alt' => $items->getEntity()->label()
+                        ]
                       ];
                   }
                   else {

--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -45,6 +45,7 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
       'number_images' => 1,
       'quality' => 'default',
       'rotation' => '0',
+      'image_link' =>  TRUE,
     ];
   }
 
@@ -66,6 +67,11 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
         '#size' => 2,
         '#maxlength' => 2,
         '#min' => 0,
+      ],
+      'image_link' => [
+        '#type' => 'checkbox',
+        '#title' => t('Link this image to the Full Node'),
+        '#default_value' => $this->getSetting('image_link'),
       ],
       'max_width' => [
         '#type' => 'number',
@@ -113,6 +119,9 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
         '%max_height' => $this->getSetting('max_height') . ' pixels',
       ]
     );
+    $summary[] = $this->t('Link to Node? %value', [
+      '%value' => boolval($this->getSetting('image_link')) === TRUE ? "Yes." : "No",
+    ]);
 
     return $summary;
   }
@@ -253,6 +262,11 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
                     '#width' => $max_width,
                     '#height' => $max_height,
                   ];
+
+                  if (boolval($this->getSetting('image_link')) === TRUE) {
+                    $elements[$delta]['media_thumb' . $i]['#url'] = $items->getEntity()->toUrl();
+                  }
+
                   if (isset($item->_attributes)) {
                     $elements[$delta] += ['#attributes' => []];
                     $elements[$delta]['#attributes'] += $item->_attributes;

--- a/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
@@ -158,7 +158,7 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
 
     return [
       'customtext' => [
-        '#type' => 'item',
+        '#type' => 'html',
         '#markup' => '<h3>Use this form to select the template for your metadata.</h3><p>Several templates such as MODS 3.6 and a simple Object Description ship with Archipelago. To design your own template for any metadata standard you like, or see the full list of existing templates, visit <a href="/metadatadisplay/list">/metadatadisplay/list</a>. </p>',
       ],
       'metadatadisplayentity_id' => [
@@ -243,7 +243,8 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
         continue;
       }
 
-      $jsondata = json_decode($item->value, true);
+      $jsondata = json_decode($item->value, TRUE);
+
       // Probably good idea to strip our own keys here
       // @TODO remove private access to keys
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
@@ -158,7 +158,6 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
 
     return [
       'customtext' => [
-        '#type' => 'html',
         '#markup' => '<h3>Use this form to select the template for your metadata.</h3><p>Several templates such as MODS 3.6 and a simple Object Description ship with Archipelago. To design your own template for any metadata standard you like, or see the full list of existing templates, visit <a href="/metadatadisplay/list">/metadatadisplay/list</a>. </p>',
       ],
       'metadatadisplayentity_id' => [


### PR DESCRIPTION
See #54 
Ok people, this finally solves all the Schema issues we had on this module. I found some issues left i'm tackling here. Status report now looks almost clear. Can not be 100% clear because some core issues i found (like if a Solr Data Source has not Display Mode it can not save its settings. Our SBF Flavour has no Display mode enabled yet, so i won't fix that). Also Views has Core issues with some missing schema definitions and finally our webform Handler id needs to be renamed. I won't touch that until beta3.

Also. Since i was here and there, i added a new option for the Simple Image Formatter. Now we can link to the node via the Thumbnail.  Quite useful, basic but was not present anywhere in core. Good. 

Also did some cleanup. All works! Now will make the huge settings commit to archipelago-deployment and we can tell people we are READY for this release. Can't even tell how much we all worked on this 🎂 
