### PR TITLE
ISSUE-102: large files via Ranged request delivery, replay.web 1.3.0

### DIFF
--- a/format_strawberryfield.libraries.yml
+++ b/format_strawberryfield.libraries.yml
@@ -93,6 +93,7 @@ av_strawberry:
   css:
     component:
       css/htmlaudiovideo.css: {}
+
 jsm_modeler:
   version: 0.45
   js:
@@ -164,6 +165,17 @@ mirador_strawberry:
     - format_strawberryfield/mirador_projectmirador
     - format_strawberryfield/mirador_font
 
+uv_strawberry:
+  version: 1.0
+  js:
+    js/uv_strawberry.js: {minified: false}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/jquery.once
+    - core/drupalSettings
+    - format_strawberryfield/universalviewer
+
 leaflet_markercluster:
   version: 1.4.1
   remote: https://github.com/Leaflet/Leaflet.markercluster
@@ -216,13 +228,13 @@ leaflet_strawberry:
 # Don't forget to update \Drupal\format_strawberryfield\Controller\JsWorkerController::servereplay
 # when moving versions up!
 replayweb:
-  version: 1.2.0
+  version: 1.3.0
   license:
     name: AGPLv3
     url: https://github.com/webrecorder/replayweb.page/blob/master/LICENSE
     gpl-compatible: true
   js:
-    https://cdn.jsdelivr.net/npm/replaywebpage@1.2.0/ui.js: { external: true, minified: true, preprocess: false}
+    https://cdn.jsdelivr.net/npm/replaywebpage@1.3.0/ui.js: { external: true, minified: true, preprocess: false}
 
 universalviewer:
   version: 4.0.0-pre.49
@@ -233,6 +245,7 @@ universalviewer:
   js:
     https://cdn.jsdelivr.net/npm/universalviewer@4.0.0-pre.49/dist/uv-dist-umd/UV.min.js: { external: true, minified: true, preprocess: false}
     https://unpkg.com/@edsilv/utils@1.0.2/dist-umd/utils.js: { external: true, minified: true, preprocess: false}
+    https://cdn.jsdelivr.net/npm/jsviews@1.0.8/jsviews.min.js: {external: true, minified: true, preprocess: false}
 
 annotorious:
   version: 2.1.2

--- a/format_strawberryfield.libraries.yml
+++ b/format_strawberryfield.libraries.yml
@@ -136,13 +136,13 @@ pdfs_strawberry:
     - format_strawberryfield/pdfs_mozilla
 
 mirador_projectmirador:
-  version: 3.0.0-rc.5
+  version: 3.0.0
   license:
     name: Apache
     url: //github.com/ProjectMirador/mirador/blob/master/LICENSE
     gpl-compatible: true
   js:
-    https://cdn.jsdelivr.net/npm/mirador@3.0.0-rc.5/dist/mirador.min.js: { external: true, minified: true, preprocess: false}
+    https://cdn.jsdelivr.net/npm/mirador@3.0.0/dist/mirador.min.js: { external: true, minified: true, preprocess: false}
 
 mirador_font:
   css:

--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -52,7 +52,7 @@ format_strawberryfield.metadatadisplay_settings:
 # Direct File access for SBF managed files.
 format_strawberryfield.iiifbinary:
   path: '/do/{node}/iiif/{uuid}/full/full/0/{format}'
-  methods: [GET]
+  methods: [GET,HEAD]
   defaults:
     _controller: '\Drupal\format_strawberryfield\Controller\IiifBinaryController::servefile'
   options:

--- a/js/mirador_strawberry.js
+++ b/js/mirador_strawberry.js
@@ -43,7 +43,7 @@
                         }
                         //@TODO add an extra Manifests key with every other one so people can select the others.
                         var miradorInstance = Mirador.viewer($options);
-                        console.log('initializing Mirador 3.0.0-RC5')
+                        console.log('initializing Mirador 3.0.0')
                     }
                 })}}
 })(jQuery, Drupal, drupalSettings, window.Mirador);

