### PR TITLE
Issue-91: update JS libraries/Twig/Formatters and prepare of D9 deployment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "require": {
         "ml/json-ld": "^1.2",
         "mtdowling/jmespath.php":"^2.5",
-        "strawberryfield/strawberryfield":"dev-8.x-1.0-beta3",
-        "drupal/webform": "^5.19",
+        "strawberryfield/strawberryfield":"dev-1.0.0-RC1",
+        "drupal/webform": "^5.19 || ^6.0",
         "drupal/webform_views": "^5.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "mtdowling/jmespath.php":"^2.5",
         "strawberryfield/strawberryfield":"dev-1.0.0-RC1",
         "drupal/webform": "^5.19 || ^6.0",
-        "drupal/webform_views": "^5.0"
+        "drupal/webform_views": "^5.0",
+        "ext-json": "*"
     }
 }

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -58,6 +58,8 @@ field.formatter.settings.strawberry_image_formatter:
       type: string
     image_type:
       type: string
+    webannotations:
+      type: boolean
     quality:
       type: string
     rotation:
@@ -81,6 +83,8 @@ field.formatter.settings.strawberry_media_formatter:
       type: string
     max_height:
       type: string
+    webannotations:
+      type: boolean
     use_iiif_globals:
       type: string
       label: 'Whether to use global IIIF settings or not.'

--- a/format_strawberryfield.libraries.yml
+++ b/format_strawberryfield.libraries.yml
@@ -8,6 +8,7 @@ iiif_openseadragon:
   header: true
   js:
     https://cdn.jsdelivr.net/npm/openseadragon@2.4.2/build/openseadragon/openseadragon.min.js: { external: true, minified: true, preprocess: false}
+
 iiif_openseadragon_strawberry:
   version: 1.0
   js:
@@ -16,6 +17,8 @@ iiif_openseadragon_strawberry:
     - core/jquery
     - core/drupal
     - core/drupalSettings
+    - format_strawberryfield/annotoriousopenseadragon
+
 iiif_iabookreader:
   remote: https://openlibrary.org/dev/docs/bookreader
   version: 4.15.0
@@ -171,8 +174,8 @@ leaflet_markercluster:
     https://unpkg.com/browse/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js: { external: true, minified: true, preprocess: false}
   css:
     component:
-      https://unpkg.com/browse/leaflet.markercluster@1.4.1/dist/MarkerCluster.css: { external: true}
-      https://unpkg.com/browse/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css: { external: true}
+      https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css: { external: true}
+      https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css: { external: true}
 
 leaflet_core:
   version: 1.6.0
@@ -208,6 +211,7 @@ leaflet_strawberry:
     - core/drupal
     - core/drupalSettings
     - format_strawberryfield/leaflet_ajax
+
 # Don't forget to update \Drupal\format_strawberryfield\Controller\JsWorkerController::servereplay
 # when moving versions up!
 replayweb:
@@ -228,3 +232,38 @@ universalviewer:
   js:
     https://cdn.jsdelivr.net/npm/universalviewer@4.0.0-pre.49/dist/uv-dist-umd/UV.min.js: { external: true, minified: true, preprocess: false}
     https://unpkg.com/@edsilv/utils@1.0.2/dist-umd/utils.js: { external: true, minified: true, preprocess: false}
+
+annotorious:
+  version: 2.1.2
+  license:
+    name: BSD-3 Clause
+    url: https://github.com/recogito/annotorious/blob/master/LICENSE
+    gpl-compatible: true
+  js:
+    https://cdn.jsdelivr.net/npm/@recogito/annotorious@2.1.2/dist/annotorious.min.js: { external: true, minified: true, preprocess: false}
+  css:
+    component:
+      https://cdn.jsdelivr.net/npm/@recogito/annotorious@2.1.2/dist/annotorious.min.css: { external: true }
+
+annotoriousopenseadragon:
+  version: 2.10
+  license:
+    name: BSD-3 Clause
+    url: https://github.com/recogito/annotorious-openseadragon/blob/master/LICENSE
+    gpl-compatible: true
+  js:
+    https://cdn.jsdelivr.net/npm/@recogito/annotorious-openseadragon@2.1.0/dist/openseadragon-annotorious.min.js: { external: true, minified: true, preprocess: false}
+  css:
+    component:
+      https://cdn.jsdelivr.net/npm/@recogito/annotorious@2.1.2/dist/annotorious.min.css: { external: true }
+
+w3cWebAnnotations_strawberry:
+  version: 1.0
+  js:
+    js/w3cWebAnnon_strawberry.js: { minified: false }
+  dependencies:
+    - core/jquery
+    - core/jquery.once
+    - core/jquery.ui
+    - core/drupal
+    - core/drupalSettings

--- a/format_strawberryfield.libraries.yml
+++ b/format_strawberryfield.libraries.yml
@@ -1,13 +1,13 @@
 iiif_openseadragon:
   remote: http://openseadragon.github.io
-  version: 2.4
+  version: 2.4.2
   license:
     name: NewBSD
     url: http://openseadragon.github.io/license/
     gpl-compatible: false
   header: true
   js:
-    https://cdn.jsdelivr.net/npm/openseadragon@2.4/build/openseadragon/openseadragon.min.js: { external: true, minified: true, preprocess: false}
+    https://cdn.jsdelivr.net/npm/openseadragon@2.4.2/build/openseadragon/openseadragon.min.js: { external: true, minified: true, preprocess: false}
 iiif_openseadragon_strawberry:
   version: 1.0
   js:
@@ -18,7 +18,7 @@ iiif_openseadragon_strawberry:
     - core/drupalSettings
 iiif_iabookreader:
   remote: https://openlibrary.org/dev/docs/bookreader
-  version: 4.15
+  version: 4.15.0
   license:
     name: GNU Affero General Public License v3.0
     url: https://github.com/internetarchive/bookreader/blob/4.15.0/LICENSE
@@ -132,18 +132,18 @@ pdfs_strawberry:
     - format_strawberryfield/pdfs_mozilla
 
 mirador_projectmirador:
-  version: 3.0.0-rc.3
+  version: 3.0.0-rc.5
   license:
     name: Apache
     url: //github.com/ProjectMirador/mirador/blob/master/LICENSE
     gpl-compatible: true
   js:
-    https://cdn.jsdelivr.net/npm/mirador@3.0.0-rc.3/dist/mirador.min.js: { external: true, minified: true, preprocess: false}
+    https://cdn.jsdelivr.net/npm/mirador@3.0.0-rc.5/dist/mirador.min.js: { external: true, minified: true, preprocess: false}
 
 mirador_font:
- css:
-   base:
-     'https://fonts.googleapis.com/css?family=Roboto:300,400,500': { external: true }
+  css:
+    base:
+      'https://fonts.googleapis.com/css?family=Roboto:300,400,500': { external: true }
 
 mirador_strawberry:
   version: 1.0
@@ -159,6 +159,20 @@ mirador_strawberry:
     - core/drupalSettings
     - format_strawberryfield/mirador_projectmirador
     - format_strawberryfield/mirador_font
+
+leaflet_markercluster:
+  version: 1.4.1
+  remote: https://github.com/Leaflet/Leaflet.markercluster
+  license:
+    name: MIT
+    url: https://github.com/Leaflet/Leaflet.markercluster/blob/master/MIT-LICENCE.txt
+    gpl-compatible: true
+  js:
+    https://unpkg.com/browse/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js: { external: true, minified: true, preprocess: false}
+  css:
+    component:
+      https://unpkg.com/browse/leaflet.markercluster@1.4.1/dist/MarkerCluster.css: { external: true}
+      https://unpkg.com/browse/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css: { external: true}
 
 leaflet_core:
   version: 1.6.0
@@ -182,6 +196,7 @@ leaflet_ajax:
     https://cdn.jsdelivr.net/npm/leaflet-ajax@2.1.0/dist/leaflet.ajax.min.js: { external: true, minified: true, preprocess: false}
   dependencies:
     - format_strawberryfield/leaflet_core
+    - format_strawberryfield/leaflet_markercluster
 
 leaflet_strawberry:
   version: 1.0
@@ -196,10 +211,20 @@ leaflet_strawberry:
 # Don't forget to update \Drupal\format_strawberryfield\Controller\JsWorkerController::servereplay
 # when moving versions up!
 replayweb:
-  version: 1.0
+  version: 1.0.2
   license:
     name: AGPLv3
     url: https://github.com/webrecorder/replayweb.page/blob/master/LICENSE
     gpl-compatible: true
   js:
-    https://cdn.jsdelivr.net/npm/replaywebpage@1.0.1/ui.js: { external: true, minified: true, preprocess: false}
+    https://cdn.jsdelivr.net/npm/replaywebpage@1.0.2/ui.js: { external: true, minified: true, preprocess: false}
+
+universalviewer:
+  version: 4.0.0-pre.49
+  license:
+    name: MIT
+    url: hhttps://cdn.jsdelivr.net/npm/universalviewer@4.0.0-pre.49/LICENSE.txt
+    gpl-compatible: true
+  js:
+    https://cdn.jsdelivr.net/npm/universalviewer@4.0.0-pre.49/dist/uv-dist-umd/UV.min.js: { external: true, minified: true, preprocess: false}
+    https://unpkg.com/@edsilv/utils@1.0.2/dist-umd/utils.js: { external: true, minified: true, preprocess: false}

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -5,6 +5,8 @@
  */
 use \Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\node\NodeInterface;
+use Drupal\Core\Form\FormStateInterface;
 /**
  * Implements hook_page_attachments().
  *
@@ -100,5 +102,51 @@ function format_strawberryfield_file_mimetype_mapping_alter(&$mapping) {
   $mapping['extensions']['warc.gz'] = 'webarchive_mimetype';
   // @see https://www.iana.org/assignments/media-types/media-types.xhtml
 
+}
 
+/**
+ * Implements hook_ENTITY_TYPE_prepare_form() for node entities.
+ */
+function format_strawberryfield_node_prepare_form(NodeInterface $entity, $operation, FormStateInterface $form_state) {
+  // Prepare defaults for the add/edit form.
+  //Because of Form Modes we can not only depend on "edit". But more likely on
+  if (($operation == 'delete' || $operation == 'quick_node_clone')) {
+    return;
+  }
+  $account = \Drupal::currentUser();
+  if (($sbf_fields = \Drupal::service('strawberryfield.utility')->bearsStrawberryfield($entity)) && $account->hasPermission('add strawberryfield webannotation')) {
+    foreach ($sbf_fields as $field_name) {
+      /* @var $field \Drupal\Core\Field\FieldItemInterface */
+      $field = $entity->get($field_name);
+      /* @var \Drupal\strawberryfield\Field\StrawberryFieldItemList $field */
+      $entity = $field->getEntity();
+      $entity_type_id = $entity->getEntityTypeId();
+      /** @var $field \Drupal\Core\Field\FieldItemList */
+      foreach ($field->getIterator() as $delta => $itemfield) {
+        /** @var $itemfield \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem */
+        $fullvalues = $itemfield->provideDecoded(TRUE);
+        /* @var $tempstore \Drupal\Core\TempStore\PrivateTempStore */
+        $tempstore = \Drupal::service('tempstore.private')->get('webannotation');
+        $annotation_values =  $tempstore->get($entity->uuid());
+        if (count($annotation_values)) {
+          if (!isset($fullvalues['ap:annotationCollection'])) {
+            $fullvalues['ap:annotationCollection'] = [];
+          }
+          $fullvalues['ap:annotationCollection'] =  array_merge_recursive($annotation_values, $fullvalues['ap:annotationCollection']);
+          $entity->{$field_name}[0]->setMainValueFromArray($fullvalues);
+          \Drupal::messenger()->addStatus(\Drupal::translation()->formatPlural(count($annotation_values),
+            'You have one pending WebAnnotation for this Digital Object. To persist Save the Object. ',
+            'You have %number unsaved WebAnnotation for this Digital Object.To persist Save the Object.',
+            ['%number' => count($annotation_values)]
+          ));
+          $form_state->set('hadAnnotations', TRUE);
+          break 2;
+        }
+        if (!is_array($fullvalues)) {
+          break;
+        }
+
+      }
+    }
+  }
 }

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -3,37 +3,85 @@
  * @file
  * Contains formater_strawberryfield.module.
  */
