### PR TITLE
ISSUE-80: WebArchiving my old friend

### DIFF
--- a/format_strawberryfield.libraries.yml
+++ b/format_strawberryfield.libraries.yml
@@ -194,4 +194,4 @@ replayweb:
     url: https://github.com/webrecorder/replayweb.page/blob/master/LICENSE
     gpl-compatible: true
   js:
-    https://cdn.jsdelivr.net/npm/replaywebpage@1.0.0/ui.js: { external: true, minified: true, preprocess: false}
+    https://cdn.jsdelivr.net/npm/replaywebpage@1.0.1/ui.js: { external: true, minified: true, preprocess: false}

--- a/format_strawberryfield.libraries.yml
+++ b/format_strawberryfield.libraries.yml
@@ -185,3 +185,12 @@ leaflet_strawberry:
     - core/drupal
     - core/drupalSettings
     - format_strawberryfield/leaflet_ajax
+
+replayweb:
+  version: 1.0
+  license:
+    name: AGPLv3
+    url: https://github.com/webrecorder/replayweb.page/blob/master/LICENSE
+    gpl-compatible: true
+  js:
+    https://cdn.jsdelivr.net/npm/replaywebpage@1.0.0/ui.js: { external: true, minified: true, preprocess: false}

--- a/format_strawberryfield.libraries.yml
+++ b/format_strawberryfield.libraries.yml
@@ -185,7 +185,8 @@ leaflet_strawberry:
     - core/drupal
     - core/drupalSettings
     - format_strawberryfield/leaflet_ajax