--- a/src/Component/HttpFoundation/RangedRemoteFileRespone.php
+++ b/src/Component/HttpFoundation/RangedRemoteFileRespone.php
@@ -1,0 +1,170 @@
+<?php
+
+
+namespace Drupal\format_strawberryfield\Component\HttpFoundation;
+
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\Request;
+
+class RangedRemoteFileRespone extends BinaryFileResponse {
+
+  protected static $trustXSendfileTypeHeader = false;
+
+  /**
+   * @var File
+   */
+  protected $file;
+  protected $offset = 0;
+  protected $end = 0;
+  protected $maxlen = -1;
+  protected $deleteFileAfterSend = false;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepare(Request $request)
+  {
+    if (!$this->headers->has('Content-Type')) {
+      $this->headers->set('Content-Type', $this->file->getMimeType() ?: 'application/octet-stream');
+    }
+
+    if ('HTTP/1.0' !== $request->server->get('SERVER_PROTOCOL')) {
+      $this->setProtocolVersion('1.1');
+    }
+
+    $this->ensureIEOverSSLCompatibility($request);
+
+    $this->offset = 0;
+    $this->maxlen = -1;
+
+    if (false === $fileSize = $this->file->getSize()) {
+      return $this;
+    }
+    $this->headers->set('Content-Length', $fileSize);
+
+    if (!$this->headers->has('Accept-Ranges')) {
+      // Only accept ranges on safe HTTP methods
+      $this->headers->set('Accept-Ranges', $request->isMethodSafe(false) ? 'bytes' : 'none');
+    }
+
+    if (self::$trustXSendfileTypeHeader && $request->headers->has('X-Sendfile-Type')) {
+      // Use X-Sendfile, do not send any content.
+      $type = $request->headers->get('X-Sendfile-Type');
+      $path = $this->file->getRealPath();
+      // Fall back to scheme://path for stream wrapped locations.
+      if (false === $path) {
+        $path = $this->file->getPathname();
+      }
+      if ('x-accel-redirect' === strtolower($type)) {
+        // Do X-Accel-Mapping substitutions.
+        // @link https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/#x-accel-redirect
+        foreach (explode(',', $request->headers->get('X-Accel-Mapping', '')) as $mapping) {
+          $mapping = explode('=', $mapping, 2);
+
+          if (2 === \count($mapping)) {
+            $pathPrefix = trim($mapping[0]);
+            $location = trim($mapping[1]);
+
+            if (substr($path, 0, \strlen($pathPrefix)) === $pathPrefix) {
+              $path = $location.substr($path, \strlen($pathPrefix));
+              // Only set X-Accel-Redirect header if a valid URI can be produced
+              // as nginx does not serve arbitrary file paths.
+              $this->headers->set($type, $path);
+              $this->maxlen = 0;
+              break;
+            }
+          }
+        }
+      } else {
+        $this->headers->set($type, $path);
+        $this->maxlen = 0;
+      }
+    } elseif ($request->headers->has('Range')) {
+      // Process the range headers.
+      if (!$request->headers->has('If-Range') || $this->hasValidIfRangeHeader($request->headers->get('If-Range'))) {
+        $range = $request->headers->get('Range');
+
+        [$start, $end] = explode('-', substr($range, 6), 2) + [0];
+
+        $end = ('' === $end) ? $fileSize - 1 : (int) $end;
+        $this->end = $end;
+        if ('' === $start) {
+          $start = $fileSize - $end;
+          $end = $fileSize - 1;
+        } else {
+          $start = (int) $start;
+        }
+
+        if ($start <= $end) {
+          if ($start < 0 || $end > $fileSize - 1) {
+            $this->setStatusCode(416);
+            $this->headers->set('Content-Range', sprintf('bytes */%s', $fileSize));
+          } elseif (0 !== $start || $end !== $fileSize - 1) {
+            $this->maxlen = $end < $fileSize ? $end - $start + 1 : -1;
+            $this->offset = $start;
+
+            $this->setStatusCode(206);
+            $this->headers->set('Content-Range', sprintf('bytes %s-%s/%s', $start, $end, $fileSize));
+            $this->headers->set('Content-Length', $end - $start + 1);
+          }
+        }
+      }
+    }
+
+    return $this;
+  }
+
+  private function hasValidIfRangeHeader($header)
+  {
+    if ($this->getEtag() === $header) {
+      return true;
+    }
+
+    if (null === $lastModified = $this->getLastModified()) {
+      return false;
+    }
+
+    return $lastModified->format('D, d M Y H:i:s').' GMT' === $header;
+  }
+
+  /**
+   * Sends the file.
+   *
+   * {@inheritdoc}
+   */
+  public function sendContent()
+  {
+    if (!$this->isSuccessful()) {
+      return parent::sendContent();
+    }
+
+    if (0 === $this->maxlen) {
+      return $this;
+    }
+
+    $out = fopen('php://output', 'wb');
+
+    // Pass context needed for S3 byte range
+    // Remember Kids. This is the right range syntax.
+    // @See https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
+    $context = stream_context_create([
+      's3' => [
+        'Range' => "bytes=" . $this->offset . "-" . $this->end,
+        'seekable' => FALSE
+      ]
+    ]);
+    $file = fopen($this->file->getPathname(), 'r', false, $context);
+    stream_copy_to_stream($file, $out, $this->maxlen);
+
+    fclose($out);
+    fclose($file);
+
+    if ($this->deleteFileAfterSend && file_exists($this->file->getPathname())) {
+      unlink($this->file->getPathname());
+    }
+
+    return $this;
+  }
+
+}

