### PR TITLE
ISSUE-64: Fix duplicated HTML id/ Mirador and Map

### DIFF
--- a/js/mirador_strawberry.js
+++ b/js/mirador_strawberry.js
@@ -12,7 +12,9 @@
                     if (typeof(drupalSettings.format_strawberryfield.mirador[element_id]) != 'undefined') {
 
                         $(this).height(drupalSettings.format_strawberryfield.mirador[element_id]['height']);
-                        $(this).width(drupalSettings.format_strawberryfield.mirador[element_id]['width']);
+                        if (drupalSettings.format_strawberryfield.mirador[element_id]['width'] != '100%') {
+                            $(this).width(drupalSettings.format_strawberryfield.mirador[element_id]['width']);
+                        }
                         // Defines our basic options for Mirador IIIF.
                         var $options = {
                             id: element_id,

--- a/src/Plugin/Field/FieldFormatter/StrawberryMapFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMapFormatter.php
@@ -599,7 +599,7 @@ class StrawberryMapFormatter extends StrawberryBaseFormatter implements Containe
         if (!empty($main_geojsonurl)) {
 
           $groupid = 'iiif-' . $item->getName(
-            ) . '-' . $nodeuuid . '-' . $delta . '-media';
+            ) . '-' . $nodeuuid . '-' . $delta . '-map';
           $htmlid = $groupid;
 
           $elements[$delta]['media'] = [

--- a/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
@@ -535,7 +535,6 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
               'container',
             ],
             'style' => "width:{$max_width_css}; height:{$max_height}px",
-            'width' => $max_width,
             'height' => $max_height,
           ],
         ];

--- a/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
@@ -520,7 +520,7 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
       if (!empty($main_manifesturl)) {
 
         $groupid = 'iiif-' . $item->getName(
-          ) . '-' . $nodeuuid . '-' . $delta . '-media';
+          ) . '-' . $nodeuuid . '-' . $delta . '-mirador';
         $htmlid = $groupid;
 
         $elements[$delta]['media'] = [


### PR DESCRIPTION
See #64 

# What is new?

A tiny bug fix, Mirador Viewer Formatter and Map one had the same HTML id being generated, blocking right JS attachment which is based on a selector passed via a data property. This fixes the issue. Since i was there i also removed the `JQuery` width setting for Mirador which was translating 100% to a fixed with, making variable with (specially when rescaling the window) impossible. I was not even aware of this. This gets merged in Beta2. And now moving forward with Beta3