### PR TITLE
ISSUE-109: Add the new WACZ mimetype

### DIFF
--- a/src/Controller/WebAnnotationController.php
+++ b/src/Controller/WebAnnotationController.php
@@ -58,7 +58,7 @@ class WebAnnotationController extends ControllerBase {
   protected $mimeTypeGuesser;
 
   /**
-   * MetadataExposeDisplayController constructor.
+   * WebAnnotationController constructor.
    *
    * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
    *   The Symfony Request Stack.

--- a/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
@@ -32,7 +32,7 @@ use Drupal\Core\Url;
  * )
  */
 class StrawberryWarcFormatter extends StrawberryBaseFormatter {
-  
+
   /**
    * {@inheritdoc}
    */
@@ -192,9 +192,11 @@ class StrawberryWarcFormatter extends StrawberryBaseFormatter {
           }
           if (isset($mediaitem['type']) && (
             $mediaitem['dr:mimetype'] == 'application/warc' ||
+            $mediaitem['dr:mimetype'] == 'application/wacz' ||
             $mediaitem['dr:mimetype'] == 'application/zip' ||
             $mediaitem['dr:mimetype'] == 'application/gzip' ||
-            $mediaitem['dr:mimetype'] == ' application/x-gzip'
+            $mediaitem['dr:mimetype'] == 'application/vnd.datapackage+zip' ||
+            $mediaitem['dr:mimetype'] == 'application/x-gzip'
             )
           ) {
             if (isset($mediaitem['dr:fid'])) {


### PR DESCRIPTION
So this adds a new mime type check for the web replay widget which matches our idea of how a WACZ file should be recognized since it derives from a frictionless data package. `application/vnd.datapackage+zip`. I will add another commit later where in the presence of both a WARC and a WACZ we prefer the later.