### PR TITLE
Issue 74b: IABookreader, please cooperate with old friend PDF?

### DIFF
--- a/js/mirador_strawberry.js
+++ b/js/mirador_strawberry.js
@@ -43,7 +43,7 @@
                         }
                         //@TODO add an extra Manifests key with every other one so people can select the others.
                         var miradorInstance = Mirador.viewer($options);
-                        console.log('initializing Mirador 3.0.0-beta.4')
+                        console.log('initializing Mirador 3.0.0-RC3')
                     }
                 })}}
 })(jQuery, Drupal, drupalSettings, window.Mirador);

--- a/js/plugin.iiif-iabookreader_strawberry.js
+++ b/js/plugin.iiif-iabookreader_strawberry.js
@@ -100,7 +100,6 @@ BookReader.prototype.parseSequence = function (sequenceId) {
     var tmpdata = [];
     jQuery.each(self.IIIFsequence.imagesList, function(index,image) {
         var imageuri = null;
-        console.log(image.serviceUrl + ' called with argument' + image.imageGetArgument);
         var infojson = null;
 
         // If serviceURL is null then we can not call infoJSON which also means, if width and height are not

--- a/js/plugin.iiif-iabookreader_strawberry.js
+++ b/js/plugin.iiif-iabookreader_strawberry.js
@@ -132,7 +132,7 @@ BookReader.prototype.parseSequence = function (sequenceId) {
                 console.log('usign a fallback of 3:4, please correct your manifest');
                 image.width = Math.round(image.height * 0.75);
             }
-        } else if (image.heigth == 0 || image.height == null) {
+        } else if (image.height == 0 || image.height == null) {
             if ((image.canvasWidth != 0 && image.canvasWidth != null) &&
                 (image.canvasHeight != 0 && image.canvasHeight != null)
             ) {

--- a/js/plugin.iiif-iabookreader_strawberry.js
+++ b/js/plugin.iiif-iabookreader_strawberry.js
@@ -100,9 +100,8 @@ BookReader.prototype.parseSequence = function (sequenceId) {
     var tmpdata = [];
     jQuery.each(self.IIIFsequence.imagesList, function(index,image) {
         var imageuri = null;
-        console.log(image.serviceUrl +' called with argument'+  image.imageGetArgument);
+        console.log(image.serviceUrl + ' called with argument' + image.imageGetArgument);
         var infojson = null;
-
 
         // If serviceURL is null then we can not call infoJSON which also means, if width and height are not
         // present, render will fail
@@ -110,42 +109,48 @@ BookReader.prototype.parseSequence = function (sequenceId) {
         // If either width or height is missing, use canvas ratio, which will have to require if all fails then simply
         // use the default 4:3 and log into console so the user/admin/webmaster knows this is happening
         // Example of what can happen with Service Level 0 and no correct dimensions
-        /* aspectRatio: Infinity
-
+        /*
+        aspectRatio: Infinity // HAHAHA
         canvasHeight: 4
-
         canvasWidth: 3
-
         height: 0
-
         imageGetArgument: "?page=2"
-
         imageUrl: "http://localhost:8183/iiif/2/65f%2Fapplication-williams-college-yearbook-01-d708c989-229b-4ba9-a547-ed2faf568e0f.pdf/full/full/0/default.jpg…"
-
         serviceUrl: null
-
         width: 800
         */
 
-        if (image.width == 0 || image.width == null)  {
+        if (image.width == 0 || image.width == null) {
             if ((image.canvasWidth != 0 && image.canvasWidth != null) &&
                 (image.canvasHeight != 0 && image.canvasHeight != null)
             ) {
                 // We have a full ration
-                var aspectRatio  = (image.canvasWidth / image.canvasHeight) || 1;
-                image.width =  Math.round(image.height * aspectRatio);
+                var aspectRatio = (image.canvasWidth / image.canvasHeight) || 0.75;
+                image.width = Math.round(image.height * aspectRatio);
             } else {
-                console.log('canvas is incorrect and has no ratio for '+ image.imageUrl);
-                console.log('usign a fallback of 4:3, please correct your manifest');
-
+                console.log('canvas is incorrect and has no ratio for ' + image.imageUrl);
+                console.log('usign a fallback of 3:4, please correct your manifest');
+                image.width = Math.round(image.height * 0.75);
+            }
+        } else if (image.heigth == 0 || image.height == null) {
+            if ((image.canvasWidth != 0 && image.canvasWidth != null) &&
+                (image.canvasHeight != 0 && image.canvasHeight != null)
+            ) {
+                // We have a full ration
+                var aspectRatio = (image.canvasWidth / image.canvasHeight) || 0.75;
+                image.height = Math.round(image.width * aspectRatio);
+            } else {
+                image.height = Math.round(image.width * 0.75);
+                console.log('canvas is incorrect and has no ratio for ' + image.imageUrl);
+                console.log('usign a fallback of 3:4, please correct your manifest');
             }
         }
+
         // infojson will be empty if service URL is empty
 
-
-
         if (image.serviceUrl != null) {
-            infojson = image.serviceUrl + "/info.json";
+            // Pass also the imageGerArgument to the info.json -- Cantaloupe 4.1.6
+            infojson = image.serviceUrl + "/info.json" + image.imageGetArgument;
             imageuri = image.serviceUrl + "/full/" + image.width + ",/0/default.jpg" + image.imageGetArgument;
         } else {
             imageuri = image.imageUrl;

--- a/js/plugin.iiif-iabookreader_strawberry.js
+++ b/js/plugin.iiif-iabookreader_strawberry.js
@@ -138,9 +138,9 @@ BookReader.prototype.parseSequence = function (sequenceId) {
             ) {
                 // We have a full ration
                 var aspectRatio = (image.canvasWidth / image.canvasHeight) || 0.75;
-                image.height = Math.round(image.width * aspectRatio);
+                image.height = Math.round(image.width / aspectRatio);
             } else {
-                image.height = Math.round(image.width * 0.75);
+                image.height = Math.round(image.width / 0.75);
                 console.log('canvas is incorrect and has no ratio for ' + image.imageUrl);
                 console.log('usign a fallback of 3:4, please correct your manifest');
             }

--- a/js/plugin.iiif-iabookreader_strawberry.js
+++ b/js/plugin.iiif-iabookreader_strawberry.js
@@ -165,7 +165,7 @@ BookReader.prototype.parseSequence = function (sequenceId) {
             });
     });
     self.options.data.push(tmpdata);
-    console.log(self.options.data);
+    
     delete self.jsonLd;
 
     function getImagesList(sequence) {


### PR DESCRIPTION
See #74 

# What is this?

Some JS magic to deal with missing/partial/missunderstood Manifests.  It does the following
- If service level is > 0 (means we have an info.json), append the get arguments to it (?page=1)
- If width/height is present but level == 0 (like static image or one we want o set because we are like that) then use the Canvas width/height ratio to calculate the missing one. (either height or width)
- If service level == 0 don't even bother trying to figure out an .info.json and in the worst possible condition just use the generic 3/4 ration and console it out so the webmaster/admin/can have nightmares and fix its Twig Template.

Gosh! @giancarlobi i know you out but someone needs to see this even if in 2 days. @alliomeria i need to introduce you IIIF Manifests sooner than later.

In conclusion. This allows Bookreader to display individual pages for PDFs without any issue, even if we don't want to fake the size