+
+use Drupal\Component\Serialization\Json;
 use \Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Url;
 use Drupal\format_strawberryfield\Controller\WebAnnotationController;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Swaggest\JsonDiff\JsonDiff;
 /**
  * Implements hook_page_attachments().
  *
  * Adds the iiif_openseadragon js library.
  */
 function format_strawberryfield_page_attachments(array &$page) {
-    /*if (!\Drupal::currentUser()->hasPermission('access search')) {
-        return;
-    @TODO discuss if we need to limit viewers to a particular role?
-    Could be nice to allow annotations as a drop replacement
-    of the same viewer dependant on the rol
-    }*/
+  /*if (!\Drupal::currentUser()->hasPermission('access search')) {
+      return;
+  @TODO discuss if we need to limit viewers to a particular role?
+  Could be nice to allow annotations as a drop replacement
+  of the same viewer dependant on the rol
+  }*/
 
-    // Remove IIIF on admin routes, why make peoples life more complicated
-    /* if (\Drupal::service('router.admin_context')->isAdminRoute()) {
-        return;
-    }*/
-    $page['#attached']['library'][] = 'format_strawberryfield/iiif_openseadragon';
-    $page['#attached']['library'][] = 'format_strawberryfield/iiif_iabookreader';
-    $page['#attached']['library'][] = 'format_strawberryfield/pannellum';
-    $page['#attached']['library'][] = 'format_strawberryfield/jsm_modeler';
-    $page['#attached']['library'][] = 'core/jquery';
-    $page['#attached']['library'][] = 'core/drupal.dialog.ajax';
-    $page['#attached']['library'][] = 'core/drupal.ajax';
+  // Remove IIIF on admin routes, why make peoples life more complicated
+  /* if (\Drupal::service('router.admin_context')->isAdminRoute()) {
+      return;
+  }*/
+  $page['#attached']['library'][] = 'format_strawberryfield/iiif_openseadragon';
+  $page['#attached']['library'][] = 'format_strawberryfield/iiif_iabookreader';
+  $page['#attached']['library'][] = 'format_strawberryfield/pannellum';
+  $page['#attached']['library'][] = 'format_strawberryfield/jsm_modeler';
+  $page['#attached']['library'][] = 'core/jquery';
+  $page['#attached']['library'][] = 'core/drupal.dialog.ajax';
+  $page['#attached']['library'][] = 'core/drupal.ajax';
 
 }
