### PR TITLE
Fix IAB 1up mode off sync

### DIFF
--- a/js/iiif-iabookreader_strawberry.js
+++ b/js/iiif-iabookreader_strawberry.js
@@ -35,6 +35,7 @@
                             bookId: node_uuid,
                             enableSearch: true,
                             searchInsideUrl: '/do/' + node_uuid + '/flavorsearch/all/ocr/',
+			    padding: 11,
                         };
                         console.log('initializing IABookreader')
                         var br = new BookReader(options);


### PR DESCRIPTION
@DiegoPino It seems due to how page height sum is rounded to calculate BRpageview element height. I found that set padding to 11 instead of 10 solves this issue with Archipelago. I don't see any collateral issues, please check if this is ok also for you.