-
+# Don't forget to update \Drupal\format_strawberryfield\Controller\JsWorkerController::servereplay
+# when moving versions up!
 replayweb:
   version: 1.0
   license:

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -93,7 +93,12 @@ function format_strawberryfield_theme() {
 function format_strawberryfield_file_mimetype_mapping_alter(&$mapping) {
   // Add relevant Repository Mimetypes missing from D8
   $mapping['extensions']['obj'] = 'obj_model_mimetype';
+  $mapping['extensions']['warc'] = 'webarchive_mimetype';
+  $mapping['extensions']['warc.gz'] = 'webarchive_mimetype';
   // @see https://www.iana.org/assignments/media-types/media-types.xhtml
   $mapping['mimetypes']['obj_model_mimetype'] = 'model/obj';
+  $mapping['mimetypes']['webarchive_mimetype'] = 'application/warc';
+
+
 
 }

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -95,10 +95,9 @@ function format_strawberryfield_file_mimetype_mapping_alter(&$mapping) {
   $mapping['extensions']['obj'] = 'obj_model_mimetype';
   $mapping['extensions']['warc'] = 'webarchive_mimetype';
   $mapping['extensions']['warc.gz'] = 'webarchive_mimetype';
+  $mapping['extensions']['warcz'] = 'webarchive_mimetype';
   // @see https://www.iana.org/assignments/media-types/media-types.xhtml
   $mapping['mimetypes']['obj_model_mimetype'] = 'model/obj';
   $mapping['mimetypes']['webarchive_mimetype'] = 'application/warc';
-
-
 
 }

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -92,12 +92,13 @@ function format_strawberryfield_theme() {
  */
 function format_strawberryfield_file_mimetype_mapping_alter(&$mapping) {
   // Add relevant Repository Mimetypes missing from D8
-  $mapping['extensions']['obj'] = 'obj_model_mimetype';
-  $mapping['extensions']['warc'] = 'webarchive_mimetype';
-  $mapping['extensions']['warc.gz'] = 'webarchive_mimetype';
-  $mapping['extensions']['warcz'] = 'webarchive_mimetype';
-  // @see https://www.iana.org/assignments/media-types/media-types.xhtml
   $mapping['mimetypes']['obj_model_mimetype'] = 'model/obj';
   $mapping['mimetypes']['webarchive_mimetype'] = 'application/warc';
+  $mapping['extensions']['obj'] = 'obj_model_mimetype';
+  $mapping['extensions']['warc'] = 'webarchive_mimetype';
+  $mapping['extensions']['warcz'] = 'webarchive_mimetype';
+  $mapping['extensions']['warc.gz'] = 'webarchive_mimetype';
+  // @see https://www.iana.org/assignments/media-types/media-types.xhtml
+
 
 }

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -96,7 +96,7 @@ function format_strawberryfield_file_mimetype_mapping_alter(&$mapping) {
   $mapping['mimetypes']['webarchive_mimetype'] = 'application/warc';
   $mapping['extensions']['obj'] = 'obj_model_mimetype';
   $mapping['extensions']['warc'] = 'webarchive_mimetype';
-  $mapping['extensions']['warcz'] = 'webarchive_mimetype';
+  $mapping['extensions']['wacz'] = 'webarchive_mimetype';
   $mapping['extensions']['warc.gz'] = 'webarchive_mimetype';
   // @see https://www.iana.org/assignments/media-types/media-types.xhtml
 

--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -125,3 +125,10 @@ format_strawberryfield.replayweb:
     _controller: '\Drupal\format_strawberryfield\Controller\JsWorkerController::servereplay'
   requirements:
     _permission: 'access content'
+format_strawberryfield.replayweb_index:
+  path: '/replay/index.html'
+  methods: [GET]
+  defaults:
+    _controller: '\Drupal\format_strawberryfield\Controller\JsWorkerController::serveindex'
+  requirements:
+    _permission: 'access content'

--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -114,3 +114,14 @@ format_strawberryfield.view_mode_mapping_settings_form:
     _permission: 'access administration pages'
   options:
     _admin_route: TRUE
+
+# Direct File access for replayweb JS Worker
+# This file will be called by replayweb library and needs to exist in that exact path
+# Reason why we went for a controller. Just an overhead!
+format_strawberryfield.replayweb:
+  path: '/replay/sw.js'
+  methods: [GET]
+  defaults:
+    _controller: '\Drupal\format_strawberryfield\Controller\JsWorkerController::servereplay'
+  requirements:
+    _permission: 'access content'

--- a/src/Controller/JsWorkerController.php
+++ b/src/Controller/JsWorkerController.php
@@ -19,8 +19,41 @@ class JsWorkerController extends ControllerBase {
    * @return \Symfony\Component\HttpFoundation\Response
    */
   public function servereplay() {
-    $response = new Response('importScripts("https://unpkg.com/replaywebpage@1.0.0/sw.js");');
-    $response->headers->set('Content-Type','text/javascript');
+    $response = new Response(
+      'importScripts("https://cdn.jsdelivr.net/npm/replaywebpage@1.0.0/sw.js");'
+    );
+    // Alternative https://unpkg.com/replaywebpage@1.0.0/sw.js
+    $response->headers->set('Content-Type', 'text/javascript');
     return $response;
-    }
+  }
+
+  /**
+   * Serves 'statically' Index to avoid failure while worker is warmin up.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   */
+  public function serveindex() {
+
+    $index = <<<'EOD'
+<!doctype html>
+<html class="no-overflow">
+<head>
+<link rel="manifest" href="/webmanifest.json">
+<link rel="icon" href="build/icon.png" type="image/png" />
+<title>ReplayWeb.page</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./ui.js"></script>
+</head>
+<body>
+<replay-app-main></replay-app-main>
+</body>
+</html>;
+EOD;
+    $response = new Response($index);
+    $response->headers->set('Content-Type', 'text/html');
+    return $response;
+
+  }
+
+
 }

--- a/src/Controller/JsWorkerController.php
+++ b/src/Controller/JsWorkerController.php
@@ -20,7 +20,7 @@ class JsWorkerController extends ControllerBase {
    */
   public function servereplay() {
     $response = new Response(
-      'importScripts("https://cdn.jsdelivr.net/npm/replaywebpage@1.0.0/sw.js");'
+      'importScripts("https://cdn.jsdelivr.net/npm/replaywebpage@1.0.1/sw.js");'
     );
     // Alternative https://unpkg.com/replaywebpage@1.0.0/sw.js
     $response->headers->set('Content-Type', 'text/javascript');

--- a/src/Controller/JsWorkerController.php
+++ b/src/Controller/JsWorkerController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\format_strawberryfield\Controller;
+
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpFoundation\Response;
+
+
+/**
+ * A JS Worker Static JS controller.
+ */
+class JsWorkerController extends ControllerBase {
+
+
+  /**
+   * Serves 'statically' the replay web JS Worker file.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   */
+  public function servereplay() {
+    $response = new Response('importScripts("https://unpkg.com/replaywebpage@1.0.0/sw.js");');
+    $response->headers->set('Content-Type','text/javascript');
+    return $response;
+    }
+}

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -13,6 +13,7 @@ use Drupal\strawberryfield\Tools\Ocfl\OcflHelper;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\format_strawberryfield\Tools\IiifHelper;
 use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
+use Drupal\Core\StreamWrapper\StreamWrapperManager;
 /**
  * Simplistic Strawberry Field formatter.
  *
@@ -192,9 +193,8 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
               }
               if ($this->checkAccess($file)) {
                 $iiifidentifier = urlencode(
-                  file_uri_target($file->getFileUri())
+                  StreamWrapperManager::getTarget($file->getFileUri())
                 );
-                //@TODO replace with  \Drupal::service('stream_wrapper_manager')->getTarget()
                 if ($iiifidentifier == NULL || empty($iiifidentifier)) {
                   continue;
                 }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -15,6 +15,7 @@ use Drupal\Core\Cache\Cache;
 use Drupal\format_strawberryfield\Tools\IiifHelper;
 use Drupal\file\FileInterface;
 use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
+use Drupal\Core\StreamWrapper\StreamWrapperManager;
 
 /**
  * Simplistic Strawberry Field formatter.
@@ -260,7 +261,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
               // we should inform to logs and continue
               if ($this->checkAccess($file)) {
                 $iiifidentifier = urlencode(
-                  file_uri_target($file->getFileUri())
+                  StreamWrapperManager::getTarget($file->getFileUri())
                 );
 
                 if ($iiifidentifier == NULL || empty($iiifidentifier)) {

--- a/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 9/18/18
+ * Time: 8:56 PM
+ */
+
+namespace Drupal\format_strawberryfield\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\strawberryfield\Tools\Ocfl\OcflHelper;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Cache\Cache;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
+use Drupal\Core\StreamWrapper\StreamWrapperManager;
+use Drupal\Core\Url;
+
+/**
+ * Simplistic Strawberry Field formatter.
+ *
+ * @FieldFormatter(
+ *   id = "strawberry_warc_formatter",
+ *   label = @Translation("Strawberry Warc Formatter using replay.web embeded player"),
+ *   class = "\Drupal\format_strawberryfield\Plugin\Field\FieldFormatter\StrawberryWarcFormatter",
+ *   field_types = {
+ *     "strawberryfield_field"
+ *   },
+ *   quickedit = {
+ *     "editor" = "disabled"
+ *   }
+ * )
+ */
+class StrawberryWarcFormatter extends StrawberryBaseFormatter {
+  
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return
+      parent::defaultSettings() + [
+      'json_key_source' => 'as:document',
+      'warcurl_json_key_source' => '',
+      'max_width' => 0,
+      'max_height' => 520,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    return [
+        'json_key_source' => [
+          '#type' => 'textfield',
+          '#title' => t('JSON Key from where to fetch Media URLs'),
+          '#default_value' => $this->getSetting('json_key_source'),
+          '#required' => TRUE,
+        ],
+        'max_width' => [
+          '#type' => 'number',
+          '#title' => $this->t('Maximum width'),
+          '#description' => $this->t('Use 0 to force 100% width'),
+          '#default_value' => $this->getSetting('max_width'),
+          '#size' => 5,
+          '#maxlength' => 5,
+          '#field_suffix' => $this->t('pixels'),
+          '#min' => 0,
+          '#required' => TRUE
+        ],
+        'max_height' => [
+          '#type' => 'number',
+          '#title' => $this->t('Maximum height'),
+          '#default_value' => $this->getSetting('max_height'),
+          '#size' => 5,
+          '#maxlength' => 5,
+          '#field_suffix' => $this->t('pixels'),
+          '#min' => 0,
+          '#required' => TRUE
+        ],
+        'warcurl_json_key_source' => [
+          '#type' => 'textfield',
+          '#title' => t('JSON key containing a list or external Warc URLs. Leave empty to skip'),
+          '#default_value' => $this->getSetting('warcurl_json_key_source'),
+        ],
+      ] + parent::settingsForm($form, $form_state);
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = parent::settingsSummary();
+    if ($this->getSetting('json_key_source')) {
+      $summary[] = $this->t('WARC file fetched from JSON "%json_key_source" key', [
+        '%json_key_source' => $this->getSetting('json_key_source'),
+      ]);
+    }
+    $summary[] = $this->t(
+      'Maximum size: %max_width x %max_height',
+      [
+        '%max_width' => (int) $this->getSetting('max_width') == 0 ? '100%' : $this->getSetting('max_width') . ' pixels',
+        '%max_height' => $this->getSetting('max_height') . ' pixels',
+      ]
+    );
+    if ($this->getSetting('warcurl_json_key_source')) {
+      $summary[] = $this->t('External WARC file URLs fetched from JSON "%json_key_source" key', [
+        '%json_key_source' => $this->getSetting('warcurl_json_key_source'),
+      ]);
+    }
+
+    return $summary;
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    $max_width = $this->getSetting('max_width');
+    $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
+    $max_height = $this->getSetting('max_height');
+    $number_images =  $this->getSetting('number_images');
+    /* @var \Drupal\file\FileInterface[] $files */
+    // Fixing the key to extract while coding to 'Media'
+    $key = $this->getSetting('json_key_source');
+
+    $nodeuuid = $items->getEntity()->uuid();
+    $nodeid = $items->getEntity()->id();
+    $fieldname = $items->getName();
+    foreach ($items as $delta => $item) {
+      $main_property = $item->getFieldDefinition()->getFieldStorageDefinition()->getMainPropertyName();
+      $value = $item->{$main_property};
+
+      if (empty($value)) {
+        continue;
+      }
+
+      $jsondata = json_decode($item->value, true);
+      // @TODO use future flatversion precomputed at field level as a property
+      $json_error = json_last_error();
+      if ($json_error != JSON_ERROR_NONE) {
+        $message= $this->t('We could had an issue decoding as JSON your metadata for node @id, field @field',
+          [
+            '@id' => $nodeid,
+            '@field' => $items->getName(),
+          ]);
+        return $elements[$delta] = ['#markup' => $this->t('ERROR')];
+      }
+      /* Expected structure of an Media item inside JSON
+      "as:application": {
+         "urn:uuid:1170c27d-431e-46e2-b003-3fb51cfcd166": {
+         "dr:fid": 66, // Drupal's FID
+         "dr:for": "add_some_warc_files", // The webform element key that generated this one
+         "url": "s3:\/\/f23\/google.com-crawl-1999.warc",
+         "name": "Google Crawl we did back on 1999.warc",
+         "type": "Application",
+         "mimetype: "application/warc"
+         "checksum": "f231aed5ae8c2e02ef0c5df6fe38a99b"
+         }
+      }*/
+      $i = 0;
+      if (isset($jsondata[$key])) {
+        // Order Files based on a given 'sequence' key
+        $ordersubkey = 'sequence';
+        // We are taking a single one here for now
+        StrawberryfieldJsonHelper::orderSequence($jsondata, $key, $ordersubkey);
+        foreach ($jsondata[$key] as $mediaitem) {
+          $i++;
+          if ($i > 1) {
+            break;
+          }
+          if (isset($mediaitem['type']) && $mediaitem['dr:mimetype'] == 'application/warc') {
+            if (isset($mediaitem['dr:fid'])) {
+              // @TODO check if loading the entity is really needed to check access.
+              // @TODO we can refactor a lot here and move it to base methods
+              $file = OcflHelper::resolvetoFIDtoURI(
+                $mediaitem['dr:fid']
+              );
+              if (!$file) {
+                continue;
+              }
+              //@TODO if no media key to file loading was possible
+              // means we have a broken/missing media reference
+              // we should inform to logs and continue
+              if ($this->checkAccess($file)) {
+                $audiourl = $file->getFileUri();
+                // We assume here file could not be accessible publicly
+                $route_parameters = [
+                  'node' => $nodeid,
+                  'uuid' => $file->uuid(),
+                  'format' => 'default.'. pathinfo($file->getFilename(), PATHINFO_EXTENSION)
+                ];
+                $publicurl = Url::fromRoute('format_strawberryfield.iiifbinary', $route_parameters);
+
+                $filecachetags = $file->getCacheTags();
+                //@TODO check this filecachetags and see if they make sense
+
+                $uniqueid =
+                  'replayweb-' . $items->getName(
+                  ) . '-' . $nodeuuid . '-' . $delta . '-warc' . $i;
+
+                $cache_contexts = [
+                  'url.site',
+                  'url.path',
+                  'url.query_args',
+                  'user.permissions'
+                ];
+                // @ see https://www.drupal.org/files/issues/2517030-125.patch
+                $cache_tags = Cache::mergeTags(
+                  $filecachetags,
+                  $items->getEntity()->getCacheTags()
+                );
+
+                // @see https://www.iandevlin.com/blog/2015/12/html5/webvtt-and-audio/
+                $elements[$delta]['warc_replayweb_' . $i] = [
+                  '#type' => 'html_tag',
+                  '#tag' => 'replay-web-page',
+                  '#cache' => [
+                    'tags' =>
+                      $cache_tags
+                    ],
+                  '#attributes' => [
+                    'source' => $publicurl->toString(),
+                    'style' => "width:{$max_width_css}; height:{$max_height}px; display:block",
+                   ]
+                  ];
+                  $elements[$delta]['#attached']['library'][] = 'format_strawberryfield/replayweb';
+                  if (isset($item->_attributes)) {
+                    $elements[$delta] += ['#attributes' => []];
+                    $elements[$delta]['#attributes'] += $item->_attributes;
+                    // Unset field item attributes since they have been included in the
+                    // formatter output and should not be rendered in the field template.
+                    unset($item->_attributes);
+                  }
+                }
+              }
+              else {
+                // @TODO Deal with no access here
+                // Should we put a thumb? Just hide?
+                // @TODO we can bring a plugin here and there that deals with
+                $elements[$delta]['media_thumb'.$i] = [
+                  '#markup' => '<i class="fas fa-times-circle"></i>',
+                  '#prefix' => '<span>',
+                  '#suffix' => '</span>',
+                ];
+              }
+
+          }
+        }
+      }
+      // Get rid of empty #attributes key to avoid render error
+      if (isset( $elements[$delta]["#attributes"]) && empty( $elements[$delta]["#attributes"])) {
+        unset($elements[$delta]["#attributes"]);
+      }
+    }
+
+    return $elements;
+
+  }
+}

--- a/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
@@ -21,7 +21,7 @@ use Drupal\Core\Url;
  *
  * @FieldFormatter(
  *   id = "strawberry_warc_formatter",
- *   label = @Translation("Strawberry Warc Formatter using replay.web embeded player"),
+ *   label = @Translation("Strawberry Warc Formatter using replay.web embedded player"),
  *   class = "\Drupal\format_strawberryfield\Plugin\Field\FieldFormatter\StrawberryWarcFormatter",
  *   field_types = {
  *     "strawberryfield_field"

--- a/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
@@ -190,7 +190,13 @@ class StrawberryWarcFormatter extends StrawberryBaseFormatter {
           if ($i > 1) {
             break;
           }
-          if (isset($mediaitem['type']) && $mediaitem['dr:mimetype'] == 'application/warc') {
+          if (isset($mediaitem['type']) && (
+            $mediaitem['dr:mimetype'] == 'application/warc' ||
+            $mediaitem['dr:mimetype'] == 'application/zip' ||
+            $mediaitem['dr:mimetype'] == 'application/gzip' ||
+            $mediaitem['dr:mimetype'] == ' application/x-gzip'
+            )
+          ) {
             if (isset($mediaitem['dr:fid'])) {
               // @TODO check if loading the entity is really needed to check access.
               // @TODO we can refactor a lot here and move it to base methods


### PR DESCRIPTION
See #80 

# This code actually works!

You will see a few JS alerts but those are harmless. Related to how the web replay JS library tries multiple sources for its ui.js library. This adds a new formatter (proof of concept, can be way better and will be) 
`Strawberry Warc Formatter using replay.web Embedded player` with simple settings for now
JSON Source Key for WARCS (use as:document please), Width, Height and an extra one for remote URLs.
`@TODO:` add extra settings to hide nav bar via "embed=replay" and "url="

The rest is what we do, load some JS, iterate over some stuff, do some checks and render some HTML.

A note. I figured out that the issue with the height of the element/iframe is the fact that is not automatically seen as of type block, so it was not flowing, extending the rest of the layout. Now it should fine!

One last note: I had to create a controller to serve the ws.js file. It needs to be inside a /replay path inside the main domain and D8 can not do that via a direct file or the library. I like how i did it!
@giancarlobi @mitchellkeaney @ikreymer 


![image](https://user-images.githubusercontent.com/6946023/85632868-1e449b00-b646-11ea-862e-24a732365e6e.png)