+
+function format_strawberryfield_form_node_form_alter(&$form, FormStateInterface $form_state) {
+
+  // Deal with Possible Addded Annotations.
+
+  if ($form_state->get('hadAnnotations')) {
+    $node = $form_state->getFormObject()->getEntity();
+    $count = $form_state->get('hadAnnotations');
+    $form['annotations'] = [
+      '#type' => 'fieldset',
+      '#weigth ' => -1000,
+      '#title' => 'Unsaved Web Annotations',
+    ];
+    $form['annotations']['markup'] = [
+      '#type' => 'markup',
+      '#markup' => 'To persist them <em>save</em> the Object or continue editing by going back to <em>View</em>. '
+    ];
+    $form['annotations']['markup2'] = [
+      '#type' => 'markup',
+      '#markup' => 'Pressing <em>Discard</em> will keep the original ones untouched and will reload this page.'
+    ];
+    // We may had the need to reload the page since we are overriding the SBF
+    // field value on format_strawberryfield_node_prepare_form
+    // @TODO maybe someone has a better idea on how to avoid/force reloading?
+    // The simples way really is to redirect the user back here.
+
+    $form['annotations']['discard'] = [
+      '#prefix' => '<div>',
+      '#suffix' => '</div>',
+      '#type' => 'button',
+      '#value' => t('Discard'),
+      '#ajax' => [
+        'callback' => 'Drupal\format_strawberryfield\Controller\WebAnnotationController::deleteKeyStoreAjaxCallback',
+        'event' => 'click',
+        'progress' => [
+          'type' => 'throbber',
+          'message' => 'Restoring original Web Annotations ',
+        ],
+      ]
+    ];
+  }
+}
+
+
 
 function format_strawberryfield_entity_view_mode_alter(&$view_mode, EntityInterface $entity, $context) {
   if ($entity->getEntityTypeId() == 'node' && $view_mode == 'full') {
@@ -57,7 +105,7 @@ function format_strawberryfield_entity_view_mode_alter(&$view_mode, EntityInterf
     }
     if (!empty($adotype)) {
       $config = \drupal::config(
-      'format_strawberryfield.viewmodemapping_settings'
+        'format_strawberryfield.viewmodemapping_settings'
       );
       $viewmodemappings = $config->get('type_to_viewmode');
       $viewmodemappings = !empty($viewmodemappings) ? (array) $viewmodemappings : [];
@@ -122,9 +170,6 @@ function format_strawberryfield_node_prepare_form(NodeInterface $entity, $operat
       /* @var $field \Drupal\Core\Field\FieldItemInterface */
       $field = $entity->get($field_name);
       /* @var \Drupal\strawberryfield\Field\StrawberryFieldItemList $field */
-      $entity = $field->getEntity();
-      $entity_type_id = $entity->getEntityTypeId();
-      /** @var $field \Drupal\Core\Field\FieldItemList */
       foreach ($field->getIterator() as $delta => $itemfield) {
         /** @var $itemfield \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem */
         $fullvalues = $itemfield->provideDecoded(TRUE);
@@ -142,29 +187,22 @@ function format_strawberryfield_node_prepare_form(NodeInterface $entity, $operat
         if (count($annotation_values) &&
           (isset($fullvalues['ap:annotationCollection']) && $annotation_values != $fullvalues['ap:annotationCollection']) ||
           (count($annotation_values) && !isset($fullvalues['ap:annotationCollection']))) {
-          $number_of_annotations = 0;
-          foreach($annotation_values as $target_resources => $annotations) {
-            $number_of_annotations = $number_of_annotations + count($annotations);
-          }
-
-        if (count($annotation_values)) {
-          if (!isset($fullvalues['ap:annotationCollection'])) {
-            $fullvalues['ap:annotationCollection'] = [];
-          }
-          $fullvalues['ap:annotationCollection'] = array_merge(
+          // Super handy! Potential for the future: JSON UNDO!!
+          $r = new JsonDiff(
+            $fullvalues['ap:annotationCollection'],
             $annotation_values,
-            $fullvalues['ap:annotationCollection']
+            JsonDiff::REARRANGE_ARRAYS + JsonDiff::SKIP_JSON_MERGE_PATCH
           );
-          $entity->{$field_name}[0]->setMainValueFromArray($fullvalues);
-          \Drupal::messenger()->addStatus(
-            \Drupal::translation()->translate(
-              'You have unsaved Annotation for this Digital Object. To persist them Save the Object.'
-            )
-          );
-          $form_state->set('hadAnnotations', TRUE);
+          // We just keep track of the changes. If none! Then we do not set
+          // the formstate flag.
+          if ($r->getDiffCnt() > 0 ) {
+            $fullvalues['ap:annotationCollection'] = $annotation_values;
+            $entity->{$field_name}[0]->setMainValueFromArray($fullvalues);
+            $form_state->set('hadAnnotations', $r->getDiffCnt());
+          }
           break 2;
+
         }
-      }
         if (!is_array($fullvalues)) {
           break;
         }

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -5,6 +5,7 @@
  */
 use \Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\format_strawberryfield\Controller\WebAnnotationController;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Form\FormStateInterface;
 /**
@@ -110,9 +111,11 @@ function format_strawberryfield_file_mimetype_mapping_alter(&$mapping) {
 function format_strawberryfield_node_prepare_form(NodeInterface $entity, $operation, FormStateInterface $form_state) {
   // Prepare defaults for the add/edit form.
   //Because of Form Modes we can not only depend on "edit". But more likely on
-  if (($operation == 'delete' || $operation == 'quick_node_clone')) {
+
+  if (($operation == 'delete' || $operation == 'quick_node_clone' || $entity->isNew())) {
     return;
   }
+
   $account = \Drupal::currentUser();
   if (($sbf_fields = \Drupal::service('strawberryfield.utility')->bearsStrawberryfield($entity)) && $account->hasPermission('add strawberryfield webannotation')) {
     foreach ($sbf_fields as $field_name) {
@@ -126,22 +129,42 @@ function format_strawberryfield_node_prepare_form(NodeInterface $entity, $operat
         /** @var $itemfield \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem */
         $fullvalues = $itemfield->provideDecoded(TRUE);
         /* @var $tempstore \Drupal\Core\TempStore\PrivateTempStore */
-        $tempstore = \Drupal::service('tempstore.private')->get('webannotation');
-        $annotation_values =  $tempstore->get($entity->uuid());
+        $tempstore = \Drupal::service('tempstore.private')->get(
+          'webannotation'
+        );
+        $keystoreid = WebAnnotationController::getTempStoreKeyName(
+          $field_name,
+          $delta,
+          $entity->uuid()
+        );
+        $annotation_values = $tempstore->get($keystoreid);
+        $annotation_values = is_array($annotation_values) ? $annotation_values : [];
+        if (count($annotation_values) &&
+          (isset($fullvalues['ap:annotationCollection']) && $annotation_values != $fullvalues['ap:annotationCollection']) ||
+          (count($annotation_values) && !isset($fullvalues['ap:annotationCollection']))) {
+          $number_of_annotations = 0;
+          foreach($annotation_values as $target_resources => $annotations) {
+            $number_of_annotations = $number_of_annotations + count($annotations);
+          }
+
         if (count($annotation_values)) {
           if (!isset($fullvalues['ap:annotationCollection'])) {
             $fullvalues['ap:annotationCollection'] = [];
           }
-          $fullvalues['ap:annotationCollection'] =  array_merge_recursive($annotation_values, $fullvalues['ap:annotationCollection']);
+          $fullvalues['ap:annotationCollection'] = array_merge(
+            $annotation_values,
+            $fullvalues['ap:annotationCollection']
+          );
           $entity->{$field_name}[0]->setMainValueFromArray($fullvalues);
-          \Drupal::messenger()->addStatus(\Drupal::translation()->formatPlural(count($annotation_values),
-            'You have one pending WebAnnotation for this Digital Object. To persist Save the Object. ',
-            'You have %number unsaved WebAnnotation for this Digital Object.To persist Save the Object.',
-            ['%number' => count($annotation_values)]
-          ));
+          \Drupal::messenger()->addStatus(
+            \Drupal::translation()->translate(
+              'You have unsaved Annotation for this Digital Object. To persist them Save the Object.'
+            )
+          );
           $form_state->set('hadAnnotations', TRUE);
           break 2;
         }
+      }
         if (!is_array($fullvalues)) {
           break;
         }

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -46,11 +46,20 @@ function format_strawberryfield_form_node_form_alter(&$form, FormStateInterface 
   if ($form_state->get('hadAnnotations')) {
     $node = $form_state->getFormObject()->getEntity();
     $count = $form_state->get('hadAnnotations');
+
     $form['annotations'] = [
       '#type' => 'fieldset',
       '#weigth ' => -1000,
-      '#title' => 'Unsaved Web Annotations',
+      '#title' => t('Unsaved Web Annotations'),
     ];
+    $form['annotations']['container'] = [
+      '#type' => 'container',
+      '#markup' =>  \Drupal::translation()->formatPlural($count,
+        'You have one unsaved Annotation/Modification to an Annotation for this Digital Object',
+        'You have @count unsaved Annotation/Modification for this Digital Object'
+      )
+    ];
+
     $form['annotations']['markup'] = [
       '#type' => 'markup',
       '#markup' => 'To persist them <em>save</em> the Object or continue editing by going back to <em>View</em>. '

--- a/format_strawberryfield.permissions.yml
+++ b/format_strawberryfield.permissions.yml
@@ -14,6 +14,10 @@ add strawberryfield webannotation:
   title: 'Add W3C Web Annotations'
   description: 'This permission only applies if editing the Entity (e.g) that holds the given Strawberry Field is also granted'
   restrict access: TRUE
+view strawberryfield webannotation:
+  title: 'View W3C Web Annotations'
+  description: 'This permission only applies if Entity (e.g) can also be seen by the user'
+  restrict access: TRUE
 edit own strawberryfield webannotation:
   title: 'Edit own W3C Web Annotations'
   description: 'This permission only applies if editing the Entity (e.g) that holds the given Strawberry Field is also granted'

--- a/format_strawberryfield.permissions.yml
+++ b/format_strawberryfield.permissions.yml
@@ -10,3 +10,15 @@ delete metadatadisplay entity:
 administer metadatadisplay entity:
   title: 'Administer Metadata Display Template entity'
   restrict access: TRUE
+add strawberryfield webannotation:
+  title: 'Add W3C Web Annotations'
+  description: 'This permission only applies if editing the Entity (e.g) that holds the given Strawberry Field is also granted'
+  restrict access: TRUE
+edit own strawberryfield webannotation:
+  title: 'Edit own W3C Web Annotations'
+  description: 'This permission only applies if editing the Entity (e.g) that holds the given Strawberry Field is also granted'
+  restrict access: TRUE
+delete strawberryfield webannotation:
+  title: 'Delete W3C Web Annotations'
+  description: 'This permission only applies if editing the Entity (e.g) that holds the given Strawberry Field is also granted'
+  restrict access: TRUE

--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -152,7 +152,7 @@ format_strawberryfield.push_webannotation:
 # Delete in temporary State/limbo a generated WebAnnotation.
 format_strawberryfield.delete_webannotation:
   path: '/do/{node}/webannon/delete'
-  methods: [PUSH]
+  methods: [DELETE]
   defaults:
     _controller: '\Drupal\format_strawberryfield\Controller\WebAnnotationController::deleteTemp'
   options:
@@ -214,3 +214,20 @@ format_strawberryfield.get_webannotations:
     _format: 'json'
     _entity_access: 'node.view'
     _permission: 'view strawberryfield webannotation'
+
+# Persist in a SBF any generated Webannotations.
+format_strawberryfield.deletetmp_webannotations:
+  path: '/do/{node}/webannon/deletetmp'
+  methods: [POST]
+  defaults:
+    _controller: '\Drupal\format_strawberryfield\Controller\WebAnnotationController::deleteKeyStore'
+  options:
+    parameters:
+      node:
+        type: 'entity:node'
+      resource_type:
+        type: 'ado'
+  requirements:
+    _format: 'json'
+    _entity_access: 'node.update'
+    _permission: 'add strawberryfield webannotation'

--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -93,7 +93,7 @@ format_strawberryfield.metadatadisplay_caster:
   requirements:
     format: .+
     _entity_access: 'node.view'
-    _entity_access: 'metadataexpose_entity.view'
+#    _entity_access: 'metadataexpose_entity.view'
 
 format_strawberryfield.iiif_admin_settings_form:
   path: '/admin/config/archipelago/iiif'

--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -133,12 +133,12 @@ format_strawberryfield.replayweb_index:
   requirements:
     _permission: 'access content'
 
-# Persist in temporary State/limbo any generated Webannotations.
-format_strawberryfield.process_webannotations:
-  path: '/do/{node}/crud/webannon'
-  methods: [POST]
+# Update in temporary State/limbo a generated Webannotation.
+format_strawberryfield.push_webannotation:
+  path: '/do/{node}/webannon/put'
+  methods: [PUT]
   defaults:
-    _controller: '\Drupal\format_strawberryfield\Controller\WebAnnotationController::persistTemp'
+    _controller: '\Drupal\format_strawberryfield\Controller\WebAnnotationController::putTemp'
   options:
     parameters:
       node:
@@ -149,10 +149,41 @@ format_strawberryfield.process_webannotations:
     _format: 'json'
     _entity_access: 'node.update'
     _permission: 'add strawberryfield webannotation'
-
-# Persist in a SBF any generated Webannotations.
+# Delete in temporary State/limbo a generated WebAnnotation.
+format_strawberryfield.delete_webannotation:
+  path: '/do/{node}/webannon/delete'
+  methods: [PUSH]
+  defaults:
+    _controller: '\Drupal\format_strawberryfield\Controller\WebAnnotationController::deleteTemp'
+  options:
+    parameters:
+      node:
+        type: 'entity:node'
+      resource_type:
+        type: 'ado'
+  requirements:
+    _format: 'json'
+    _entity_access: 'node.update'
+    _permission: 'add strawberryfield webannotation'
+# Persist in temporary State/limbo any generated WebAnnotations.
+format_strawberryfield.post_webannotation:
+  path: '/do/{node}/webannon/post'
+  methods: [POST]
+  defaults:
+    _controller: '\Drupal\format_strawberryfield\Controller\WebAnnotationController::postTemp'
+  options:
+    parameters:
+      node:
+        type: 'entity:node'
+      resource_type:
+        type: 'ado'
+  requirements:
+    _format: 'json'
+    _entity_access: 'node.update'
+    _permission: 'add strawberryfield webannotation'
+# Persist in a SBF any generated WebAnnotations.
 format_strawberryfield.save_webannotations:
-  path: '/do/{node}/crud/webannon'
+  path: '/do/{node}/webannon/save'
   methods: [POST]
   defaults:
     _controller: '\Drupal\format_strawberryfield\Controller\WebAnnotationController::persist'
@@ -169,10 +200,10 @@ format_strawberryfield.save_webannotations:
 
 # Persist in a SBF any generated Webannotations.
 format_strawberryfield.get_webannotations:
-  path: '/do/{node}/crud/webannon/{target}'
+  path: '/do/{node}/webannon/read'
   methods: [GET]
   defaults:
-    _controller: '\Drupal\format_strawberryfield\Controller\WebAnnotationController::persist'
+    _controller: '\Drupal\format_strawberryfield\Controller\WebAnnotationController::read'
   options:
     parameters:
       node:
@@ -180,7 +211,6 @@ format_strawberryfield.get_webannotations:
       resource_type:
         type: 'ado'
   requirements:
-    target: .+
     _format: 'json'
-    _entity_access: 'node.update'
-    _permission: 'add strawberryfield webannotation'
+    _entity_access: 'node.view'
+    _permission: 'view strawberryfield webannotation'

--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -132,3 +132,20 @@ format_strawberryfield.replayweb_index:
     _controller: '\Drupal\format_strawberryfield\Controller\JsWorkerController::serveindex'
   requirements:
     _permission: 'access content'
+
+# Direct access to Metadata display processed json using Metadata Expose Config Entity.
+format_strawberryfield.process_webannotations:
+  path: '/do/{node}/crud/webannon'
+  methods: [POST]
+  defaults:
+    _controller: '\Drupal\format_strawberryfield\Controller\WebAnnotationController::persist'
+  options:
+    parameters:
+      node:
+        type: 'entity:node'
+      resource_type:
+        type: 'ado'
+  requirements:
+    _format: 'json'
+    _entity_access: 'node.update'
+    _permission: 'add strawberryfield webannotation'

--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -133,8 +133,25 @@ format_strawberryfield.replayweb_index:
   requirements:
     _permission: 'access content'
 
-# Direct access to Metadata display processed json using Metadata Expose Config Entity.
+# Persist in temporary State/limbo any generated Webannotations.
 format_strawberryfield.process_webannotations:
+  path: '/do/{node}/crud/webannon'
+  methods: [POST]
+  defaults:
+    _controller: '\Drupal\format_strawberryfield\Controller\WebAnnotationController::persistTemp'
+  options:
+    parameters:
+      node:
+        type: 'entity:node'
+      resource_type:
+        type: 'ado'
+  requirements:
+    _format: 'json'
+    _entity_access: 'node.update'
+    _permission: 'add strawberryfield webannotation'
+
+# Persist in a SBF any generated Webannotations.
+format_strawberryfield.save_webannotations:
   path: '/do/{node}/crud/webannon'
   methods: [POST]
   defaults:
@@ -146,6 +163,24 @@ format_strawberryfield.process_webannotations:
       resource_type:
         type: 'ado'
   requirements:
+    _format: 'json'
+    _entity_access: 'node.update'
+    _permission: 'add strawberryfield webannotation'
+
+# Persist in a SBF any generated Webannotations.
+format_strawberryfield.get_webannotations:
+  path: '/do/{node}/crud/webannon/{target}'
+  methods: [GET]
+  defaults:
+    _controller: '\Drupal\format_strawberryfield\Controller\WebAnnotationController::persist'
+  options:
+    parameters:
+      node:
+        type: 'entity:node'
+      resource_type:
+        type: 'ado'
+  requirements:
+    target: .+
     _format: 'json'
     _entity_access: 'node.update'
     _permission: 'add strawberryfield webannotation'

--- a/format_strawberryfield.services.yml
+++ b/format_strawberryfield.services.yml
@@ -3,3 +3,8 @@ services:
     class: Drupal\format_strawberryfield\TwigExtension
     tags:
       - {name: twig.extension}
+  format_strawberryfield.deletetmpstorage_subscriber:
+    class: Drupal\format_strawberryfield\EventSubscriber\formatStrawberryfieldDeleteTmpStorage
+    tags:
+      - {name: event_subscriber}
+    arguments: ['@string_translation', '@messenger', '@logger.factory', '@tempstore.private']

--- a/format_strawberryfield.services.yml
+++ b/format_strawberryfield.services.yml
@@ -1,0 +1,5 @@
+services:
+  format_strawberryfield.twig.TwigExtension:
+    class: Drupal\format_strawberryfield\TwigExtension
+    tags:
+      - {name: twig.extension}

--- a/js/iiif-iabookreader_strawberry.js
+++ b/js/iiif-iabookreader_strawberry.js
@@ -25,7 +25,7 @@
                             iiifmanifest: drupalSettings.format_strawberryfield.iabookreader[element_id]['manifest'],
                             iiifdefaultsequence: null, //If null given will use the first sequence found.
                             maxWidth: 800,
-                            imagesBaseURL: 'https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.2.0/BookReader/images/',
+                            imagesBaseURL: 'https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.15.0/BookReader/images/',
                         };
                         console.log('initializing IABookreader')
                         var br = new BookReader(options);

--- a/js/iiif-openseadragon_strawberry.js
+++ b/js/iiif-openseadragon_strawberry.js
@@ -54,7 +54,7 @@
                     preserveViewport: true,
                     id: element_id,
                     sequenceMode: sequence,
-                    prefixUrl: "https://cdn.jsdelivr.net/npm/openseadragon@2.4/build/openseadragon/images/",
+                    prefixUrl: "https://cdn.jsdelivr.net/npm/openseadragon@2.4.2/build/openseadragon/images/",
                     tileSources: tiles,
                     showNavigator: true,
                     navigatorAutoFade:  true,

--- a/js/iiif-openseadragon_strawberry.js
+++ b/js/iiif-openseadragon_strawberry.js
@@ -10,6 +10,7 @@
             var groupssettings = {};
             var groupsid =  {};
             var showthumbs = false
+            var nodeuuid = null;
             $('.strawberry-media-item[data-iiif-infojson]').once('attache_osd')
                 .each(function (index, value) {
 
@@ -29,7 +30,8 @@
                         groupssettings[group] = {
                             "default_width": default_width,
                             "default_height": default_height,
-                            "webannotations" : false
+                            "webannotations" : false,
+                            "nodeuuid" : settings.format_strawberryfield.openseadragon.innode[element_id]
                         }
 
                         if (typeof annotations != "undefined" && annotations == true) {
@@ -49,7 +51,7 @@
                         $(this).height(0);
                         $(this).width(0);
                     }
-                    var nodeuuid = settings.format_strawberryfield.openseadragon.innode[element_id];
+
                 });
 
             $.each(groupsid, function (group, element_id)  {
@@ -92,11 +94,23 @@
                     annotorious[element_id] = OpenSeadragonAnnotorious(viewers[element_id], $config);
                     var $container = '<div class="format_strawberryfield_annotation_savebutton" title = "Save Annotations" style="background-color: transparent; border: none; top:-1em; margin: 0px; padding: 0px; position: relative; touch-action: none; display: inline-block;">';
                     var $savebutton = $($container + '<input type="button" value="Save Annotations" />' + '</div>');
-                    $savebutton.appendTo(  $('#'+element_id + '  div.openseadragon-container > div:nth-child(2) > div > div'));
+                    if (settings.user.uid > 0) {
+                        $savebutton.appendTo($('#' + element_id + '  div.openseadragon-container > div:nth-child(2) > div > div'));
+                    }
                     console.log(settings.user.uid);
                     // Attach handlers to listen to events
                     annotorious[element_id].on('createAnnotation', function(a) {
                         console.log(a);
+                        jQuery.ajax({
+                            url: '/do/'+ groupssettings[group].nodeuuid + '/crud/webannon',
+                            type: "POST",
+                            dataType: 'json',
+                            data: annotorious[element_id].getAnnotations(),
+                            success:  function(data){
+                                console.log('back!');
+                                console.log(data);
+                            }
+                        });
                         console.log( annotorious[element_id].getAnnotations());
                     });
                 }

--- a/js/iiif-openseadragon_strawberry.js
+++ b/js/iiif-openseadragon_strawberry.js
@@ -1,11 +1,13 @@
-(function ($, Drupal, drupalSettings) {
+(function ($, Drupal,  OpenSeadragonAnnotorious, drupalSettings) {
 
     'use strict';
 
     Drupal.behaviors.format_strawberryfield_openseadragon_initiate = {
         attach: function (context, settings) {
             var viewers = [];
+            var annotorious = [];
             var groupsinfojsons =  {};
+            var groupssettings = {};
             var groupsid =  {};
             var showthumbs = false
             $('.strawberry-media-item[data-iiif-infojson]').once('attache_osd')
@@ -15,11 +17,25 @@
                     var element_id = $(this).attr("id");
                     var default_width = drupalSettings.format_strawberryfield.openseadragon[element_id]['width'];
                     var default_height = drupalSettings.format_strawberryfield.openseadragon[element_id]['height'];
+                    var annotations = drupalSettings.format_strawberryfield.openseadragon[element_id]['webannotations'];
+                    console.log(annotations);
                     var group = $(this).data("iiif-group");
                     var infojson = $(this).data("iiif-infojson");
+
                     showthumbs = $(this).data("iiif-thumbnails");
                     if (!groupsinfojsons.hasOwnProperty(group)) {
-                        groupsinfojsons[group]= [infojson];
+                        groupsinfojsons[group] = [infojson];
+                        groupssettings[group]
+                        groupssettings[group] = {
+                            "default_width": default_width,
+                            "default_height": default_height,
+                            "webannotations" : false
+                        }
+
+                        if (typeof annotations != "undefined" && annotations == true) {
+                            groupssettings[group].webannotations = true;
+                        }
+
                         // We only need a single css id per group
                         groupsid[group] = element_id;
 
@@ -32,7 +48,6 @@
                         // hide other strawberry-media-items
                         $(this).height(0);
                         $(this).width(0);
-
                     }
                     var nodeuuid = settings.format_strawberryfield.openseadragon.innode[element_id];
                 });
@@ -63,9 +78,30 @@
                     showReferenceStrip: thumbs,
                     referenceStripScroll: 'horizontal',
                 });
+                if (typeof  groupssettings[group].webannotations != "undefined" && groupssettings[group].webannotations == true) {
+                    console.log("Attaching W3C Annotations");
+                    var $readonly = true;
+                    if (settings.user.uid != 0) {
+                        $readonly = false;
+                    }
 
+                    var $config = {
+                        "readOnly":$readonly
+                    }
+
+                    annotorious[element_id] = OpenSeadragonAnnotorious(viewers[element_id], $config);
+                    var $container = '<div class="format_strawberryfield_annotation_savebutton" title = "Save Annotations" style="background-color: transparent; border: none; top:-1em; margin: 0px; padding: 0px; position: relative; touch-action: none; display: inline-block;">';
+                    var $savebutton = $($container + '<input type="button" value="Save Annotations" />' + '</div>');
+                    $savebutton.appendTo(  $('#'+element_id + '  div.openseadragon-container > div:nth-child(2) > div > div'));
+                    console.log(settings.user.uid);
+                    // Attach handlers to listen to events
+                    annotorious[element_id].on('createAnnotation', function(a) {
+                        console.log(a);
+                        console.log( annotorious[element_id].getAnnotations());
+                    });
+                }
             });
         }
     };
 
-})(jQuery, Drupal, drupalSettings);
+})(jQuery, Drupal, OpenSeadragon.Annotorious, drupalSettings);

--- a/js/iiif-openseadragon_strawberry.js
+++ b/js/iiif-openseadragon_strawberry.js
@@ -190,6 +190,7 @@
                                 'keystoreid': groupssettings[group].keystoreid,
                             },
                             success:  function(data){
+                                console.log('Created');
                                 console.log(data);
                             }
                         });
@@ -210,6 +211,7 @@
                                 'keystoreid': groupssettings[group].keystoreid,
                             },
                             success:  function(data){
+                                console.log('Updated');
                                 console.log(data);
                             }
                         });
