### PR TITLE
ISSUE-109: Allow JMESPaths to define which media is used. WebReplay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 
 src/Plugin/Field/FieldType/IIIFlinkItem.php
 .idea/format_strawberryfield.iml
+.idea/codeStyles/Project.xml

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -33,6 +33,9 @@ field.formatter.settings.strawberry_audio_formatter:
       type: string
     number_media:
       type: integer
+    jmespath:
+      type: format_strawberryfield.jmespath_config.mapping
+      label: 'JMESPath filter expression settings'
 
 field.formatter.settings.strawberry_image_formatter:
   type: mapping
@@ -66,6 +69,9 @@ field.formatter.settings.strawberry_image_formatter:
       type: string
     image_link:
       type: boolean
+    jmespath:
+      type: format_strawberryfield.jmespath_config.mapping
+      label: 'JMESPath filter expression settings'
 field.formatter.settings.strawberry_media_formatter:
   type: mapping
   label: 'Specific Config for strawberry_media_formatter'
@@ -100,6 +106,9 @@ field.formatter.settings.strawberry_media_formatter:
     number_images:
       type: integer
       label: 'Number of images'
+    jmespath:
+      type: format_strawberryfield.jmespath_config.mapping
+      label: 'JMESPath filter expression settings'
 field.formatter.settings.strawberry_3d_formatter:
   type: mapping
   label: 'Specific Config for strawberry_3d_formatter'
@@ -123,7 +132,9 @@ field.formatter.settings.strawberry_3d_formatter:
     number_models:
       type: integer
       label: 'Number of 3D Models to load from JSON'
-
+    jmespath:
+      type: format_strawberryfield.jmespath_config.mapping
+      label: 'JMESPath filter expression settings'
 field.formatter.settings.strawberry_metadata_formatter:
   type: mapping
   label: 'Specific Config for strawberry_metadata_formatter using Twig'
@@ -181,6 +192,9 @@ field.formatter.settings.strawberry_paged_formatter:
       type: string
     manifesturl_source:
       type: string
+    jmespath:
+      type: format_strawberryfield.jmespath_config.mapping
+      label: 'JMESPath filter expression settings'
 field.formatter.settings.strawberry_pannellum_formatter:
   type: mapping
   label: 'Specific Config for strawberry_pannellum_formatter'
@@ -222,6 +236,9 @@ field.formatter.settings.strawberry_pannellum_formatter:
     number_images:
       type: integer
       label: "Number of Images"
+    jmespath:
+      type: format_strawberryfield.jmespath_config.mapping
+      label: 'JMESPath filter expression settings'
 field.formatter.settings.strawberry_video_formatter:
   type: mapping
   label: 'Specific Config for strawberry_video_formatter'
@@ -250,6 +267,9 @@ field.formatter.settings.strawberry_video_formatter:
       type: integer
     posterframe:
       type: string
+    jmespath:
+      type: format_strawberryfield.jmespath_config.mapping
+      label: 'JMESPath filter expression settings'
 field.formatter.settings.strawberry_pdf_formatter:
   type: mapping
   label: 'Specific Config for strawberry_pdf_formatter'
@@ -280,6 +300,10 @@ field.formatter.settings.strawberry_pdf_formatter:
     initial_page:
       type: integer
       label: 'First Page to display per PDF'
+    jmespath:
+      type: format_strawberryfield.jmespath_config.mapping
+      label: 'JMESPath filter expression settings'
+
 field.formatter.settings.strawberry_mirador_formatter:
   type: mapping
   label: 'Specific Config for strawberry_mirador_formatter'
@@ -355,6 +379,9 @@ field.formatter.settings.strawberry_warc_formatter:
       label: 'Whether to use global IIIF settings or not.'
     json_key_starting_url:
       type: string
+    jmespath:
+      type: format_strawberryfield.jmespath_config.mapping
+      label: 'JMESPath filter expression settings'
 
 # Multiple JSON type / View Mode Mappings
 format_strawberryfield.viewmodemapping_settings:
@@ -455,3 +482,21 @@ ds.field_plugin.*:
     formatter:
       type: field.formatter.settings.[%parent.%parent.formatter]
       label: "Formatter settings for a generic ds.field plugin"
+
+# Reusable JMESPath Config schema for File dependant Formatters
+format_strawberryfield.jmespath_config.mapping:
+  type: mapping
+  label: 'JMESPath Config to be used in Formatters using direct access to Files'
+  mapping:
+    use_jmespath:
+      type: boolean
+      label: 'Whether to use JMESPath Expression to Filter Files'
+    fallback_jmespath:
+      type: boolean
+      label: 'Whether to use the base defaults in case JMESPath Expression returns null or not'
+    jmespath_filter:
+      type: string
+      label: 'A JMESPath filter expression'
+    jmespath_alternative_filter:
+      type: string
+      label: 'An alternative JMESPath filter expression'

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -1,137 +1,152 @@
 (function ($, Drupal, drupalSettings, pannellum) {
 
-    'use strict';
+  'use strict';
 
-    function FormatStrawberryfieldPanoramas(panorama) {
-        this.panorama = panorama;
-    }
+  function checkMobileDevice() {
+    let check = false;
+    (function (a) {
+      if (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i.test(a) || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0, 4))) check = true;
+    })(navigator.userAgent || navigator.vendor || window.opera);
+    return check;
+  };
 
