### PR TITLE
ISSUE-78: Metadata can now rule over display

### DIFF
--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -200,6 +200,8 @@ field.formatter.settings.strawberry_pannellum_formatter:
       type: string
     json_key_hotspots:
       type: string
+    json_key_settings:
+      type: string
     json_key_multiscene:
       type: string
     panorama_type:

--- a/format_strawberryfield.libraries.yml
+++ b/format_strawberryfield.libraries.yml
@@ -63,12 +63,12 @@ iiif_iabookreader_strawberry:
     - core/drupal.debounce
     - format_strawberryfield/iiif_iabookreader
 pannellum:
-  version: 2.5.4
+  version: 2.5.6
   css:
     component:
-      https://cdn.jsdelivr.net/npm/pannellum@2.5.4/build/pannellum.css: { external: true}
+      https://cdn.jsdelivr.net/npm/pannellum@2.5.6/build/pannellum.css: { external: true}
   js:
-    https://cdn.jsdelivr.net/npm/pannellum@2.5.4/build/pannellum.js: { external: true, minified: true, preprocess: false}
+    https://cdn.jsdelivr.net/npm/pannellum@2.5.6/build/pannellum.js: { external: true, minified: true, preprocess: false}
 
 
 iiif_pannellum_strawberry:

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -87,6 +87,9 @@ function format_strawberryfield_theme() {
   ];
 }
 
+/**
+ * Implements hook__file_mimetype_mapping_alter().
+ */
 function format_strawberryfield_file_mimetype_mapping_alter(&$mapping) {
   // Add relevant Repository Mimetypes missing from D8
   $mapping['extensions']['obj'] = 'obj_model_mimetype';

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -29,7 +29,7 @@
             $('.strawberry-panorama-item[data-iiif-image]').once('attache_pnl')
                 .each(function (index, value) {
                     // New 2019.
-                    // If value is a an array then we have a multiscene panorama
+                    // If value is an array then we have a multiscene panorama
                     // Mostlikely, if i coded this right, hotspots will also be arrays
                     var hotspots = [];
                     // Get the node uuid for this element
@@ -37,7 +37,20 @@
                     var $multiscene = drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('tour');
                     var default_width = drupalSettings.format_strawberryfield.pannellum[element_id]['width'];
                     var default_height = drupalSettings.format_strawberryfield.pannellum[element_id]['height'];
+                    var externalConfigURL =  drupalSettings.format_strawberryfield.pannellum[element_id]['configjsonurl'];
+                    if (externalConfigURL) {
+                        $.getJSON('http://query.yahooapis.com/v1/public/yql?q=select%20%2a%20from%20yahoo.finance.quotes%20WHERE%20symbol%3D%27WRC%27&format=json&diagnostics=true&env=store://datatables.org/alltableswithkeys&callback', function(data) {
+                           console.log(data);
+                        });
+                    }
 
+                    const $haov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.haov;
+                    const $vaov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.vaov;
+                    const $minYaw = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.minYaw;
+                    const $maxYaw = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.maxYaw;
+                    const $vOffset = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.vOffset;
+                    const $maxPitch = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.maxPitch;
+                    const $minPitch = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.minPitch;
 
                     // Check if we got some data passed via Drupal settings.
                     if (typeof(drupalSettings.format_strawberryfield.pannellum[element_id]) != 'undefined') {
@@ -68,6 +81,14 @@
                                 "hotSpotDebug": drupalSettings.format_strawberryfield.pannellum[element_id].settings.hotSpotDebug,
                                 "autoLoad": Boolean(drupalSettings.format_strawberryfield.pannellum[element_id].settings.autoLoad),
                                 "hotSpots": hotspots,
+                                "haov": $haov || 360,
+                                "vaov": $vaov || 180,
+                                "maxYaw": $maxYaw || 180,
+                                "minYaw": $minYaw || -180,
+                                "vOffset": $vOffset || 0,
+                                "maxPitch": $maxPitch||undefined,
+                                "minPitch": $minPitch|| undefined
+
                             });
                         }
                         else {

--- a/src/Entity/MetadataDisplayEntity.php
+++ b/src/Entity/MetadataDisplayEntity.php
@@ -354,6 +354,7 @@ class MetadataDisplayEntity extends ContentEntityBase implements MetadataDisplay
     if (!isset($context['data']) || !is_array($context['data']) || empty($context['data'])) {
       throw new InvalidArgumentException('Processing a Metadata Display requires a valid "data" structure to be passed');
     }
+    $context = $context + $this->getTwigDefaultContext();
     $twigtemplate = $this->get('twig')->getValue();
     $twigtemplate = !empty($twigtemplate) ? $twigtemplate[0]['value'] : "{{ 'empty' }}";
     // @TODO should we have a custom theme hint here?
@@ -377,6 +378,9 @@ class MetadataDisplayEntity extends ContentEntityBase implements MetadataDisplay
     // leaking that metadata/early rendering when using it in a Cacheable
     // response Controller.
     // @See \Drupal\format_strawberryfield\Controller\MetadataExposeDisplayController.
+
+    // Complement $context with default one
+    $context = $context + $this->getTwigDefaultContext();
     $twigtemplate = $this->get('twig')->getValue();
     $twigtemplate = !empty($twigtemplate) ? $twigtemplate[0]['value'] : "{{ 'empty' }}";
     $rendered = $this->twigEnvironment()->renderInline(
@@ -437,6 +441,23 @@ class MetadataDisplayEntity extends ContentEntityBase implements MetadataDisplay
       }
     }
     return $variables;
+  }
+
+
+  /**
+   * Provides default Context so we can get common values
+   *
+   * @return array
+   */
+  private function getTwigDefaultContext() {
+
+    $context = [];
+    $context['is_front'] = \Drupal::service('path.matcher')->isFrontPage();
+    $context['language'] = \Drupal::languageManager()->getCurrentLanguage();
+    $user = \Drupal::currentUser();
+    $context['is_admin'] = $user->hasPermission('access administration pages');
+    $context['logged_in'] = $user->isAuthenticated();
+    return $context;
   }
 
 }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -352,6 +352,9 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
                   ];
                   // Let's check if the user provided in-metadata settings for the viewer
                   // This is needed to adjust ROLL/PITCH/ETC for partial panoramas.
+
+                  // @TODO. We can maybe have an option where $mediaitemkey is not set
+                  // And then have general settings for every image?
                   if (isset($jsondata[$setttings_key]) &&
                     isset($jsondata[$setttings_key][$this->pluginId]) &&
                     isset($jsondata[$setttings_key][$this->pluginId][$mediaitemkey]) &&


### PR DESCRIPTION
See #78 

This pull will also solve a few other tiny things, like adding/pushing other fun things into the twig templates (hey, hey!) and wait for it... 2 more options for the static image formatter (nice one that we can use for thumbnails and such)..
- No image? Nothing to see? Choose a FONT! yep. a mapping per type: For now a static set using Fontawesome, but i expect this to have its own Config Form (who said me?)
- No image but part of another object? Or child of another one? or the opposite? Dad? Yes. Get your images from your neighbors' front yard and reuse. Plan here is to make that very action compatible, method for other stuff. Like 'compounding' and ACL inheritance. But that comes later... 