@@ -227,6 +229,7 @@
                                 'keystoreid': groupssettings[group].keystoreid,
                             },
                             success:  function(data){
+                                console.log('Deleted');
                                 console.log(data);
                             }
                         });

--- a/js/iiif-openseadragon_strawberry.js
+++ b/js/iiif-openseadragon_strawberry.js
@@ -18,14 +18,14 @@
                     var default_width = drupalSettings.format_strawberryfield.openseadragon[element_id]['width'];
                     var default_height = drupalSettings.format_strawberryfield.openseadragon[element_id]['height'];
                     var annotations = drupalSettings.format_strawberryfield.openseadragon[element_id]['webannotations'];
-                    console.log(annotations);
+
                     var group = $(this).data("iiif-group");
                     var infojson = $(this).data("iiif-infojson");
 
                     showthumbs = $(this).data("iiif-thumbnails");
                     if (!groupsinfojsons.hasOwnProperty(group)) {
                         groupsinfojsons[group] = [infojson];
-                        groupssettings[group]
+
                         groupssettings[group] = {
                             "default_width": default_width,
                             "default_height": default_height,

--- a/js/mirador_strawberry.js
+++ b/js/mirador_strawberry.js
@@ -43,7 +43,7 @@
                         }
                         //@TODO add an extra Manifests key with every other one so people can select the others.
                         var miradorInstance = Mirador.viewer($options);
-                        console.log('initializing Mirador 3.0.0-RC3')
+                        console.log('initializing Mirador 3.0.0-RC5')
                     }
                 })}}
 })(jQuery, Drupal, drupalSettings, window.Mirador);

--- a/js/w3cWebAnnon_strawberry.js
+++ b/js/w3cWebAnnon_strawberry.js
@@ -1,0 +1,49 @@
+(function ($, Drupal, drupalSettings, Mirador) {
+
+    'use strict';
+
+    Drupal.behaviors.format_strawberryfield_w3cwebannon_initiate = {
+        attach: function(context, settings) {
+            $('.strawberry-mirador-item[data-iiif-infojson]').once('attache_mirador')
+                .each(function (index, value) {
+                    // Get the node uuid for this element
+                    var element_id = $(this).attr("id");
+                    // Check if we got some data passed via Drupal settings.
+                    if (typeof(drupalSettings.format_strawberryfield.mirador[element_id]) != 'undefined') {
+
+                        $(this).height(drupalSettings.format_strawberryfield.mirador[element_id]['height']);
+                        if (drupalSettings.format_strawberryfield.mirador[element_id]['width'] != '100%') {
+                            $(this).width(drupalSettings.format_strawberryfield.mirador[element_id]['width']);
+                        }
+                        // Defines our basic options for Mirador IIIF.
+                        var $options = {
+                            id: element_id,
+                            windows: [{
+                                manifestId: drupalSettings.format_strawberryfield.mirador[element_id]['manifesturl'],
+                                thumbnailNavigationPosition: 'far-bottom',
+                            }]
+                        };
+                        var $firstmanifest = [drupalSettings.format_strawberryfield.mirador[element_id]['manifesturl']];
+                        var $allmanifests = $firstmanifest.concat(drupalSettings.format_strawberryfield.mirador[element_id]['manifestother']);
+                        var $secondmanifest = drupalSettings.format_strawberryfield.mirador[element_id]['manifestother'].find(x=>x!==undefined);
+
+                        if (Array.isArray($allmanifests) && $allmanifests.length && typeof($secondmanifest) != 'undefined') {
+                            var $secondwindow = new Object();
+                            $secondwindow.manifestId = $secondmanifest;
+                            $secondwindow.thumbnailNavigationPosition = 'far-bottom';
+                            $options.windows.push($secondwindow);
+                            var $manifests = new Object();
+                            $allmanifests.forEach(manifestURL => {
+                                // TODO Provider should be passed by metadata at
+                                // \Drupal\format_strawberryfield\Plugin\Field\FieldFormatter\StrawberryMiradorFormatter::viewElements
+                                // Deal with this for Beta3
+                                $manifests[manifestURL] = new Object({'provider':'See Metadata'});
+                            })
+                            $options.manifests = $manifests;
+                        }
+                        //@TODO add an extra Manifests key with every other one so people can select the others.
+                        var miradorInstance = Mirador.viewer($options);
+                        console.log('initializing WC3 Annotation service')
+                    }
+                })}}
+})(jQuery, Drupal, drupalSettings, window.Mirador);