-    function FormatStrawberryfieldhotspotPopUp(event, url) {
-        if (url!== null) {
-            var $myDialog = $('<div class="format-strawberryfield-hotspot-dialog"></div>').appendTo('body');
-            var ajaxObject = Drupal.ajax({
-                url: url,
-                dialogType: 'modal',
-                dialog: {width: '800px'},
-                progress: {
-                    type: 'fullscreen',
-                    message: Drupal.t('Please wait...')
-                }
-            });
-            ajaxObject.execute();
-            event.preventDefault();
+
+  function FormatStrawberryfieldPanoramas(panorama) {
+    this.panorama = panorama;
+  }
+
+  function FormatStrawberryfieldhotspotPopUp(event, url) {
+    if (url !== null) {
+      var $myDialog = $('<div class="format-strawberryfield-hotspot-dialog"></div>').appendTo('body');
+      var ajaxObject = Drupal.ajax({
+        url: url,
+        dialogType: 'modal',
+        dialog: {width: '800px'},
+        progress: {
+          type: 'fullscreen',
+          message: Drupal.t('Please wait...')
         }
+      });
+      ajaxObject.execute();
+      event.preventDefault();
     }
+  }
 
 
-    Drupal.behaviors.format_strawberryfield_pannellum_initiate = {
-        attach: function(context, settings) {
-            $('.strawberry-panorama-item[data-iiif-image]').once('attache_pnl')
-                .each(function (index, value) {
-                    // New 2019.
-                    // If value is an array then we have a multiscene panorama
-                    // Mostlikely, if i coded this right, hotspots will also be arrays
-                    var hotspots = [];
-                    // Get the node uuid for this element
-                    var element_id = $(this).attr("id");
-                    var $multiscene = drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('tour');
-                    var default_width = drupalSettings.format_strawberryfield.pannellum[element_id]['width'];
-                    var default_height = drupalSettings.format_strawberryfield.pannellum[element_id]['height'];
-                    var externalConfigURL =  drupalSettings.format_strawberryfield.pannellum[element_id]['configjsonurl'];
-                    if (externalConfigURL) {
-                        $.getJSON('http://query.yahooapis.com/v1/public/yql?q=select%20%2a%20from%20yahoo.finance.quotes%20WHERE%20symbol%3D%27WRC%27&format=json&diagnostics=true&env=store://datatables.org/alltableswithkeys&callback', function(data) {
-                           console.log(data);
-                        });
+  Drupal.behaviors.format_strawberryfield_pannellum_initiate = {
+    attach: function (context, settings) {
+      $('.strawberry-panorama-item[data-iiif-image]').once('attache_pnl')
+        .each(function (index, value) {
+          // New 2019.
+          // If value is an array then we have a multiscene panorama
+          // Mostlikely, if i coded this right, hotspots will also be arrays
+          var hotspots = [];
+          // Get the node uuid for this element
+          var element_id = $(this).attr("id");
+          var $multiscene = drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('tour');
+          var default_width = drupalSettings.format_strawberryfield.pannellum[element_id]['width'];
+          var default_height = drupalSettings.format_strawberryfield.pannellum[element_id]['height'];
+          var externalConfigURL = drupalSettings.format_strawberryfield.pannellum[element_id]['configjsonurl'];
+          if (externalConfigURL) {
+            $.getJSON('http://query.yahooapis.com/v1/public/yql?q=select%20%2a%20from%20yahoo.finance.quotes%20WHERE%20symbol%3D%27WRC%27&format=json&diagnostics=true&env=store://datatables.org/alltableswithkeys&callback', function (data) {
+              console.log(data);
+            });
+          }
+
+          const $haov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.haov;
+          const $vaov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.vaov;
+          const $minYaw = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.minYaw;
+          const $maxYaw = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.maxYaw;
+          const $vOffset = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.vOffset;
+          const $maxPitch = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.maxPitch;
+          const $minPitch = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.minPitch;
+
+          // Check if we got some data passed via Drupal settings.
+          if (typeof (drupalSettings.format_strawberryfield.pannellum[element_id]) != 'undefined') {
+            if (drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('hotspots') &&
+              !$multiscene
+            ) {
+              $.each(drupalSettings.format_strawberryfield.pannellum[element_id].hotspots, function (id, hotspotdata) {
+                // Also add Popups for Standalone Panoramas if they have an URL.
+                if (hotspotdata.hasOwnProperty('URL')) {
+                  hotspotdata.clickHandlerFunc = Drupal.FormatStrawberryfieldhotspotPopUp;
+                  hotspotdata.clickHandlerArgs = hotspotdata.URL;
+                }
+                hotspots.push(hotspotdata);
+              });
+            }
+            $(this).height(default_height);
+            $(this).css("width", default_width);
+
+            console.log('Initializing Pannellum.')
+            // When loading a webform with an embeded Viewer
+            // The context of Pannellum is not global
+            // So we can't really use 'pannellum' directly
+            if (checkMobileDevice()) {
+              console.log('Mobile defaulting to smaller version');
+              var sourceimage = $(value).data('iiifImageMobile');
+            } else {
+              var sourceimage = $(value).data('iiifImage');
+            }
+            if (!$multiscene) {
+              var viewer = window.pannellum.viewer(element_id, {
+                "type": "equirectangular",
+                "panorama": sourceimage,
+                "hotSpotDebug": drupalSettings.format_strawberryfield.pannellum[element_id].settings.hotSpotDebug,
+                "autoLoad": Boolean(drupalSettings.format_strawberryfield.pannellum[element_id].settings.autoLoad),
+                "hotSpots": hotspots,
+                "haov": $haov || 360,
+                "vaov": $vaov || 180,
+                "friction": 0.2,
+                "maxYaw": $maxYaw || 180,
+                "minYaw": $minYaw || -180,
+                "vOffset": $vOffset || 0,
+                "maxPitch": $maxPitch || undefined,
+                "minPitch": $minPitch || undefined
+              });
+            } else {
+              console.log('Pannellum Multiscene found.');
+              $.each(drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes, function (sceneid, data) {
+                // Add Model Window Behaviour to hotSpots with Links
+                if (data.hasOwnProperty('hotSpots')) {
+                  $.each(data.hotSpots, function (hotspotid, hotspotdata) {
+                    if (hotspotdata.hasOwnProperty('URL')) {
+                      drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes[sceneid].hotSpots[hotspotid].clickHandlerFunc = Drupal.FormatStrawberryfieldhotspotPopUp;
+                      drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes[sceneid].hotSpots[hotspotid].clickHandlerArgs = hotspotdata.URL;
                     }
 
-                    const $haov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.haov;
-                    const $vaov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.vaov;
-                    const $minYaw = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.minYaw;
-                    const $maxYaw = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.maxYaw;
-                    const $vOffset = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.vOffset;
-                    const $maxPitch = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.maxPitch;
-                    const $minPitch = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.minPitch;
+                  });
 
-                    // Check if we got some data passed via Drupal settings.
-                    if (typeof(drupalSettings.format_strawberryfield.pannellum[element_id]) != 'undefined') {
-                        if (drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('hotspots') &&
-                            !$multiscene
-                        ) {
-                            $.each(drupalSettings.format_strawberryfield.pannellum[element_id].hotspots, function (id, hotspotdata)  {
-                                // Also add Popups for Standalone Panoramas if they have an URL.
-                                if (hotspotdata.hasOwnProperty('URL')) {
-                                    hotspotdata.clickHandlerFunc = Drupal.FormatStrawberryfieldhotspotPopUp;
-                                    hotspotdata.clickHandlerArgs = hotspotdata.URL;
-                                }
-                                hotspots.push(hotspotdata);
-                            });
-                        }
-                        $(this).height(default_height);
-                        $(this).css("width",default_width);
-
-                        console.log('Initializing Pannellum.')
-                        // When loading a webform with an embeded Viewer
-                        // The context of Pannellum is not global
-                        // So we can't really use 'pannellum' directly
-
-                        if (!$multiscene) {
-                            var viewer = window.pannellum.viewer(element_id, {
-                                "type": "equirectangular",
-                                "panorama": $(value).data('iiifImage'),
-                                "hotSpotDebug": drupalSettings.format_strawberryfield.pannellum[element_id].settings.hotSpotDebug,
-                                "autoLoad": Boolean(drupalSettings.format_strawberryfield.pannellum[element_id].settings.autoLoad),
-                                "hotSpots": hotspots,
-                                "haov": $haov || 360,
-                                "vaov": $vaov || 180,
-                                "maxYaw": $maxYaw || 180,
-                                "minYaw": $minYaw || -180,
-                                "vOffset": $vOffset || 0,
-                                "maxPitch": $maxPitch||undefined,
-                                "minPitch": $minPitch|| undefined
-
-                            });
-                        }
-                        else {
-                            console.log('Pannellum Multiscene found.');
-                            $.each(drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes, function (sceneid, data)  {
-                                // Add Model Window Behaviour to hotSpots with Links
-                                if (data.hasOwnProperty('hotSpots')) {
-                                    $.each(data.hotSpots, function (hotspotid, hotspotdata) {
-                                        if (hotspotdata.hasOwnProperty('URL')) {
-                                            drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes[sceneid].hotSpots[hotspotid].clickHandlerFunc = Drupal.FormatStrawberryfieldhotspotPopUp;
-                                            drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes[sceneid].hotSpots[hotspotid].clickHandlerArgs = hotspotdata.URL;
-                                        }
-
-                                    });
-
-                                }
-                            });
-                            var viewer = window.pannellum.viewer(element_id, drupalSettings.format_strawberryfield.pannellum[element_id].tour);
-                        }
-                        FormatStrawberryfieldPanoramas.panoramas.set(element_id, new FormatStrawberryfieldPanoramas(viewer));
+                }
+              });
+              var viewer = window.pannellum.viewer(element_id, drupalSettings.format_strawberryfield.pannellum[element_id].tour);
+            }
+            FormatStrawberryfieldPanoramas.panoramas.set(element_id, new FormatStrawberryfieldPanoramas(viewer));
 
 
-                    }
+          }
 
-                })}}
-    /**
-     * Extend the FormatStrawberryfieldPanoramas.
-     */
-    $.extend(
-        FormatStrawberryfieldPanoramas,
-        /** @lends Drupal.FormatStrawberryfieldPanoramas */ {
-            /**
-             * Store all created Panorama Viewer Instances.
-             *
-             * @type {Array.<Drupal.FormatStrawberryfieldPanoramas>}
-             */
-            panoramas: new Map(),
-            hotspots:  new Map(),
-        },
-    );
+        })
+    }
+  }
+  /**
+   * Extend the FormatStrawberryfieldPanoramas.
+   */
+  $.extend(
+    FormatStrawberryfieldPanoramas,
+    /** @lends Drupal.FormatStrawberryfieldPanoramas */ {
+      /**
+       * Store all created Panorama Viewer Instances.
+       *
+       * @type {Array.<Drupal.FormatStrawberryfieldPanoramas>}
+       */
+      panoramas: new Map(),
+      hotspots: new Map(),
+    },
+  );
 
-    // Make the FormatStrawberryfieldPanoramas object available in the Drupal namespace.
-    Drupal.FormatStrawberryfieldPanoramas = FormatStrawberryfieldPanoramas;
-    // Make the FormatStrawberryfieldhotspotPopUp function available in the Drupal namespace.
-    Drupal.FormatStrawberryfieldhotspotPopUp = FormatStrawberryfieldhotspotPopUp;
+  // Make the FormatStrawberryfieldPanoramas object available in the Drupal namespace.
+  Drupal.FormatStrawberryfieldPanoramas = FormatStrawberryfieldPanoramas;
+  // Make the FormatStrawberryfieldhotspotPopUp function available in the Drupal namespace.
+  Drupal.FormatStrawberryfieldhotspotPopUp = FormatStrawberryfieldhotspotPopUp;
 })(jQuery, Drupal, drupalSettings, window.pannellum);

--- a/src/Plugin/Field/FieldFormatter/StrawberryDirectJsonFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryDirectJsonFormatter.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace Drupal\format_strawberryfield\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
+
+/**
+ * StrawberryBaseFormatter base class for SBF/JSON based formatters.
+ */
+abstract class StrawberryDirectJsonFormatter extends StrawberryBaseFormatter {
+
+  const EXAMPLE_JMESPATH = "\"as:image\".*|[?\"dr:for\"=='images' && \"dr:mimetype\"== 'image/jpeg' ]|[?\"flv:exif\".ImageWidth!='null']|[?\"sequence\">=`2`]";
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return
+      parent::defaultSettings() + [
+        'jmespath' => [
+          'use_jmespath' => FALSE,
+          'fallback_jmespath' => FALSE,
+          'jmespath_filter' => '',
+          'jmespath_alternative_filter' => '',
+        ],
+      ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = parent::settingsSummary();
+    $jmespath_settings = $this->getSetting('jmespath');
+    $summary[] = $this->t('Use JMESPath? %value', [
+      '%value' => isset($jmespath_settings['use_jmespath']) && $jmespath_settings['use_jmespath'] ? 'Yes.' : 'No.',
+    ]);
+    if (isset($jmespath_settings['use_jmespath'])) {
+      $summary[] = $this->t(
+        'JMESPath expression used: <em>%expression</em>', [
+          '%expression' => $jmespath_settings['jmespath_filter'],
+        ]
+      );
+      $summary[] = $this->t(
+        'Alternative JMESPath expression used: <em>%expression</em>', [
+          '%expression' => $jmespath_settings['jmespath_alternative_filter'],
+        ]
+      );
+      $summary[] = $this->t('Fallback to non JMESPath? %value', [
+        '%value' => isset($jmespath_settings['fallback_jmespath']) && $jmespath_settings['fallback_jmespath'] ? 'Yes.' : 'No.',
+      ]);
+    }
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+
+    $form = parent::settingsForm($form, $form_state);
+    $current_field = array_keys($form_state->getValue('fields'));
+    $field_name = reset($current_field);
+    $realparents = [
+      'fields',
+      $field_name,
+      'settings_edit_form',
+      'settings',
+      'formatter',
+      'jmespath',
+    ];
+    $jmespath_settings = $this->getSetting('jmespath');
+    $form['jmespath']['use_jmespath'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Use JMESPath Expression to fetch files used by this Formatter'),
+      '#description' => t('Enabling this will allow you to have full control of which files are used for this Formatter using a JMESPath filter expression'),
+      '#default_value' => isset($jmespath_settings['use_jmespath']) ? (bool) $jmespath_settings['use_jmespath'] : FALSE,
+      '#attributes' => [
+        'data-checkbox-selector' => 'use_jmespath',
+      ],
+    ];
+
+    $form['jmespath_container'] = [
+      '#type' => 'container',
+      '#tree' => TRUE,
+      '#title' => t('JMESPath Settings'),
+      '#states' => [
+        'visible' => [
+          ':checkbox[data-checkbox-selector="use_jmespath"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    $realparents_fallback = $realparents_filter = $realparents_alternative_filter = $realparents;
+    $realparents_fallback[] = 'fallback_jmespath';
+    $realparents_filter[] = 'jmespath_filter';
+    $realparents_alternative_filter[] = 'jmespath_alternative_filter';
+    $form['jmespath_container']['fallback_jmespath'] = [
+      '#type' => 'checkbox',
+      '#tree' => TRUE,
+      '#parents' => $realparents_fallback,
+      '#title' => t('If the JMESPath Expression returns no files use the general config to choose any.'),
+      '#description' => t("Enabling this will allow you use the default settings in case your expression returns no files"),
+      '#default_value' => isset($jmespath_settings['fallback_jmespath']) ? (bool) $jmespath_settings['fallback_jmespath'] : FALSE,
+
+    ];
+
+    $form['jmespath_container']['jmespath_filter'] = [
+      '#type' => 'textarea',
+      '#tree' => TRUE,
+      '#cols' => '80',
+      '#rows' => '5',
+      '#parents' => $realparents_filter,
+      '#title' => t('A complete JMESPath that fetches one or more files from an as:image, etc structure'),
+      '#default_value' => isset($jmespath_settings['jmespath_filter']) ? $jmespath_settings['jmespath_filter'] : static::EXAMPLE_JMESPATH,
+      '#element_validate' => [[$this, 'validateJMESPath']],
+      '#states' => [
+        'required' => [
+          ':checkbox[data-checkbox-selector="use_jmespath"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    $form['jmespath_container']['jmespath_alternative_filter'] = [
+      '#type' => 'textarea',
+      '#tree' => TRUE,
+      '#cols' => '80',
+      '#rows' => '5',
+      '#parents' => $realparents_alternative_filter,
+      '#title' => t('A secondary complete JMESPath that fetches one or more files to fallback in case the main one fails to give results'),
+      '#default_value' => isset($jmespath_settings['jmespath_alternative_filter']) ? $jmespath_settings['jmespath_alternative_filter'] : static::EXAMPLE_JMESPATH,
+      '#element_validate' => [[$this, 'validateJMESPath']],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * Validates a JMESPath String.
+   *
+   * @param array $element
+   *   The Form element.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The Form State Object.
+   * @param array $complete_form
+   *   The complete form structure.
+   */
+  public function validateJMESPath(array &$element, FormStateInterface $form_state, array &$complete_form) {
+    $parents = $element['#parents'];
+    $enabled = array_slice($parents, 0, -1);
+    $enabled[] = 'use_jmespath';
+    // Empty array, we only want to know if its valid or not.
+    $jsonArray = [];
+    // Only validate if jmespath is enabled
+    if (boolval($form_state->getValue($enabled)) === TRUE) {
+      try {
+        $searchresult = StrawberryfieldJsonHelper::searchJson(
+          $element['#value'], $jsonArray
+        );
+      } catch (\Exception $exception) {
+        $form_state->setErrorByName(implode('][', $parents), t("Your JMESPath expression is invalid with error: @error", [
+          '@error' => $exception->getMessage(),
+        ]));
+      }
+    }
+  }
+
+  /**
+   * Filters an array against another array with same keys and values
+   *
+   * @param array $source
+   * @param null $key
+   *
+   * @return array
+   */
+  protected function filterMediaByJMESPath(array $source, $key = NULL): array {
+    $ordersubkey = 'sequence';
+    $jmespath_settings = $this->getSetting('jmespath');
+    $use_jmespath = isset($jmespath_settings['use_jmespath']) ? $jmespath_settings['use_jmespath'] : FALSE;
+    if ($use_jmespath) {
+      $fallback_jmespath = isset($jmespath_settings['fallback_jmespath']) ? $jmespath_settings['fallback_jmespath'] : FALSE;
+      $jmespath_filter = isset($jmespath_settings['jmespath_filter']) ? $jmespath_settings['jmespath_filter'] : NULL;
+      $jmespath_alternative_filter = isset($jmespath_settings['jmespath_alternative_filter']) ? $jmespath_settings['jmespath_alternative_filter'] : NULL;
+      try {
+        $searchresult = StrawberryfieldJsonHelper::searchJson(
+          $jmespath_filter, $source
+        );
+        if (empty($searchresult) && !empty($jmespath_alternative_filter)) {
+          $searchresult = StrawberryfieldJsonHelper::searchJson(
+            $jmespath_alternative_filter, $source
+          );
+        }
+        if (empty($searchresult) && $fallback_jmespath) {
+          if (isset($key) && isset($source[$key])) {
+            // We are taking a single one here for now
+            StrawberryfieldJsonHelper::orderSequence($source, $key, $ordersubkey);
+            return $source[$key];
+          }
+          else {
+            return [];
+          }
+        }
+        return $searchresult;
+      } catch (\Exception $exception) {
+        $this->messenger()
+          ->addWarning($this->t('We could not fetch Media for this ADO. Your JMESPath settings may need to be adjusted.'));
+        return [];
+      }
+    }
+    else {
+      if (isset($key) && isset($source[$key])) {
+        StrawberryfieldJsonHelper::orderSequence($source, $key, $ordersubkey);
+        return $source[$key];
+      }
+      else {
+        return [];
+      }
+    }
+  }
+
+
+  /**
+   * Filters an array against another array with same keys and values
+   *
+   * @param array $source
+   * @param array $properties
+   *
+   * @return array
+   */
+  protected function filterMediaByArray(array $source, array $properties): array {
+    // Remove empties first from the properties
+    $properties = array_filter($properties);
+    return array_filter($source, function ($s) use ($properties) {
+      $allow = FALSE;
+      foreach ($properties as $prop => $value) {
+        $allow = $allow ||
+          isset($s[$prop]) &&
+          ($s[$prop] == $value ||
+            in_array((array) $s[$prop], $value));
+        return $allow;
+      }
+      return $allow;
+    });
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
@@ -8,12 +8,11 @@
 
 namespace Drupal\format_strawberryfield\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Field\Annotation\FieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\strawberryfield\Tools\Ocfl\OcflHelper;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Cache\Cache;
-use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
-use Drupal\Core\StreamWrapper\StreamWrapperManager;
 use Drupal\Core\Url;
 
 /**
@@ -31,7 +30,7 @@ use Drupal\Core\Url;
  *   }
  * )
  */
-class StrawberryWarcFormatter extends StrawberryBaseFormatter {
+class StrawberryWarcFormatter extends StrawberryDirectJsonFormatter {
 
   /**
    * {@inheritdoc}
@@ -44,7 +43,7 @@ class StrawberryWarcFormatter extends StrawberryBaseFormatter {
         'warcurl_json_key_source' => '',
         'max_width' => 0,
         'max_height' => 520,
-    ];
+      ];
   }
 
   /**
@@ -73,7 +72,7 @@ class StrawberryWarcFormatter extends StrawberryBaseFormatter {
           '#maxlength' => 5,
           '#field_suffix' => $this->t('pixels'),
           '#min' => 0,
-          '#required' => TRUE
+          '#required' => TRUE,
         ],
         'max_height' => [
           '#type' => 'number',
@@ -83,15 +82,15 @@ class StrawberryWarcFormatter extends StrawberryBaseFormatter {
           '#maxlength' => 5,
           '#field_suffix' => $this->t('pixels'),
           '#min' => 0,
-          '#required' => TRUE
+          '#required' => TRUE,
         ],
         'navbar' => [
           '#type' => 'checkbox',
           '#title' => $this->t('Enable navbars and menus.'),
           '#description' => $this->t('Check to display full navigation bar inside the replayweb widget.'),
           '#required' => FALSE,
-          '#default_value' => $this->getSetting('navbar') ?  $this->getSetting('navbar') : TRUE,
-          ],
+          '#default_value' => $this->getSetting('navbar') ? $this->getSetting('navbar') : TRUE,
+        ],
 
         'warcurl_json_key_source' => [
           '#type' => 'textfield',
@@ -124,7 +123,6 @@ class StrawberryWarcFormatter extends StrawberryBaseFormatter {
         '%json_key_source' => $this->getSetting('warcurl_json_key_source'),
       ]);
     }
-
     return $summary;
   }
 
@@ -137,34 +135,35 @@ class StrawberryWarcFormatter extends StrawberryBaseFormatter {
     $max_width = $this->getSetting('max_width');
     $url_key = $this->getSetting('json_key_starting_url');
     $navbar = $this->getSetting('navbar');
-    $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
+    $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width . 'px';
     $max_height = $this->getSetting('max_height');
     //@TODO allow more than one?
-    $number_warcs =  $this->getSetting('number_warcs');
+    $number_warcs = $this->getSetting('number_warcs');
     /* @var \Drupal\file\FileInterface[] $files */
     // Fixing the key to extract while coding to 'Media'
     $key = $this->getSetting('json_key_source');
-
     $nodeuuid = $items->getEntity()->uuid();
     $nodeid = $items->getEntity()->id();
-    $fieldname = $items->getName();
     foreach ($items as $delta => $item) {
-      $main_property = $item->getFieldDefinition()->getFieldStorageDefinition()->getMainPropertyName();
+      $main_property = $item->getFieldDefinition()
+        ->getFieldStorageDefinition()
+        ->getMainPropertyName();
       $value = $item->{$main_property};
 
       if (empty($value)) {
         continue;
       }
 
-      $jsondata = json_decode($item->value, true);
+      $jsondata = json_decode($item->value, TRUE);
       // @TODO use future flatversion precomputed at field level as a property
       $json_error = json_last_error();
       if ($json_error != JSON_ERROR_NONE) {
-        $message= $this->t('We could had an issue decoding as JSON your metadata for node @id, field @field',
+        $message = $this->t('We could had an issue decoding as JSON your metadata for node @id, field @field',
           [
             '@id' => $nodeid,
             '@field' => $items->getName(),
           ]);
+        \Drupal::logger('format_strawberryfield')->warning($message);
         return $elements[$delta] = ['#markup' => $this->t('ERROR')];
       }
       /* Expected structure of an Media item inside JSON
@@ -180,129 +179,116 @@ class StrawberryWarcFormatter extends StrawberryBaseFormatter {
          }
       }*/
       $i = 0;
-      if (isset($jsondata[$key])) {
-        // Order Files based on a given 'sequence' key
-        $ordersubkey = 'sequence';
-        // We are taking a single one here for now
-        StrawberryfieldJsonHelper::orderSequence($jsondata, $key, $ordersubkey);
-        foreach ($jsondata[$key] as $mediaitem) {
-          $i++;
-          if ($i > 1) {
-            break;
-          }
-          if (isset($mediaitem['type']) && (
+      $jsondatafiltered = $this->filterMediaByJMESPath($jsondata, $key);
+      foreach ($jsondatafiltered as $mediaitem) {
+        $i++;
+        if ($i > 1) {
+          break;
+        }
+        if (isset($mediaitem['type']) && (
             $mediaitem['dr:mimetype'] == 'application/warc' ||
             $mediaitem['dr:mimetype'] == 'application/wacz' ||
             $mediaitem['dr:mimetype'] == 'application/zip' ||
             $mediaitem['dr:mimetype'] == 'application/gzip' ||
             $mediaitem['dr:mimetype'] == 'application/vnd.datapackage+zip' ||
             $mediaitem['dr:mimetype'] == 'application/x-gzip'
-            )
-          ) {
-            if (isset($mediaitem['dr:fid'])) {
-              // @TODO check if loading the entity is really needed to check access.
-              // @TODO we can refactor a lot here and move it to base methods
-              $file = OcflHelper::resolvetoFIDtoURI(
-                $mediaitem['dr:fid']
+          )
+        ) {
+          if (isset($mediaitem['dr:fid'])) {
+            // @TODO check if loading the entity is really needed to check access.
+            // @TODO we can refactor a lot here and move it to base methods
+            $file = OcflHelper::resolvetoFIDtoURI(
+              $mediaitem['dr:fid']
+            );
+            if (!$file) {
+              continue;
+            }
+            //@TODO if no media key to file loading was possible
+            // means we have a broken/missing media reference
+            // we should inform to logs and continue
+            if ($this->checkAccess($file)) {
+              // We assume here file could not be accessible publicly;
+              $route_parameters = [
+                'node' => $nodeid,
+                'uuid' => $file->uuid(),
+                'format' => urlencode($mediaitem['name']),
+              ];
+              $publicurl = Url::fromRoute('format_strawberryfield.iiifbinary', $route_parameters);
+              $filecachetags = $file->getCacheTags();
+
+              $uniqueid = 'replayweb-' . $items->getName() . '-' . $nodeuuid . '-' . $delta . '-warc' . $i;
+
+              $cache_contexts = [
+                'url.site',
+                'url.path',
+                'url.query_args',
+                'user.permissions',
+              ];
+              // @ see https://www.drupal.org/files/issues/2517030-125.patch
+              $cache_tags = Cache::mergeTags(
+                $filecachetags,
+                $items->getEntity()->getCacheTags()
               );
-              if (!$file) {
-                continue;
-              }
-              //@TODO if no media key to file loading was possible
-              // means we have a broken/missing media reference
-              // we should inform to logs and continue
-              if ($this->checkAccess($file)) {
-                $audiourl = $file->getFileUri();
-                // We assume here file could not be accessible publicly
-                $route_parameters = [
-                  'node' => $nodeid,
-                  'uuid' => $file->uuid(),
-                  'format' => 'default.'. pathinfo($file->getFilename(), PATHINFO_EXTENSION)
-                ];
-                $publicurl = Url::fromRoute('format_strawberryfield.iiifbinary', $route_parameters);
 
-                $filecachetags = $file->getCacheTags();
-                //@TODO check this filecachetags and see if they make sense
+              // @see https://www.iandevlin.com/blog/2015/12/html5/webvtt-and-audio/
+              $elements[$delta]['warc_replayweb_' . $i] = [
+                '#type' => 'html_tag',
+                '#tag' => 'replay-web-page',
+                '#cache' => [
+                  'tags' =>
+                    $cache_tags,
+                ],
+                '#attributes' => [
+                  'id' => $uniqueid,
+                  'source' => $publicurl->toString(),
+                  'style' => "width:{$max_width_css}; height:{$max_height}px; display:block",
+                ],
+              ];
 
-                $uniqueid =
-                  'replayweb-' . $items->getName(
-                  ) . '-' . $nodeuuid . '-' . $delta . '-warc' . $i;
+              if (isset($jsondata[$url_key])) {
+                if (is_array($jsondata[$url_key]) && isset($jsondata[$url_key][$i]) &&
+                  is_string($jsondata[$url_key][$i]) && !empty(trim($jsondata[$url_key][$i]))
+                ) {
+                  $elements[$delta]['warc_replayweb_' . $i]['#attributes']['url'] = $jsondata[$url_key][$i];
 
-                $cache_contexts = [
-                  'url.site',
-                  'url.path',
-                  'url.query_args',
-                  'user.permissions'
-                ];
-                // @ see https://www.drupal.org/files/issues/2517030-125.patch
-                $cache_tags = Cache::mergeTags(
-                  $filecachetags,
-                  $items->getEntity()->getCacheTags()
-                );
-
-                // @see https://www.iandevlin.com/blog/2015/12/html5/webvtt-and-audio/
-                $elements[$delta]['warc_replayweb_' . $i] = [
-                  '#type' => 'html_tag',
-                  '#tag' => 'replay-web-page',
-                  '#cache' => [
-                    'tags' =>
-                      $cache_tags
-                    ],
-                  '#attributes' => [
-                    'source' => $publicurl->toString(),
-                    'style' => "width:{$max_width_css}; height:{$max_height}px; display:block",
-                   ]
-                  ];
-
-                  if (isset($jsondata[$url_key])) {
-                    if (is_array($jsondata[$url_key]) &&
-                      isset($jsondata[$url_key][$i]) &&
-                      is_string($jsondata[$url_key][$i]) &&
-                      !empty(trim($jsondata[$url_key][$i]))
-                    ) {
-                      $elements[$delta]['warc_replayweb_' . $i]['#attributes']['url'] = $jsondata[$url_key][$i];
-
-                    } elseif (!is_array($jsondata[$url_key]) &&
-                      !empty(trim($jsondata[$url_key]))
-                    ){
-                      // This is if there is a single URL. WE assume its for all WARC files.
-                      // But let's be honest. We go for a single WARC file for now
-                      $elements[$delta]['warc_replayweb_' . $i]['#attributes']['url'] = $jsondata[$url_key];
-                    }
-
-                  } else {
-                    if (!$navbar) {
-                      $elements[$delta]['warc_replayweb_' . $i]['#attributes']['view'] = "pages";
-                    }
-                  }
-
-
-                  $elements[$delta]['#attached']['library'][] = 'format_strawberryfield/replayweb';
-                  if (isset($item->_attributes)) {
-                    $elements[$delta] += ['#attributes' => []];
-                    $elements[$delta]['#attributes'] += $item->_attributes;
-                    // Unset field item attributes since they have been included in the
-                    // formatter output and should not be rendered in the field template.
-                    unset($item->_attributes);
-                  }
+                }
+                elseif (!is_array($jsondata[$url_key]) && !empty(trim($jsondata[$url_key]))) {
+                  // This is if there is a single URL. WE assume its for all WARC files.
+                  // But let's be honest. We go for a single WARC file for now
+                  $elements[$delta]['warc_replayweb_' . $i]['#attributes']['url'] = $jsondata[$url_key];
                 }
               }
               else {
-                // @TODO Deal with no access here
-                // Should we put a thumb? Just hide?
-                // @TODO we can bring a plugin here and there that deals with
-                $elements[$delta]['media_thumb'.$i] = [
-                  '#markup' => '<i class="fas fa-times-circle"></i>',
-                  '#prefix' => '<span>',
-                  '#suffix' => '</span>',
-                ];
+                if (!$navbar) {
+                  $elements[$delta]['warc_replayweb_' . $i]['#attributes']['view'] = "pages";
+                }
               }
 
+
+              $elements[$delta]['#attached']['library'][] = 'format_strawberryfield/replayweb';
+              if (isset($item->_attributes)) {
+                $elements[$delta] += ['#attributes' => []];
+                $elements[$delta]['#attributes'] += $item->_attributes;
+                // Unset field item attributes since they have been included in the
+                // formatter output and should not be rendered in the field template.
+                unset($item->_attributes);
+              }
+            }
+          }
+          else {
+            // @TODO Deal with no access here
+            // Should we put a thumb? Just hide?
+            // @TODO we can bring a plugin here and there that deals with
+            $elements[$delta]['media_thumb' . $i] = [
+              '#markup' => '<i class="fas fa-times-circle"></i>',
+              '#prefix' => '<span>',
+              '#suffix' => '</span>',
+            ];
           }
         }
       }
       // Get rid of empty #attributes key to avoid render error
-      if (isset( $elements[$delta]["#attributes"]) && empty( $elements[$delta]["#attributes"])) {
+      if (isset($elements[$delta]["#attributes"]) && empty($elements[$delta]["#attributes"])) {
         unset($elements[$delta]["#attributes"]);
       }
     }
@@ -310,4 +296,5 @@ class StrawberryWarcFormatter extends StrawberryBaseFormatter {
     return $elements;
 
   }
+
 }

--- a/src/Tools/IiifHelper.php
+++ b/src/Tools/IiifHelper.php
@@ -93,13 +93,19 @@ class IiifHelper {
    */
   public function getImageSizes($id) {
     $remoteInfoJson = $this->getRemoteInfoJson($id);
+    $sizes = [];
     if (empty($remoteInfoJson)) {
-      return [];
+      return $sizes;
     }
+    // This could be optional in other IIIF Server implementations.
     if (isset($remoteInfoJson['sizes'])) {
-      return $remoteInfoJson['sizes'];
+      $sizes = $remoteInfoJson['sizes'];
     }
-    return [];
+    // Adds at the end the full size
+    if (isset($remoteInfoJson['width']) && isset($remoteInfoJson['height'])) {
+      $sizes[] = ['width' => $remoteInfoJson['width'], 'height' => $remoteInfoJson['height']];
+    }
+    return $sizes;
   }
 
 


### PR DESCRIPTION
# What is this?

See #109 

A new base class for Formatters that need/want to extract Media from the JSON in a more fine grained way. This allows right now two extra JMESPaths to be defined and also 2 fallback options.

This also adds non related data that we found today. IIIF limits on Pannellum panorama Formatter/JS. Now we detect if the Device is Mobile or Not and also calculate (gosh) estimated memory usage based on the IIIF JSON provide size arrays. That way we avoid Java HEAP overflows with + 32K images when asking for more that 50%. you can always without any issues as for MAX size since those are served directly without any preprocessing/scaling from Cantaloupe. I also added + friction to help with #121 