### PR TITLE
Updates JS to comply with Drupal 9 missing attachments

### DIFF
--- a/format_strawberryfield.libraries.yml
+++ b/format_strawberryfield.libraries.yml
@@ -18,29 +18,30 @@ iiif_openseadragon_strawberry:
     - core/drupalSettings
 iiif_iabookreader:
   remote: https://openlibrary.org/dev/docs/bookreader
-  version: 4.2
+  version: 4.15
   license:
     name: GNU Affero General Public License v3.0
-    url: https://github.com/internetarchive/bookreader/blob/4.2.0/LICENSE
+    url: https://github.com/internetarchive/bookreader/blob/4.15.0/LICENSE
     gpl-compatible: true
   header: true
   css:
     component:
       css/iabookreader.css: {}
-      https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.2.0/BookReader/BookReader.css: { external: true}
+      https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.15.0/BookReader/BookReader.css: { external: true}
   js:
     js/jquery_dollar.js: {preprocess: false, minified: false, weight: -10}
     https://cdn.jsdelivr.net/npm/jquery.dragscrollable@1.0.0/dragscrollable.min.js: { external: true, minified: true, preprocess: false}
     https://cdn.jsdelivr.net/npm/jquery-colorbox@1.6.4/jquery.colorbox.min.js: { external: true, minified: true, preprocess: false}
     https://cdn.jsdelivr.net/npm/jquery.mmenu@7.3.3/dist/jquery.mmenu.all.min.js: { external: true, minified: true, preprocess: false}
     https://cdn.jsdelivr.net/npm/jquery.mmenu@7.3.3/dist/addons/navbars/jquery.mmenu.navbars.js: { external: true, minified: true, preprocess: false}
-    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.2.0/BookReader/dragscrollable-br.js: { external: true, minified: false, preprocess: false}
-    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.2.0/BookReader/BookReader.js: { external: true, minified: false, preprocess: false,  weight: -9}
-    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.2.0/BookReader/plugins/plugin.url.js: { external: true, minified: false, preprocess: false, weight: -8}
-    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.2.0/BookReader/plugins/plugin.resume.js: { external: true, minified: false, preprocess: false, weight: -8}
-    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.2.0/BookReader/plugins/plugin.mobile_nav.js: { external: true, minified: false, preprocess: false, weight: -8}
-    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.2.0/BookReader/plugins/plugin.chapters.js: { external: true, minified: false, preprocess: false, weight: -8}
-    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.2.0/BookReader/plugins/plugin.search.js: { external: true, minified: false, preprocess: false, weight: -8}
+    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.15.0/BookReader/jquery-ui-1.12.0.min.js: { external: true, minified: true, preprocess: false}
+    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.15.0/BookReader/dragscrollable-br.js: { external: true, minified: false, preprocess: false}
+    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.15.0/BookReader/BookReader.js: { external: true, minified: false, preprocess: false,  weight: -9}
+    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.15.0/BookReader/plugins/plugin.url.js: { external: true, minified: false, preprocess: false, weight: -8}
+    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.15.0/BookReader/plugins/plugin.resume.js: { external: true, minified: false, preprocess: false, weight: -8}
+    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.15.0/BookReader/plugins/plugin.mobile_nav.js: { external: true, minified: false, preprocess: false, weight: -8}
+    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.15.0/BookReader/plugins/plugin.chapters.js: { external: true, minified: false, preprocess: false, weight: -8}
+    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.15.0/BookReader/plugins/plugin.search.js: { external: true, minified: false, preprocess: false, weight: -8}
   dependencies:
     - core/jquery
     - core/jquery.ui

--- a/format_strawberryfield.libraries.yml
+++ b/format_strawberryfield.libraries.yml
@@ -56,11 +56,13 @@ iiif_iabookreader_strawberry:
     js/iiif-iabookreader_collapse.js: {minified: false}
   dependencies:
     - core/jquery
+    - core/jquery.once
     - core/jquery.ui
     - core/drupal
     - core/drupal.form
     - core/drupalSettings
     - core/drupal.debounce
+    - core/modernizr
     - format_strawberryfield/iiif_iabookreader
 pannellum:
   version: 2.5.6
@@ -77,6 +79,7 @@ iiif_pannellum_strawberry:
     js/iiif-pannellum_strawberry.js: {minified: false}
   dependencies:
     - core/jquery
+    - core/jquery.once
     - core/drupal
     - core/drupalSettings
     - format_strawberryfield/pannellum
@@ -101,6 +104,7 @@ jsm_model_strawberry:
     js/jsm-model_strawberry.js: {minified: false}
   dependencies:
     - core/jquery
+    - core/jquery.once
     - core/jquery.ui
     - core/drupal
     - core/drupalSettings
@@ -122,6 +126,7 @@ pdfs_strawberry:
   dependencies:
     - core/jquery
     - core/drupal
+    - core/jquery.once
     - core/drupalSettings
     - format_strawberryfield/pdfs_mozilla
 
@@ -149,6 +154,7 @@ mirador_strawberry:
   dependencies:
     - core/jquery
     - core/drupal
+    - core/jquery.once
     - core/drupalSettings
     - format_strawberryfield/mirador_projectmirador
     - format_strawberryfield/mirador_font
@@ -182,6 +188,7 @@ leaflet_strawberry:
     js/leaflet_strawberry.js: {minified: false}
   dependencies:
     - core/jquery
+    - core/jquery.once
     - core/drupal
     - core/drupalSettings
     - format_strawberryfield/leaflet_ajax


### PR DESCRIPTION
# What is this?

@giancarlobi Seven Theme (in Drupal 9) does not include modernizr anymore. We use it for the bookreader. Here is the patch!