--- a/js/w3cWebAnnon_strawberry.js
+++ b/js/w3cWebAnnon_strawberry.js
@@ -1,49 +1,13 @@
-(function ($, Drupal, drupalSettings, Mirador) {
+(function ($, Drupal, drupalSettings, Annotorious) {
 
     'use strict';
 
     Drupal.behaviors.format_strawberryfield_w3cwebannon_initiate = {
         attach: function(context, settings) {
-            $('.strawberry-mirador-item[data-iiif-infojson]').once('attache_mirador')
+            $('.strawberry-w3cannon-item[data-iiif-infojson]').once('attache_w3cannon')
                 .each(function (index, value) {
                     // Get the node uuid for this element
                     var element_id = $(this).attr("id");
                     // Check if we got some data passed via Drupal settings.
-                    if (typeof(drupalSettings.format_strawberryfield.mirador[element_id]) != 'undefined') {
-
-                        $(this).height(drupalSettings.format_strawberryfield.mirador[element_id]['height']);
-                        if (drupalSettings.format_strawberryfield.mirador[element_id]['width'] != '100%') {
-                            $(this).width(drupalSettings.format_strawberryfield.mirador[element_id]['width']);
-                        }
-                        // Defines our basic options for Mirador IIIF.
-                        var $options = {
-                            id: element_id,
-                            windows: [{
-                                manifestId: drupalSettings.format_strawberryfield.mirador[element_id]['manifesturl'],
-                                thumbnailNavigationPosition: 'far-bottom',
-                            }]
-                        };
-                        var $firstmanifest = [drupalSettings.format_strawberryfield.mirador[element_id]['manifesturl']];
-                        var $allmanifests = $firstmanifest.concat(drupalSettings.format_strawberryfield.mirador[element_id]['manifestother']);
-                        var $secondmanifest = drupalSettings.format_strawberryfield.mirador[element_id]['manifestother'].find(x=>x!==undefined);
-
-                        if (Array.isArray($allmanifests) && $allmanifests.length && typeof($secondmanifest) != 'undefined') {
-                            var $secondwindow = new Object();
-                            $secondwindow.manifestId = $secondmanifest;
-                            $secondwindow.thumbnailNavigationPosition = 'far-bottom';
-                            $options.windows.push($secondwindow);
-                            var $manifests = new Object();
-                            $allmanifests.forEach(manifestURL => {
-                                // TODO Provider should be passed by metadata at
-                                // \Drupal\format_strawberryfield\Plugin\Field\FieldFormatter\StrawberryMiradorFormatter::viewElements
-                                // Deal with this for Beta3
-                                $manifests[manifestURL] = new Object({'provider':'See Metadata'});
-                            })
-                            $options.manifests = $manifests;
-                        }
-                        //@TODO add an extra Manifests key with every other one so people can select the others.
-                        var miradorInstance = Mirador.viewer($options);
-                        console.log('initializing WC3 Annotation service')
-                    }
                 })}}
-})(jQuery, Drupal, drupalSettings, window.Mirador);
+})(jQuery, Drupal, drupalSettings, OpenSeadragon.Annotorious);

--- a/src/Controller/JsWorkerController.php
+++ b/src/Controller/JsWorkerController.php
@@ -20,9 +20,9 @@ class JsWorkerController extends ControllerBase {
    */
   public function servereplay() {
     $response = new Response(
-      'importScripts("https://cdn.jsdelivr.net/npm/replaywebpage@1.0.1/sw.js");'
+      'importScripts("https://cdn.jsdelivr.net/npm/replaywebpage@1.0.2/sw.js");'
     );
-    // Alternative https://unpkg.com/replaywebpage@1.0.0/sw.js
+    // Alternative https://unpkg.com/replaywebpage@1.0.2/sw.js
     $response->headers->set('Content-Type', 'text/javascript');
     return $response;
   }

--- a/src/Controller/WebAnnotationController.php
+++ b/src/Controller/WebAnnotationController.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Drupal\format_strawberryfield\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\format_strawberryfield\Entity\MetadataExposeConfigEntity;
+use Drupal\strawberryfield\StrawberryfieldUtilityService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class WebAnnotationController extends ControllerBase {
+
+  /**
+   * Symfony\Component\HttpFoundation\RequestStack definition.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * The Strawberry Field Utility Service.
+   *
+   * @var \Drupal\strawberryfield\StrawberryfieldUtilityService
+   */
+  protected $strawberryfieldUtility;
+
+
+  /**
+   * The Drupal Renderer.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected $renderer;
+
+  /**
+   * The MIME type guesser.
+   *
+   * @var \Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface
+   */
+  protected $mimeTypeGuesser;
+
+  /**
+   * MetadataExposeDisplayController constructor.
+   *
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The Symfony Request Stack.
+   * @param \Drupal\strawberryfield\StrawberryfieldUtilityService $strawberryfield_utility_service
+   *   The SBF Utility Service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entitytype_manager
+   *   The Entity Type Manager.
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The Drupal Renderer Service.
+   * @param \Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface $mime_type_guesser
+   *   The Drupal Mime type guesser Service.
+   */
+  public function __construct(
+    RequestStack $request_stack,
+    StrawberryfieldUtilityService $strawberryfield_utility_service,
+    EntityTypeManagerInterface $entitytype_manager,
+    RendererInterface $renderer,
+    MimeTypeGuesserInterface $mime_type_guesser
+  ) {
+    $this->requestStack = $request_stack;
+    $this->strawberryfieldUtility = $strawberryfield_utility_service;
+    $this->entityTypeManager = $entitytype_manager;
+    $this->renderer = $renderer;
+    $this->mimeTypeGuesser = $mime_type_guesser;
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('request_stack'),
+      $container->get('strawberryfield.utility'),
+      $container->get('entity_type.manager'),
+      $container->get('renderer'),
+      $container->get('file.mime_type.guesser')
+    );
+  }
+
+  /**
+   * Main Controller Method.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $node
+   *   A Node as argument.
+   * @param \Drupal\format_strawberryfield\Entity\MetadataExposeConfigEntity $metadataexposeconfig_entity
+   *   The Metadata Exposed Config Entity that carries the settings.
+   * @param string $format
+   *   A possible Filename used in the last part of the Route.
+   *
+   * @return \Drupal\Core\Cache\CacheableJsonResponse|\Drupal\Core\Cache\CacheableResponse
+   *   A cacheable response.
+   */
+  public function persist(Request $request,
+    ContentEntityInterface $node
+  ) {
+    $annotations = $this->requestStack->getCurrentRequest()->request->get('data');
+    error_log(var_export($annotations, true));
+    $data = [
+      'success' => true
+    ];
+    return new JsonResponse($data);
+  }
+}