--- a/src/Controller/IiifBinaryController.php
+++ b/src/Controller/IiifBinaryController.php
@@ -168,6 +168,9 @@ class IiifBinaryController extends ControllerBase {
         $response->headers->set("Content-Length", $size);
         $response->prepare($request);
         $response->setCallback(function () use ($uri) {
+            // We may want to force Garbage Collection here
+            // Even if globally available...
+            gc_enable();
             $stream = fopen($uri, 'r');
             // While the stream is still open
             while (!feof($stream)) {

--- a/src/Controller/IiifBinaryController.php
+++ b/src/Controller/IiifBinaryController.php
@@ -158,6 +158,9 @@ class IiifBinaryController extends ControllerBase {
         $response->headers->set('Content-Type', $mime);
         $response->headers->set('Last-Modified', gmdate("D, d M Y H:i:s", $createdtime)." GMT");
         $response->headers->set('Content-Length', $size);
+        if ($request->headers->has('Range')) {
+          $response->setStatusCode(206);
+        }
         $response->setETag($etag, TRUE);
         return $response;
       }

--- a/src/Controller/IiifBinaryController.php
+++ b/src/Controller/IiifBinaryController.php
@@ -168,8 +168,9 @@ class IiifBinaryController extends ControllerBase {
 
       // If client is asking for a range streaming won't help.
       // We should be able to decide when to stream, always based on Size
-      // And contraints.
-      if ($stream) {
+      // And constraints.
+
+      if ($stream && !$request->headers->has('Range') || !$request->headers->has('Range') && $size > (memory_get_usage(TRUE)/2)) {
         $response = new StreamedResponse();
         $response->headers->set("Content-Type", $mime);
         $response->headers->set("Last-Modified", gmdate("D, d M Y H:i:s", $createdtime)." GMT");
@@ -199,7 +200,7 @@ class IiifBinaryController extends ControllerBase {
                 $i = 0;
               }
               // Read 1,024 bytes from the stream
-              echo fread($stream, 1024);
+              echo fread($stream, 8192);
             }
             // Be sure to close the stream resource when you're done with it
             fclose($stream);

--- a/src/Controller/JsWorkerController.php
+++ b/src/Controller/JsWorkerController.php
@@ -20,15 +20,15 @@ class JsWorkerController extends ControllerBase {
    */
   public function servereplay() {
     $response = new Response(
-      'importScripts("https://cdn.jsdelivr.net/npm/replaywebpage@1.2.0/sw.js");'
+      'importScripts("https://cdn.jsdelivr.net/npm/replaywebpage@1.3.0/sw.js");'
     );
-    // Alternative https://unpkg.com/replaywebpage@1.0.2/sw.js
+    // Alternative https://unpkg.com/replaywebpage@1.3.0/sw.js
     $response->headers->set('Content-Type', 'text/javascript');
     return $response;
   }
 
   /**
-   * Serves 'statically' Index to avoid failure while worker is warmin up.
+   * Serves 'statically' Index to avoid failure while worker is warming up.
    *
    * @return \Symfony\Component\HttpFoundation\Response
    */

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -279,10 +279,15 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
                 $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['dr:uuid']  = $file->uuid();
                 // Used to keep annotations around during edit.
                 // Note: Since View modes are cached, if no change to the NODE this will be served from a cache! mmm.
-                if ($this->currentUser->hasPermission('view strawberryfield webannotation')) {
+                if ($this->currentUser->hasPermission('view strawberryfield webannotation') && $webannotations) {
                   $elements[$delta]['media' . $i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['keystoreid'] = WebAnnotationController::getTempStoreKeyName($fieldname, $delta, $nodeuuid);
                   $elements[$delta]['media' . $i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['webannotations'] = (boolean) $webannotations;
                   $elements[$delta]['media' . $i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['webannotations_tool'] = $webannotations_tool ? $webannotations_tool : 'rect';
+                  // This also never runs if cached. So after deletion we better call the controller!
+                  if (!empty($jsondata['ap:annotationCollection']) && is_array($jsondata['ap:annotationCollection'])) {
+                    $keystoreid = $elements[$delta]['media' . $i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['keystoreid'];
+                    WebAnnotationController::primeKeyStore($items[$delta]);
+                  }
                 }
                 if ($this->currentUser) {
                    $elements[$delta]['media' . $i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['user']['url'] = Url::fromRoute('entity.user.canonical', ['user' => $this->currentUser->getAccount()->id()])->toString();
@@ -292,13 +297,7 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
                   $elements[$delta]['media' . $i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['user']['name'] = 'anonymous';
                 }
 
-                // We only set this if/and only if/ we have annotations loaded
-                // This also never runs if cached. So after deletion we better call the controller!
 
-                if (($webannotations) && !empty($jsondata['ap:annotationCollection']) && is_array($jsondata['ap:annotationCollection'])) {
-                  $keystoreid = $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['keystoreid'];
-                  WebAnnotationController::primeKeyStore($items[$delta]);
-                }
                 $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['height'] = max(
                   $max_height,
                   480

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -279,9 +279,11 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
                 $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['dr:uuid']  = $file->uuid();
                 // Used to keep annotations around during edit.
                 // Note: Since View modes are cached, if no change to the NODE this will be served from a cache! mmm.
-                $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['keystoreid'] = WebAnnotationController::getTempStoreKeyName($fieldname,$delta, $nodeuuid);
-                $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['webannotations'] = (boolean)$webannotations;
-                $elements[$delta]['media'.$i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['webannotations_tool'] = $webannotations_tool ? $webannotations_tool : 'rect';
+                if ($this->currentUser->hasPermission('view strawberryfield webannotation')) {
+                  $elements[$delta]['media' . $i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['keystoreid'] = WebAnnotationController::getTempStoreKeyName($fieldname, $delta, $nodeuuid);
+                  $elements[$delta]['media' . $i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['webannotations'] = (boolean) $webannotations;
+                  $elements[$delta]['media' . $i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['webannotations_tool'] = $webannotations_tool ? $webannotations_tool : 'rect';
+                }
                 if ($this->currentUser) {
                    $elements[$delta]['media' . $i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['user']['url'] = Url::fromRoute('entity.user.canonical', ['user' => $this->currentUser->getAccount()->id()])->toString();
                   $elements[$delta]['media' . $i]['#attached']['drupalSettings']['format_strawberryfield']['openseadragon'][$uniqueid]['user']['name'] = $this->currentUser->getAccount()->getAccountName();


### PR DESCRIPTION
# What is new?

Won't repeat. Its all here https://github.com/esmero/archipelago-deployment/issues/75#issue-745187010
Gist: large files leak memory when delivered via Range requests because Guzzle/AWS SDK and Symfony have issues 🤕 
Solution: we make the same requests we get back to the storage and only stream the bytes we need without offset on the PHP machinery. Sleek, elegant, hack-ish, perfect. Works

This also includes the new replay web 1.3.0 JS and Mirador 3.0.0 final.

Comes with bonus of a new version of PHP in our docker containers. 7.4.9. Nice and wazc tool to transform WARC files into WACZ files