### PR TITLE
ISSUE-120: Added an admin hint block and tab for the ADO view mode display

### DIFF
--- a/format_strawberryfield.links.task.yml
+++ b/format_strawberryfield.links.task.yml
@@ -26,3 +26,11 @@ metadatadisplay.admin:
   title: Metadata Display
   route_name: entity.metadatadisplay_entity.collection
   base_route: system.admin_content
+
+# Display settings tab for each ADO.
+format_strawberry.display_settings:
+  route_name: format_strawberryfield.display_settings
+  base_route: entity.node.canonical
+  title: 'Display settings'
+  class: '\Drupal\format_strawberryfield\Plugin\Menu\LocalTask\ViewModeLocalTask'
+  weight: 5

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -4,14 +4,11 @@
  * Contains formater_strawberryfield.module.
  */
 
-use Drupal\Component\Serialization\Json;
-use \Drupal\Core\Entity\Display\EntityViewDisplayInterface;
-use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Url;
 use Drupal\format_strawberryfield\Controller\WebAnnotationController;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Swaggest\JsonDiff\JsonDiff;
+
 /**
  * Implements hook_page_attachments().
  *
@@ -36,15 +33,14 @@ function format_strawberryfield_page_attachments(array &$page) {
   $page['#attached']['library'][] = 'core/jquery';
   $page['#attached']['library'][] = 'core/drupal.dialog.ajax';
   $page['#attached']['library'][] = 'core/drupal.ajax';
-
 }
 
+/**
+ * Implements hook_form_FORM_ID_alter() for node_form.
+ */
 function format_strawberryfield_form_node_form_alter(&$form, FormStateInterface $form_state) {
-
   // Deal with Possible Addded Annotations.
-
   if ($form_state->get('hadAnnotations')) {
-    $node = $form_state->getFormObject()->getEntity();
     $count = $form_state->get('hadAnnotations');
 
     $form['annotations'] = [
@@ -90,47 +86,22 @@ function format_strawberryfield_form_node_form_alter(&$form, FormStateInterface 
   }
 }
 
-
-
-function format_strawberryfield_entity_view_mode_alter(&$view_mode, EntityInterface $entity, $context) {
-  if ($entity->getEntityTypeId() == 'node' && $view_mode == 'full') {
-    $adotype = [];
-    $original_view_mode = $view_mode;
-    /* @var \Drupal\Core\Config\ImmutableConfig $config */
-    if ($sbf_fields = \Drupal::service('strawberryfield.utility')->bearsStrawberryfield($entity)) {
-      foreach ($sbf_fields as $field_name) {
-        /* @var $field StrawberryFieldItem */
-        $field = $entity->get($field_name);
-        if (!$field->isEmpty()) {
-          foreach ($field->getIterator() as $delta => $itemfield) {
-            /** @var $itemfield \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem */
-            $flatvalues = (array) $itemfield->provideFlatten();
-            if (isset($flatvalues['type'])) {
-              $adotype = array_merge($adotype, (array) $flatvalues['type']);
-            }
-          }
-        }
-      }
-    }
-    if (!empty($adotype)) {
-      $config = \drupal::config(
-        'format_strawberryfield.viewmodemapping_settings'
-      );
-      $viewmodemappings = $config->get('type_to_viewmode');
-      $viewmodemappings = !empty($viewmodemappings) ? (array) $viewmodemappings : [];
-      usort($viewmodemappings, ['\Drupal\format_strawberryfield\Form\ViewModeMappingSettingsForm', 'sortSettings']);
-
-      foreach ($viewmodemappings as $viewmodemapping) {
-        if (($viewmodemapping['active'] == TRUE) && in_array($viewmodemapping['jsontype'],$adotype)) {
-          $view_mode = $viewmodemapping['view_mode'];
-          break;
-        }
-      }
-    }
-    // To be determined if we want to be dependat on ds module or not
-    // if so we really want to act on this alter and not the general one.
-    /* \Drupal::moduleHandler()->alter('ds_switch_view_mode', $view_mode, $original_view_mode, $entity); */
+/**
+ * Implements hook_entity_view_mode_alter().
+ */
+function format_strawberryfield_entity_view_mode_alter(&$view_mode, Drupal\Core\Entity\EntityInterface $entity, $context) {
+  if ($entity->getEntityTypeId() != 'node') {
+    return;
   }
+  if ($view_mode != 'full') {
+    return;
+  }
+  $view_mode = \Drupal::service('format_strawberryfield.view_mode_resolver')->get($entity);
+
+  // To be determined if we want to be dependat on ds module or not
+  // if so we really want to act on this alter and not the general one.
+  /* \Drupal::moduleHandler()->alter('ds_switch_view_mode', $view_mode, $original_view_mode, $entity); */
+
 }
 
 /**
@@ -174,7 +145,8 @@ function format_strawberryfield_node_prepare_form(NodeInterface $entity, $operat
   }
 
   $account = \Drupal::currentUser();
-  if (($sbf_fields = \Drupal::service('strawberryfield.utility')->bearsStrawberryfield($entity)) && $account->hasPermission('add strawberryfield webannotation')) {
+  if (($sbf_fields = \Drupal::service('strawberryfield.utility')->bearsStrawberryfield($entity)) &&
+    $account->hasPermission('add strawberryfield webannotation')) {
     foreach ($sbf_fields as $field_name) {
       /* @var $field \Drupal\Core\Field\FieldItemInterface */
       $field = $entity->get($field_name);
@@ -183,9 +155,7 @@ function format_strawberryfield_node_prepare_form(NodeInterface $entity, $operat
         /** @var $itemfield \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem */
         $fullvalues = $itemfield->provideDecoded(TRUE);
         /* @var $tempstore \Drupal\Core\TempStore\PrivateTempStore */
-        $tempstore = \Drupal::service('tempstore.private')->get(
-          'webannotation'
-        );
+        $tempstore = \Drupal::service('tempstore.private')->get('webannotation');
         $keystoreid = WebAnnotationController::getTempStoreKeyName(
           $field_name,
           $delta,

--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -231,3 +231,18 @@ format_strawberryfield.deletetmp_webannotations:
     _format: 'json'
     _entity_access: 'node.update'
     _permission: 'add strawberryfield webannotation'
+
+# Display settings for each ADO
+format_strawberryfield.display_settings:
+  path: '/node/{node}/{bundle}/display-settings/{view_mode_name}'
+  defaults:
+    _entity_form: 'entity_view_display.edit'
+    _title: 'Display settings'
+    entity_type_id: 'node'
+  requirements:
+    _entity_access: 'node.update'
+  options:
+    _node_operation_route: TRUE
+    parameters:
+      node:
+        type: 'entity:node'

--- a/format_strawberryfield.services.yml
+++ b/format_strawberryfield.services.yml
@@ -8,3 +8,6 @@ services:
     tags:
       - {name: event_subscriber}
     arguments: ['@string_translation', '@messenger', '@logger.factory', '@tempstore.private']
+  format_strawberryfield.view_mode_resolver:
+    class: Drupal\format_strawberryfield\ViewModeResolver
+    arguments: ['@strawberryfield.utility', '@config.factory']

--- a/src/Plugin/Block/DisplayInformationBlock.php
+++ b/src/Plugin/Block/DisplayInformationBlock.php
@@ -110,7 +110,7 @@ class DisplayInformationBlock extends BlockBase implements ContainerFactoryPlugi
       $build['info']['disclaimer'] = [
         '#type' => 'html_tag',
         '#tag' => 'div',
-        '#value' => $this->t('<strong>Warning</strong>: Changes on a View Mode will affect every ADO(Node) that is using it.'),
+        '#value' => $this->t('<strong>Info</strong>: Changes on a View Mode will affect every ADO(Node) that is using it.'),
       ];
 
       if (empty($view_modes)) {

--- a/src/Plugin/Block/DisplayInformationBlock.php
+++ b/src/Plugin/Block/DisplayInformationBlock.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Drupal\format_strawberryfield\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\format_strawberryfield\ViewModeResolverInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Admin block that shows additional information about the displays.
+ *
+ * @Block(
+ *   id = "format_strawberryfield_display_information",
+ *   admin_label = @Translation("Strawberry Field Block: Display information"),
+ *   category = @Translation("Strawberry Field Formatter"),
+ *   context_definitions = {
+ *     "node" = @ContextDefinition("entity:node", label = @Translation("Node"))
+ *   }
+ * )
+ */
+class DisplayInformationBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The SBF View Mode resolver.
+   *
+   * @var \Drupal\format_strawberryfield\ViewModeResolverInterface
+   */
+  protected $viewModeResolver;
+
+  /**
+   * The entity display repository.
+   *
+   * @var \Drupal\Core\Entity\EntityDisplayRepositoryInterface
+   */
+  protected $entityDisplayRepository;
+
+  /**
+   * Construct a DisplayInformationBlock instance.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param string $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\format_strawberryfield\ViewModeResolverInterface $view_mode_resolver
+   *   The SBF View Mode resolver.
+   * @param \Drupal\Core\Entity\EntityDisplayRepositoryInterface $entity_display_repository
+   *   The entity display repository.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ViewModeResolverInterface $view_mode_resolver, EntityDisplayRepositoryInterface $entity_display_repository) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->viewModeResolver = $view_mode_resolver;
+    $this->entityDisplayRepository = $entity_display_repository;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('format_strawberryfield.view_mode_resolver'),
+      $container->get('entity_display.repository')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $build = [];
+
+    /** @var \Drupal\node\NodeInterface $node */
+    if ($node = $this->getContextValue('node')) {
+      $view_modes = $this->viewModeResolver->getCandidates($node);
+      $selected_view_mode = array_shift($view_modes);
+      $build['info'] = [
+        '#type' => 'details',
+        '#title' => 'Display information',
+        '#open' => TRUE,
+      ];
+
+      // Retrieve the view modes for the entity type to display the label to
+      // the user.
+      $view_mode_definitions = $this->entityDisplayRepository->getViewModes('node');
+
+      $build['info']['selected_view_mode'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'div',
+        '#value' => $this->t('<strong>Selected view mode</strong>: @view_mode',
+          [
+            '@view_mode' => Link::createFromRoute(
+              $view_mode_definitions[$selected_view_mode['view_mode']]['label'] ?? $selected_view_mode['view_mode'],
+              'format_strawberryfield.display_settings',
+              [
+                'node' => $node->id(),
+                'bundle' => $node->bundle(),
+                'view_mode_name' => $selected_view_mode['view_mode'],
+              ]
+            )->toString(),
+          ]
+        ),
+      ];
+      $build['info']['disclaimer'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'div',
+        '#value' => $this->t('<strong>Warning</strong>: Changes on a View Mode will affect every ADO(Node) that is using it.'),
+      ];
+
+      if (empty($view_modes)) {
+        $build['info']['other_view_modes'] = [
+          '#type' => 'html_tag',
+          '#tag' => 'div',
+          '#value' => $this->t('No other view modes were considered for this content.'),
+        ];
+      }
+      else {
+        $other_view_modes = array_column($view_modes, 'view_modes');
+        $build['info']['other_view_modes'] = [
+          '#type' => 'html_tag',
+          '#tag' => 'div',
+          '#value' => $this->t('These were also considered: @view_modes', ['@view_modes' => implode(', ', $other_view_modes)]),
+        ];
+      }
+    }
+
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags() {
+    /** @var \Drupal\node\NodeInterface $node */
+    if ($node = $this->getContextValue('node')) {
+      return $node->getCacheTags();
+    }
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheMaxAge() {
+    /** @var \Drupal\node\NodeInterface $node */
+    if ($node = $this->getContextValue('node')) {
+      return $node->getCacheMaxAge();
+    }
+    return 0;
+  }
+
+}

--- a/src/Plugin/Menu/LocalTask/ViewModeLocalTask.php
+++ b/src/Plugin/Menu/LocalTask/ViewModeLocalTask.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\format_strawberryfield\Plugin\Menu\LocalTask;
+
+use Drupal\Core\Menu\LocalTaskDefault;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\format_strawberryfield\ViewModeResolverInterface;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Local task plugin to calculate the current view mode.
+ */
+class ViewModeLocalTask extends LocalTaskDefault implements ContainerFactoryPluginInterface {
+
+  /**
+   * The SBF View Mode resolver.
+   *
+   * @var \Drupal\format_strawberryfield\ViewModeResolverInterface
+   */
+  protected $viewModeResolver;
+
+  /**
+   * Construct the ViewModeLocalTask object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param array $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\format_strawberryfield\ViewModeResolverInterface
+   *   The SBF View Mode resolver.
+   */
+  public function __construct(array $configuration, $plugin_id, array $plugin_definition, ViewModeResolverInterface $view_mode_resolver) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->viewModeResolver = $view_mode_resolver;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('format_strawberryfield.view_mode_resolver')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRouteParameters(RouteMatchInterface $route_match) {
+    $params = parent::getRouteParameters($route_match);
+    $node = $route_match->getParameter('node');
+    if ($node instanceof NodeInterface) {
+      $params += ['bundle' =>  $node->bundle(), 'node' => $node->id(),'view_mode_name' => $this->viewModeResolver->get($node)];
+    }
+    return $params;
+  }
+
+}

--- a/src/ViewModeResolver.php
+++ b/src/ViewModeResolver.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Drupal\format_strawberryfield;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Cache\UseCacheBackendTrait;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\strawberryfield\StrawberryfieldUtilityServiceInterface;
+
+/**
+ * View Mode resolver service.
+ *
+ * @ingroup format_strawberryfield
+ */
+class ViewModeResolver implements ViewModeResolverInterface {
+  use UseCacheBackendTrait;
+
+  /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   */
+  protected $configFactory;
+
+  /**
+   * The Strawberry Field Utility Service
+   *
+   * @var \Drupal\strawberryfield\StrawberryfieldUtilityService
+   */
+  protected $strawberryfieldUtility;
+
+  /**
+   * DisplayResolver constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\strawberryfield\StrawberryfieldUtilityServiceInterface $strawberryfield_utility_service
+   *   The SBF utility Service
+   */
+  public function __construct(StrawberryfieldUtilityServiceInterface $strawberryfield_utility_service, ConfigFactoryInterface $config_factory) {
+    $this->strawberryfieldUtility = $strawberryfield_utility_service;
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCandidates(ContentEntityInterface $entity) {
+    if ($ado_types = $this->getADOTypes($entity)) {
+      $view_modes = array_filter($this->getSortedMappings(), function($mapping) use ($ado_types) {
+        return ($mapping['active'] == TRUE) && in_array($mapping['jsontype'], $ado_types);
+      });
+      return $view_modes;
+    }
+
+    return ['default'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get(ContentEntityInterface $entity) {
+    $ado_types = $this->getADOTypes($entity);
+    if (!empty($ado_types)) {
+      foreach ($this->getSortedMappings() as $mapping) {
+        if (($mapping['active'] == TRUE) && in_array($mapping['jsontype'], $ado_types)) {
+          return $mapping['view_mode'];
+        }
+      }
+    }
+
+    return 'default';
+  }
+
+  /**
+   * Get a list of ADO types based on the SBF.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The content entity.
+   *
+   * @return array
+   *  Array of ado types.
+   *
+   * @throws \Exception
+   */
+  protected function getADOTypes(ContentEntityInterface $entity) {
+    $cache_id = 'format_strawberry:view_mode_adotypes:' . $entity->id();
+    $cached = $this->cacheGet($cache_id);
+    if ($cached) {
+      return $cached->data;
+    }
+
+    $ado_types = [];
+    if ($sbf_fields = $this->strawberryfieldUtility->bearsStrawberryfield($entity)) {
+      foreach ($sbf_fields as $field_name) {
+        /* @var \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem $field */
+        $field = $entity->get($field_name);
+        if (!$field->isEmpty()) {
+          foreach ($field->getIterator() as $delta => $itemfield) {
+            /** @var \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem $itemfield */
+            $flat_values = (array) $itemfield->provideFlatten();
+            if (isset($flat_values['type'])) {
+              $ado_types = array_merge($ado_types, (array) $flat_values['type']);
+            }
+          }
+        }
+      }
+    }
+
+    $this->cacheSet($cache_id, $ado_types, CacheBackendInterface::CACHE_PERMANENT, Cache::mergeTags($entity->getCacheTags(), [$cache_id]));
+    return $ado_types;
+  }
+
+  /**
+   * Get mappings from config and sort them.
+   *
+   * @return array
+   *   Array of mappings.
+   */
+  protected function getSortedMappings() {
+    $config = $this->configFactory->get('format_strawberryfield.viewmodemapping_settings');
+    $view_mode_mappings = $config->get('type_to_viewmode');
+    $view_mode_mappings = !empty($view_mode_mappings) ? (array) $view_mode_mappings : [];
+    usort($view_mode_mappings, ['\Drupal\format_strawberryfield\Form\ViewModeMappingSettingsForm', 'sortSettings']);
+    return $view_mode_mappings;
+  }
+
+}
+

--- a/src/ViewModeResolverInterface.php
+++ b/src/ViewModeResolverInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\format_strawberryfield;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+
+/**
+ * Interface for the View Mode resolver service.
+ *
+ * @ingroup format_strawberryfield
+ */
+interface ViewModeResolverInterface {
+
+  /**
+   * Gets the view mode for a given entity based on eligibility and priority.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The content entity.
+   *
+   * @return string
+   *   View mode machine name.
+   */
+  public function get(ContentEntityInterface $entity);
+
+  /**
+   * Gets an array of eligible view modes for a given entity.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The content entity.
+   *
+   * @return array
+   *   Array of view modes with the following structure:
+   *    - jsontype: A string defining the chosen type, Book, Media, etc.
+   *    - view_mode: View mode machine name
+   *    - active: Boolean that marks if a view mode is active.
+   *    - weight: The relative weight
+   */
+  public function getCandidates(ContentEntityInterface $entity);
+
+}


### PR DESCRIPTION
This PR adds the following:

- New block `DisplayInformationBlock` that shows the view mode selected linked to the display settings of that view mode
- A local task plugin to inject the right parameters to the Display settings tab per ADO (`ViewModeLocalTask`)
- A consolidated service: `ViewModeResolver` that is called in view_mode_alter but also in the informative block, it does the heavy lifting of selecting the view mode, caching the biggest and common part (getADOTypes)