--- a/src/Controller/WebAnnotationController.php
+++ b/src/Controller/WebAnnotationController.php
@@ -6,13 +6,16 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Render\RendererInterface;
-use Drupal\format_strawberryfield\Entity\MetadataExposeConfigEntity;
+use Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem;
 use Drupal\strawberryfield\StrawberryfieldUtilityService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
 
 class WebAnnotationController extends ControllerBase {
 
@@ -58,19 +61,24 @@ class WebAnnotationController extends ControllerBase {
    *   The Drupal Renderer Service.
    * @param \Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface $mime_type_guesser
    *   The Drupal Mime type guesser Service.
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
+   *   The tempstore factory.
    */
   public function __construct(
     RequestStack $request_stack,
     StrawberryfieldUtilityService $strawberryfield_utility_service,
     EntityTypeManagerInterface $entitytype_manager,
     RendererInterface $renderer,
-    MimeTypeGuesserInterface $mime_type_guesser
+    MimeTypeGuesserInterface $mime_type_guesser,
+    PrivateTempStoreFactory $temp_store_factory
+
   ) {
     $this->requestStack = $request_stack;
     $this->strawberryfieldUtility = $strawberryfield_utility_service;
     $this->entityTypeManager = $entitytype_manager;
     $this->renderer = $renderer;
     $this->mimeTypeGuesser = $mime_type_guesser;
+    $this->tempStore = $temp_store_factory->get('webannotation');
 
   }
 
@@ -83,7 +91,8 @@ class WebAnnotationController extends ControllerBase {
       $container->get('strawberryfield.utility'),
       $container->get('entity_type.manager'),
       $container->get('renderer'),
-      $container->get('file.mime_type.guesser')
+      $container->get('file.mime_type.guesser'),
+      $container->get('tempstore.private')
     );
   }
 
@@ -103,11 +112,107 @@ class WebAnnotationController extends ControllerBase {
   public function persist(Request $request,
     ContentEntityInterface $node
   ) {
-    $annotations = $this->requestStack->getCurrentRequest()->request->get('data');
-    error_log(var_export($annotations, true));
-    $data = [
-      'success' => true
-    ];
+    if ($sbf_fields = $this->strawberryfieldUtility->bearsStrawberryfield(
+      $node
+    )) {
+      foreach ($sbf_fields as $field_name) {
+        // by default only persist in the primary SBF
+        // @TODO make which SBF will carry the load configurable?
+        // Also. This is setting the whole list everytime
+        // Should we deal with add/remove/update/edit independently?
+        // This means more server logic
+        // but less traffic?
+        /* @var $field StrawberryFieldItem */
+        $field = $node->get($field_name);
+        $annotations = $this->requestStack->getCurrentRequest()->request->get('data');
+        $target = $this->requestStack->getCurrentRequest()->request->get('target_resource');
+        error_log($target);
+        error_log(var_export($annotations, true));
+        $data = [
+          'success' => true
+        ];
+
+        try {
+          $existingannotations = $this->tempStore->get($node->uuid());
+          $existingannotations = is_array($existingannotations) ? $existingannotations : [];
+          $existingannotations[$target] = $annotations;
+          $this->tempStore->set($node->uuid(), $existingannotations);
+        }
+        catch (\Drupal\Core\TempStore\TempStoreException $exception) {
+          $data = [
+            'success' => false
+          ];
+        }
+        break;
+      }
+
+    }
+    else {
+      throw new BadRequestHttpException(
+        "This Content can not bear Web Annotations!"
+      );
+    }
+
+    return new JsonResponse($data);
+  }
+
+  /**
+   * Persist temp Controller Method.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $node
+   *   A Node as argument.
+   * @param \Drupal\format_strawberryfield\Entity\MetadataExposeConfigEntity $metadataexposeconfig_entity
+   *   The Metadata Exposed Config Entity that carries the settings.
+   * @param string $format
+   *   A possible Filename used in the last part of the Route.
+   *
+   * @return \Drupal\Core\Cache\CacheableJsonResponse|\Drupal\Core\Cache\CacheableResponse
+   *   A cacheable response.
+   */
+  public function persistTemp(Request $request,
+    ContentEntityInterface $node
+  ) {
+    if ($sbf_fields = $this->strawberryfieldUtility->bearsStrawberryfield(
+      $node
+    )) {
+      foreach ($sbf_fields as $field_name) {
+        // by default only persist in the primary SBF
+        // @TODO make which SBF will carry the load configurable?
+        // Also. This is setting the whole list everytime
+        // Should we deal with add/remove/update/edit independently?
+        // This means more server logic
+        // but less traffic?
+        /* @var $field StrawberryFieldItem */
+        $field = $node->get($field_name);
+        $annotations = $this->requestStack->getCurrentRequest()->request->get('data');
+        $target = $this->requestStack->getCurrentRequest()->request->get('target_resource');
+        error_log($target);
+        error_log(var_export($annotations, true));
+        $data = [
+          'success' => true
+        ];
+
+        try {
+          $existingannotations = $this->tempStore->get($node->uuid());
+          $existingannotations = is_array($existingannotations) ? $existingannotations : [];
+          $existingannotations[$target] = $annotations;
+          $this->tempStore->set($node->uuid(), $existingannotations);
+        }
+        catch (\Drupal\Core\TempStore\TempStoreException $exception) {
+          $data = [
+            'success' => false
+          ];
+        }
+        break;
+      }
+
+    }
+    else {
+      throw new BadRequestHttpException(
+        "This Content can not bear Web Annotations!"
+      );
+    }
+
     return new JsonResponse($data);
   }
 }

--- a/src/Controller/WebAnnotationController.php
+++ b/src/Controller/WebAnnotationController.php
@@ -13,8 +13,9 @@ use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 
 class WebAnnotationController extends ControllerBase {
@@ -97,14 +98,12 @@ class WebAnnotationController extends ControllerBase {
   }
 
   /**
-   * Main Controller Method.
+   * Persist in temp Storage Webannotation Controller (POST).
    *
+   * @param \Symfony\Component\HttpFoundation\Request
+   *   The Full HTTPD Resquest
    * @param \Drupal\Core\Entity\ContentEntityInterface $node
-   *   A Node as argument.
-   * @param \Drupal\format_strawberryfield\Entity\MetadataExposeConfigEntity $metadataexposeconfig_entity
-   *   The Metadata Exposed Config Entity that carries the settings.
-   * @param string $format
-   *   A possible Filename used in the last part of the Route.
+   *   A Node as argument
    *
    * @return \Drupal\Core\Cache\CacheableJsonResponse|\Drupal\Core\Cache\CacheableResponse
    *   A cacheable response.
@@ -126,17 +125,15 @@ class WebAnnotationController extends ControllerBase {
         $field = $node->get($field_name);
         $annotations = $this->requestStack->getCurrentRequest()->request->get('data');
         $target = $this->requestStack->getCurrentRequest()->request->get('target_resource');
-        error_log($target);
-        error_log(var_export($annotations, true));
+        $keystoreid = $this->requestStack->getCurrentRequest()->request->get('keystoreid');
         $data = [
           'success' => true
         ];
-
         try {
-          $existingannotations = $this->tempStore->get($node->uuid());
+          $existingannotations = $this->tempStore->get($keystoreid);
           $existingannotations = is_array($existingannotations) ? $existingannotations : [];
           $existingannotations[$target] = $annotations;
-          $this->tempStore->set($node->uuid(), $existingannotations);
+          $this->tempStore->set($keystoreid, $existingannotations);
         }
         catch (\Drupal\Core\TempStore\TempStoreException $exception) {
           $data = [
@@ -145,7 +142,6 @@ class WebAnnotationController extends ControllerBase {
         }
         break;
       }
-
     }
     else {
       throw new BadRequestHttpException(
@@ -157,55 +153,70 @@ class WebAnnotationController extends ControllerBase {
   }
 
   /**
-   * Persist temp Controller Method.
+   * Updates an existing WebAnnotation Method (PUSH).
    *
+   * @param \Symfony\Component\HttpFoundation\Request
+   *   The Full HTTPD Resquest
    * @param \Drupal\Core\Entity\ContentEntityInterface $node
-   *   A Node as argument.
-   * @param \Drupal\format_strawberryfield\Entity\MetadataExposeConfigEntity $metadataexposeconfig_entity
-   *   The Metadata Exposed Config Entity that carries the settings.
-   * @param string $format
-   *   A possible Filename used in the last part of the Route.
+   *   A Node as argument
    *
    * @return \Drupal\Core\Cache\CacheableJsonResponse|\Drupal\Core\Cache\CacheableResponse
    *   A cacheable response.
    */
-  public function persistTemp(Request $request,
+  public function putTemp(Request $request,
     ContentEntityInterface $node
   ) {
     if ($sbf_fields = $this->strawberryfieldUtility->bearsStrawberryfield(
       $node
     )) {
-      foreach ($sbf_fields as $field_name) {
-        // by default only persist in the primary SBF
-        // @TODO make which SBF will carry the load configurable?
-        // Also. This is setting the whole list everytime
-        // Should we deal with add/remove/update/edit independently?
-        // This means more server logic
-        // but less traffic?
-        /* @var $field StrawberryFieldItem */
-        $field = $node->get($field_name);
-        $annotations = $this->requestStack->getCurrentRequest()->request->get('data');
-        $target = $this->requestStack->getCurrentRequest()->request->get('target_resource');
-        error_log($target);
-        error_log(var_export($annotations, true));
-        $data = [
-          'success' => true
-        ];
 
-        try {
-          $existingannotations = $this->tempStore->get($node->uuid());
+      // We are getting which field originate the annotations from AJAX.
+      $annotation = $this->requestStack->getCurrentRequest()->request->get('data');
+      $target = $this->requestStack->getCurrentRequest()->request->get('target_resource');
+      $keystoreid = $this->requestStack->getCurrentRequest()->request->get('keystoreid');
+      $data = [
+        'success' => true
+      ];
+
+      try {
+        $persisted = FALSE;
+        if (isset($annotation['id'])) {
+          $existingannotations = $this->tempStore->get($keystoreid);
           $existingannotations = is_array($existingannotations) ? $existingannotations : [];
-          $existingannotations[$target] = $annotations;
-          $this->tempStore->set($node->uuid(), $existingannotations);
+          if (isset($existingannotations[$target])) {
+            foreach ($existingannotations[$target] as $key => $existingannotation) {
+              if (($existingannotation['id'] == $annotation['id'])) {
+                error_log('found!');
+                error_log(var_export($existingannotation,true));
+                error_log('to be replace with!');
+                error_log(var_export($annotation,true));
+                $existingannotations[$target][$key] = $annotation;
+                $persisted = TRUE;
+                break;
+              }
+            }
+            if ($persisted == FALSE) {
+              throw new MethodNotAllowedHttpException(
+                "The Annotation has no unique id!"
+              );
+            } // means it was new
+          }
+          error_log('putting into '.$keystoreid);
+          error_log('for into '.$target);
+          error_log(var_export($existingannotations,true));
+          $this->tempStore->set($keystoreid, $existingannotations);
         }
-        catch (\Drupal\Core\TempStore\TempStoreException $exception) {
-          $data = [
-            'success' => false
-          ];
+        else {
+          throw new BadRequestHttpException(
+            "The Annotation has no unique id!"
+          );
         }
-        break;
       }
-
+      catch (\Drupal\Core\TempStore\TempStoreException $exception) {
+        $data = [
+          'success' => false
+        ];
+      }
     }
     else {
       throw new BadRequestHttpException(
@@ -214,5 +225,206 @@ class WebAnnotationController extends ControllerBase {
     }
 
     return new JsonResponse($data);
+  }
+
+
+
+  /**
+   * Persist temp Controller Method (POST).
+   *
+   * @param \Symfony\Component\HttpFoundation\Request
+   *   The Full HTTPD Resquest
+   * @param \Drupal\Core\Entity\ContentEntityInterface $node
+   *   A Node as argument
+   *
+   * @return \Drupal\Core\Cache\CacheableJsonResponse|\Drupal\Core\Cache\CacheableResponse
+   *   A cacheable response.
+   */
+  public function postTemp(Request $request,
+    ContentEntityInterface $node
+  ) {
+    if ($sbf_fields = $this->strawberryfieldUtility->bearsStrawberryfield(
+      $node
+    )) {
+
+        // We are getting which field originate the annotations from AJAX.
+        $annotation = $this->requestStack->getCurrentRequest()->request->get('data');
+        $target = $this->requestStack->getCurrentRequest()->request->get('target_resource');
+        $keystoreid = $this->requestStack->getCurrentRequest()->request->get('keystoreid');
+
+        $data = [
+          'success' => true
+        ];
+
+        try {
+          $persisted = FALSE;
+          if (isset($annotation['id'])) {
+          $existingannotations = $this->tempStore->get($keystoreid);
+          $existingannotations = is_array($existingannotations) ? $existingannotations : [];
+          if (isset($existingannotations[$target])) {
+            foreach ($existingannotations[$target] as $key => &$existingannotation) {
+              if (($existingannotation['id'] == $annotation['id'])) {
+                throw new MethodNotAllowedHttpException(
+                  "The ID is already present, to update use PUT method"
+                );
+              }
+            }
+          }
+          error_log('adding new into'.$keystoreid);
+          error_log('for into '.$target);
+          error_log(var_export($annotation, true));
+          $existingannotations[$target][] = $annotation;
+          $this->tempStore->set($keystoreid, $existingannotations);
+          }
+          else {
+            throw new BadRequestHttpException(
+              "The Annotation has no unique id!"
+            );
+          }
+        }
+        catch (\Drupal\Core\TempStore\TempStoreException $exception) {
+          $data = [
+            'success' => false
+          ];
+        }
+    }
+    else {
+      throw new BadRequestHttpException(
+        "This Content can not bear Web Annotations!"
+      );
+    }
+
+    return new JsonResponse($data);
+  }
+
+  /**
+   * Persist temp Controller Method (POST).
+   *
+   * @param \Symfony\Component\HttpFoundation\Request
+   *   The Full HTTPD Resquest
+   * @param \Drupal\Core\Entity\ContentEntityInterface $node
+   *   A Node as argument
+   *
+   * @return \Drupal\Core\Cache\CacheableJsonResponse|\Drupal\Core\Cache\CacheableResponse
+   *   A cacheable response.
+   */
+  public function deleteTemp(Request $request,
+    ContentEntityInterface $node
+  ) {
+    if ($sbf_fields = $this->strawberryfieldUtility->bearsStrawberryfield(
+      $node
+    )) {
+
+      // We are getting which field originate the annotations from AJAX.
+
+      $annotation = $this->requestStack->getCurrentRequest()->request->get('data');
+      $target = $this->requestStack->getCurrentRequest()->request->get('target_resource');
+      $keystoreid = $this->requestStack->getCurrentRequest()->request->get('keystoreid');
+
+      $data = [
+        'success' => true
+      ];
+
+      try {
+        if (isset($annotation['id'])) {
+          $existingannotations = $this->tempStore->get($keystoreid);
+          $existingannotations = is_array($existingannotations) ? $existingannotations : [];
+          if (isset($existingannotations[$target])) {
+            foreach ($existingannotations[$target] as $key => &$existingannotation) {
+              if (($existingannotation['id'] == $annotation['id'])) {
+                unset($existingannotation[$key]);
+                break;
+              }
+            }
+          }
+          $this->tempStore->set($keystoreid, $existingannotations);
+        }
+        else {
+          throw new BadRequestHttpException(
+            "The Annotation has no unique id!"
+          );
+        }
+      }
+      catch (\Drupal\Core\TempStore\TempStoreException $exception) {
+        $data = [
+          'success' => false
+        ];
+      }
+    }
+    else {
+      throw new BadRequestHttpException(
+        "This Content can not bear Web Annotations!"
+      );
+    }
+
+    return new JsonResponse($data);
+  }
+
+  /**
+   * Read existing WebAnnotations Controller Method (GET).
+   *
+   * @param \Symfony\Component\HttpFoundation\Request
+   *   The Full HTTPD Resquest
+   * @param \Drupal\Core\Entity\ContentEntityInterface $node
+   *   A Node as argument
+   *
+   * @return \Drupal\Core\Cache\CacheableJsonResponse|\Drupal\Core\Cache\CacheableResponse
+   *   A cacheable response.
+   */
+  public function read(Request $request,
+    ContentEntityInterface $node
+  ) {
+    $return = [];
+    // GET Argument (
+    $target = $this->requestStack->getCurrentRequest()->query->get('target_resource');
+
+    if (($sbf_fields = $this->strawberryfieldUtility->bearsStrawberryfield(
+      $node
+    )) && !empty(trim($target))) {
+
+      // We are getting which field originate the annotations from AJAX.
+      // This time Ajax
+      $keystoreid = $this->requestStack->getCurrentRequest()->query->get('keystoreid');
+
+      $data = [
+        'success' => true
+      ];
+
+      try {
+        // See \Drupal\format_strawberryfield\Plugin\Field\FieldFormatter\StrawberryMediaFormatter::viewElements
+        // It would have set initial values so we do not need to read/iterate everytime
+        $existingannotations = $this->tempStore->get($keystoreid);
+        $return = isset($existingannotations[$target]) && is_array($existingannotations[$target]) ? $existingannotations[$target] : [];
+      }
+      catch (\Drupal\Core\TempStore\TempStoreException $exception) {
+        throw new ServiceUnavailableHttpException(
+          "Temporary Storage for WebAnnotations is not working. Contact your admin."
+        );
+      }
+    }
+    else {
+      throw new BadRequestHttpException(
+        "Wrong request"
+      );
+    }
+
+    return new JsonResponse($return);
+  }
+  /**
+   * Gives us a key name used by the webforms and widgets.
+   *
+   * @param $fieldname
+   * @param int $delta
+   * @param string $entity_uuid
+   *
+   * @return string
+   */
+  public static function getTempStoreKeyName($fieldname, $delta = 0, $entity_uuid = '0') {
+    $unique_seed = array_merge(
+      [$fieldname],
+      [$delta],
+      [$entity_uuid]
+    );
+    return sha1(implode('-', $unique_seed));
   }
 }

--- a/src/Controller/WebAnnotationController.php
+++ b/src/Controller/WebAnnotationController.php
@@ -517,8 +517,8 @@ class WebAnnotationController extends ControllerBase {
             );
             try {
               $tempstore->delete($keystoreid);
-              // Sets stored settings back.
-              static::primeKeyStore($itemfield, $keystoreid);
+              // Do NOT SET stored settings back.
+              // BECAUSE WE HAVE NOT RELOADED OUR NODE from storage yet OK?
             } catch (\Drupal\Core\TempStore\TempStoreException $exception) {
               $response->addCommand(
                 new ReplaceCommand(
@@ -534,7 +534,7 @@ class WebAnnotationController extends ControllerBase {
       else {
         return $response;
       }
-      // Needed so aLl is restored from storage
+      // Needed so all is restored from storage
       $node = node::load($node->id());
 
       $response->addCommand(new RemoveCommand('#edit-annotations'));

--- a/src/Entity/MetadataDisplayEntity.php
+++ b/src/Entity/MetadataDisplayEntity.php
@@ -271,7 +271,7 @@ class MetadataDisplayEntity extends ContentEntityBase implements MetadataDisplay
       ->setDisplayConfigurable('view', TRUE)
       ->setRequired(TRUE)
       ->addConstraint('NotBlank')
-      ->addConstraint('TwigTemplateConstraint', ['useTwigMessage' => FALSE]);
+      ->addConstraint('TwigTemplateConstraint', ['useTwigMessage' => FALSE, 'TwigTemplateLogicalName' => 'MetadataDisplayEntity']);
 
     // Owner field of the Metadata Display Entity.
     // Entity reference field, holds the reference to the user object.

--- a/src/EventSubscriber/formatStrawberryfieldDeleteTmpStorage.php
+++ b/src/EventSubscriber/formatStrawberryfieldDeleteTmpStorage.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Drupal\format_strawberryfield\EventSubscriber;
+
+use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+
+/**
+ * Event subscriber that deletes format temp storage for SBF bearing entities.
+ *
+ * The actual deletion only happens after persistance of a Node.
+ *
+ */
+class formatStrawberryfieldDeleteTmpStorage implements EventSubscriberInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * @var int
+   */
+  protected static $priority = -700;
+
+  /**
+   * The messenger.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * The serializer.
+   * @var \Symfony\Component\Serializer\SerializerInterface;
+   */
+  protected $serializer;
+
+  /**
+   * Stores the tempstore factory.
+   *
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
+   */
+  protected $tempStoreFactory;
+
+  /**
+   * StrawberryfieldEventInsertSubscriberDepositDO constructor.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
+   */
+  public function __construct(
+    TranslationInterface $string_translation,
+    MessengerInterface $messenger,
+    LoggerChannelFactoryInterface $logger_factory,
+    PrivateTempStoreFactory $temp_store_factory
+  ) {
+    $this->stringTranslation = $string_translation;
+    $this->messenger = $messenger;
+    $this->loggerFactory = $logger_factory;
+    $this->tempStoreFactory = $temp_store_factory;
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+
+    // @TODO check event priority and adapt to future D9 needs.
+    $events[StrawberryfieldEventType::SAVE][] = ['onEntitySave', static::$priority];
+    return $events;
+  }
+
+
+  /**
+   * Method called when Save/Update Event occurs.
+   *
+   * @param \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent $event
+   *
+   * @throws \Drupal\Core\TempStore\TempStoreException
+   */
+  public function onEntitySave(StrawberryfieldCrudEvent $event) {
+     /* @var $entity \Drupal\Core\Entity\ContentEntityInterface */
+
+    // Means an existing Entity
+    // Our storage key will be less generic, using the actual uuid.
+
+    $current_class = get_called_class();
+    $entity = $event->getEntity();
+    $sbf_fields = $event->getFields();
+
+    /* @var $tempstore \Drupal\Core\TempStore\PrivateTempStore */
+
+    $tempstore = $this->tempStoreFactory->get('webannotation');
+    error_log($entity->uuid());
+    foreach ($sbf_fields as $field_name) {
+      /* @var $field \Drupal\Core\Field\FieldItemInterface */
+      $field = $entity->get($field_name);
+      /* @var \Drupal\strawberryfield\Field\StrawberryFieldItemList $field */
+
+      $fieldname = $field->getName();
+      foreach ($field->getIterator() as $delta => $itemfield) {
+        $keyid = $this->getTempStoreKeyName($fieldname, $delta, $entity->uuid());
+
+        $tempstore->delete($keyid);
+      }
+    }
+    $allmessages = $this->messenger->messagesByType(\Drupal\Core\Messenger\MessengerInterface::TYPE_STATUS);
+    $this->messenger->deleteByType(\Drupal\Core\Messenger\MessengerInterface::TYPE_STATUS);
+    // I can not imagine a more stupid way of avoiding double message
+    // but also can find a smarter
+    //@TODO make the message a constant
+    foreach($allmessages as $message) {
+      if ($message->__toString() != 'You have unsaved Annotation for this Digital Object. To persist them Save the Object.') {
+        $this->messenger->addStatus($message);
+      }
+    }
+    $event->setProcessedBy($current_class, true);
+  }
+
+  /**
+   * Gives us a key name used by the webforms and widgets.
+   *
+   * @param $fieldname
+   * @param int $delta
+   * @param string $entity_uuid
+   *
+   * @return string
+   */
+  public function getTempStoreKeyName($fieldname, $delta = 0, $entity_uuid = '0') {
+    $unique_seed = array_merge(
+      [$fieldname],
+      [$delta],
+      [$entity_uuid]
+    );
+    return sha1(implode('-', $unique_seed));
+  }
+
+}

--- a/src/EventSubscriber/formatStrawberryfieldDeleteTmpStorage.php
+++ b/src/EventSubscriber/formatStrawberryfieldDeleteTmpStorage.php
@@ -98,7 +98,7 @@ class formatStrawberryfieldDeleteTmpStorage implements EventSubscriberInterface 
     /* @var $tempstore \Drupal\Core\TempStore\PrivateTempStore */
 
     $tempstore = $this->tempStoreFactory->get('webannotation');
-    error_log($entity->uuid());
+
     foreach ($sbf_fields as $field_name) {
       /* @var $field \Drupal\Core\Field\FieldItemInterface */
       $field = $entity->get($field_name);
@@ -107,20 +107,14 @@ class formatStrawberryfieldDeleteTmpStorage implements EventSubscriberInterface 
       $fieldname = $field->getName();
       foreach ($field->getIterator() as $delta => $itemfield) {
         $keyid = $this->getTempStoreKeyName($fieldname, $delta, $entity->uuid());
-
+        // We do not say "saved" here because some clever person could change,
+        // enrich, add, reprocesses or even clean annotations during ingest.
+        // So not really that just passed along
+        $this->messenger->addStatus('Your Annotations were processed');
         $tempstore->delete($keyid);
       }
     }
-    $allmessages = $this->messenger->messagesByType(\Drupal\Core\Messenger\MessengerInterface::TYPE_STATUS);
-    $this->messenger->deleteByType(\Drupal\Core\Messenger\MessengerInterface::TYPE_STATUS);
-    // I can not imagine a more stupid way of avoiding double message
-    // but also can find a smarter
-    //@TODO make the message a constant
-    foreach($allmessages as $message) {
-      if ($message->__toString() != 'You have unsaved Annotation for this Digital Object. To persist them Save the Object.') {
-        $this->messenger->addStatus($message);
-      }
-    }
+
     $event->setProcessedBy($current_class, true);
   }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryBaseFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryBaseFormatter.php
@@ -8,6 +8,7 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\format_strawberryfield\Tools\IiifUrlValidator;
 use Drupal\Core\Access\AccessResult;
@@ -23,6 +24,12 @@ abstract class StrawberryBaseFormatter extends FormatterBase implements Containe
    * @var \Drupal\Core\Config\ConfigFactoryInterface
    */
   protected $iiifConfig;
+  /**
+   * The Current User
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+
+  protected $currentUser;
 
   /**
    * StrawberryBaseFormatter Constructor.
@@ -44,6 +51,7 @@ abstract class StrawberryBaseFormatter extends FormatterBase implements Containe
    *   The definition of the field to which the formatter is associated.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The ConfigFactory Container Interface.
+   * @param \Drupal\Core\Session\AccountProxyInterface|null $current_user
    */
   public function __construct(
     $plugin_id,
@@ -53,7 +61,8 @@ abstract class StrawberryBaseFormatter extends FormatterBase implements Containe
     $label,
     string $view_mode,
     array $third_party_settings,
-    ConfigFactoryInterface $config_factory
+    ConfigFactoryInterface $config_factory,
+    AccountProxyInterface $current_user = NULL
   ) {
     parent::__construct(
       $plugin_id,
@@ -65,6 +74,7 @@ abstract class StrawberryBaseFormatter extends FormatterBase implements Containe
       $third_party_settings
     );
     $this->iiifConfig = $config_factory->get('format_strawberryfield.iiif_settings');
+    $this->currentUser = $current_user;
   }
 
   /**
@@ -79,7 +89,8 @@ abstract class StrawberryBaseFormatter extends FormatterBase implements Containe
       $configuration['label'],
       $configuration['view_mode'],
       $configuration['third_party_settings'],
-      $container->get('config.factory')
+      $container->get('config.factory'),
+      $container->get('current_user')
     );
   }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -47,6 +47,7 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
       'quality' => 'default',
       'rotation' => '0',
       'image_link' =>  TRUE,
+      'webannotations' => FALSE,
     ];
   }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -254,6 +254,7 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
                 $elements[$delta]['media'.$i]['#attributes']['data-iiif-infojson'] = $iiifpublicinfojson;
                 $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon']['innode'][$uniqueid] = $nodeuuid;
                 $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['width'] = $max_width_css;
+                $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['dr:uuid']  = $file->uuid();
                 $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['webannotations'] = (boolean)$webannotations;
                 $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['height'] = max(
                   $max_height,

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -258,6 +258,7 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
                 $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['width'] = $max_width_css;
                 $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['dr:uuid']  = $file->uuid();
                 // Used to keep annotations around during edit.
+                // Note: Since View modes are cached, if no change to the NODE this will be served from a cache! mmm.
                 $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['keystoreid'] = WebAnnotationController::getTempStoreKeyName($fieldname,$delta, $nodeuuid);
                 $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['webannotations'] = (boolean)$webannotations;
                 if ($this->currentUser) {
@@ -269,16 +270,11 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
                 }
 
                 // We only set this if/and only if/ we have annotations loaded
+                // This also never runs if cached. So after deletion we better call the controller!
+
                 if (($webannotations) && !empty($jsondata['ap:annotationCollection']) && is_array($jsondata['ap:annotationCollection'])) {
                   $keystoreid = $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['keystoreid'];
-                  $tempstore = \Drupal::service('tempstore.private')->get('webannotation');
-                  // First check if there is something there already? (many reloads, we want to live version)
-                  if (empty($tempstore->get($keystoreid))) {
-                    $tempstore->set(
-                      $keystoreid,
-                      $jsondata['ap:annotationCollection']
-                    );
-                  }
+                  WebAnnotationController::primeKeyStore($items[$delta]);
                 }
                 $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['height'] = max(
                   $max_height,

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -39,6 +39,7 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
       'json_key_source' => 'as:image',
       'max_width' => 720,
       'max_height' => 480,
+      'webannotations' => FALSE,
       'thumbnails' => TRUE,
     ];
   }
@@ -48,44 +49,50 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
   public function settingsForm(array $form, FormStateInterface $form_state) {
     //@TODO document that 2 base urls are just needed when developing (localhost syndrom)
     return [
-      'iiif_group' => [
-        '#type' => 'checkbox',
-        '#title' => t('Group all Media files in a single viewer?'),
-        '#default_value' => $this->getSetting('iiif_group'),
-      ],
-      'thumbnails' => [
-        '#type' => 'checkbox',
-        '#title' => t('Show a thumbnail reference bar.'),
-        '#default_value' => $this->getSetting('thumbnails'),
-      ],
-      'json_key_source' => [
-        '#type' => 'textfield',
-        '#title' => t('JSON Key from where to fetch Media URLs'),
-        '#default_value' => $this->getSetting('json_key_source'),
-        '#required' => TRUE
-      ],
-      'max_width' => [
-        '#type' => 'number',
-        '#title' => $this->t('Maximum width'),
-        '#description' => $this->t('Use 0 to force 100% width'),
-        '#default_value' => $this->getSetting('max_width'),
-        '#size' => 5,
-        '#maxlength' => 5,
-        '#field_suffix' => $this->t('pixels'),
-        '#min' => 0,
-        '#required' => TRUE
-      ],
-      'max_height' => [
-        '#type' => 'number',
-        '#title' => $this->t('Maximum height'),
-        '#default_value' => $this->getSetting('max_height'),
-        '#size' => 5,
-        '#maxlength' => 5,
-        '#field_suffix' => $this->t('pixels'),
-        '#min' => 0,
-        '#required' => TRUE
-      ],
-    ] + parent::settingsForm($form, $form_state);
+        'iiif_group' => [
+          '#type' => 'checkbox',
+          '#title' => t('Group all Media files in a single viewer?'),
+          '#default_value' => $this->getSetting('iiif_group'),
+        ],
+        'thumbnails' => [
+          '#type' => 'checkbox',
+          '#title' => t('Show a thumbnail reference bar.'),
+          '#default_value' => $this->getSetting('thumbnails'),
+        ],
+        'webannotations' => [
+          '#type' => 'checkbox',
+          '#title' => t('Enable loading/editing of W3C webAnnotations.'),
+          '#description' => t('<a href="https://www.w3.org/TR/annotation-model/#index-of-json-keys">Click here</a> To learn more about the JSON format of a Web Annotation'),
+          '#default_value' => $this->getSetting('webannotations'),
+        ],
+        'json_key_source' => [
+          '#type' => 'textfield',
+          '#title' => t('JSON Key from where to fetch Media URLs'),
+          '#default_value' => $this->getSetting('json_key_source'),
+          '#required' => TRUE
+        ],
+        'max_width' => [
+          '#type' => 'number',
+          '#title' => $this->t('Maximum width'),
+          '#description' => $this->t('Use 0 to force 100% width'),
+          '#default_value' => $this->getSetting('max_width'),
+          '#size' => 5,
+          '#maxlength' => 5,
+          '#field_suffix' => $this->t('pixels'),
+          '#min' => 0,
+          '#required' => TRUE
+        ],
+        'max_height' => [
+          '#type' => 'number',
+          '#title' => $this->t('Maximum height'),
+          '#default_value' => $this->getSetting('max_height'),
+          '#size' => 5,
+          '#maxlength' => 5,
+          '#field_suffix' => $this->t('pixels'),
+          '#min' => 0,
+          '#required' => TRUE
+        ],
+      ] + parent::settingsForm($form, $form_state);
   }
 
   /**
@@ -98,6 +105,11 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
     if ($this->getSetting('iiif_group')) {
       $summary[] = $this->t('Use a single Viewer for multiple media: %iiif_group', [
         '%iiif_group' => $this->getSetting('iiif_group'),
+      ]);
+    }
+    if ($this->getSetting('webannotations')) {
+      $summary[] = $this->t('Enable W3C WebAnnotations: %webannotations', [
+        '%webannotations' => $this->getSetting('webannotations'),
       ]);
     }
     if ($this->getSetting('thumbnails')) {
@@ -133,6 +145,7 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
     $max_height = $this->getSetting('max_height');
     $grouped = $this->getSetting('iiif_group');
     $thumbnails = $this->getSetting('thumbnails');
+    $webannotations = $this->getSetting('webannotations');
 
     /* @var \Drupal\file\FileInterface[] $files */
     // Fixing the key to extract while coding to 'Media'
@@ -241,6 +254,7 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
                 $elements[$delta]['media'.$i]['#attributes']['data-iiif-infojson'] = $iiifpublicinfojson;
                 $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon']['innode'][$uniqueid] = $nodeuuid;
                 $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['width'] = $max_width_css;
+                $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['webannotations'] = (boolean)$webannotations;
                 $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['height'] = max(
                   $max_height,
                   480

--- a/src/Plugin/Validation/Constraint/TwigTemplateConstraint.php
+++ b/src/Plugin/Validation/Constraint/TwigTemplateConstraint.php
@@ -21,4 +21,5 @@ use Symfony\Component\Validator\Constraint;
 class TwigTemplateConstraint extends Constraint{
   public $message = 'Value is not a valid Twig template.';
   public $useTwigMessage = false;
+  public $TwigTemplateLogicalName = 'MetadataDisplayEntity';
 }

--- a/src/Plugin/Validation/Constraint/TwigTemplateConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/TwigTemplateConstraintValidator.php
@@ -13,6 +13,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Template\TwigEnvironment;
+use Twig\Source;
 use Twig_Error_Syntax;
 
 
@@ -44,7 +45,8 @@ class TwigTemplateConstraintValidator extends ConstraintValidator implements Con
     $twig = $this->twig;
     $message = $constraint->message;
     try {
-      $twig->parse($twig->tokenize($value->value));
+      $source = new Source($value->value, $constraint->TwigTemplateLogicalName);
+      $twig->parse($twig->tokenize($source));
     } catch (Twig_Error_Syntax $e) {
       if ($constraint->useTwigMessage) {
         $message = $e->getMessage();

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -1,0 +1,25 @@
+<?php
+namespace Drupal\format_strawberryfield;
+use Twig\TwigTest;
+
+/**
+ * Class TwigExtension.
+ *
+ * @package Drupal\format_strawberryfield
+ */
+class TwigExtension extends \Twig_Extension {
+
+  public function getTests(): array
+  {
+    return [
+      new TwigTest('instanceof', [$this, 'is_instanceof']),
+    ];
+  }
+
+  public function is_instanceof($value, string $type): bool
+  {
+    return ('null' === $type && null === $value)
+      || (\function_exists($func = 'is_'.$type) && $func($value))
+      || $value instanceof $type;
+  }
+}


### PR DESCRIPTION
# What is new?

See #91 
- Minor JS updates including most of our delivered viewers and libraries
- Updates to references to remote Images and assets
- Added Leaflet Marker Cluster, an old friend of mine (from back at Chile times) for larger maps
- Universal Viewer Core Library soon to be complemented with the rest of the framing, our own JS and the Formatter code
- A Twig extension to check the type (class) of an object, useful if you want to call NODE or User methods on unknown classes of Objects
- A Twig deprecation See #94 
- W3C Web Annotations with "adding", removing and updating directly on the Open Seadragon Viewer !(gosh am I good! hahaha) Tested and works. This also adds some new permissions and an almost full blown CRUD/REST API for the web annotations. Even work (designed so) with multi image slides. Annotations are keyed by Image URL. Not happy? you can always discard them before saving.

 @giancarlobi ready!