### PR TITLE
ISSUE-138: Add file tags cache to strawberry_paged_formatter (books/documents)

### DIFF
--- a/src/Plugin/Field/FieldFormatter/StrawberryBaseFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryBaseFormatter.php
@@ -8,6 +8,7 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\format_strawberryfield\Tools\IiifUrlValidator;
@@ -18,17 +19,44 @@ use Drupal\Core\Access\AccessResult;
  */
 abstract class StrawberryBaseFormatter extends FormatterBase implements ContainerFactoryPluginInterface {
 
+  /* Expected structure of an Media item inside JSON
+  "as:images": {
+     "s3:\/\/f23\/new-metadata-en-image-58455d91acf7290275c1cab77531b7f561a11a84.jpg": {
+     "dr:fid": 32, // Drupal's FID
+     "dr:for": "add_some_master_images", // The webform element key that generated this one
+     "url": "s3:\/\/f23\/new-metadata-en-image-58455d91acf7290275c1cab77531b7f561a11a84.jpg",
+     "name": "new-metadata-en-image-a8d0090cbd2cd3ca2ab16e3699577538f3049941.jpg",
+     "type": "Image",
+     "sequence" : 1,
+     "checksum": "f231aed5ae8c2e02ef0c5df6fe38a99b"
+     }
+  }*/
+
+  /* Expected structure of an Document item inside JSON
+  "as:documents" :  {
+     "s3:\/\/f23\/new-metadata-en-document-58455d91acf7290275c1cab77531b7f561a11a84.pdf": {
+     "dr:fid": 32, // Drupal's FID
+     "dr:for": "add_some_pdf_files", // The webform element key that generated this one
+     "url": "s3:\/\/f23\/new-metadata-en-document-58455d91acf7290275c1cab77531b7f561a11a84.pdf",
+     "name": "new-metadata-en-document-58455d91acf7290275c1cab77531b7f561a11a84.pdf",
+     "type": "Document",
+     "numberOfPages": 200,
+     "checksum": "f231aed5ae8c2e02ef0c5df6fe38a99b"
+     }
+  */
+
   /**
    * The Config for getting default IIIF settings.
    *
    * @var \Drupal\Core\Config\ConfigFactoryInterface
    */
   protected $iiifConfig;
-  /**
-   * The Current User
-   * @var \Drupal\Core\Session\AccountProxyInterface
-   */
 
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
   protected $currentUser;
 
   /**
@@ -53,26 +81,8 @@ abstract class StrawberryBaseFormatter extends FormatterBase implements Containe
    *   The ConfigFactory Container Interface.
    * @param \Drupal\Core\Session\AccountProxyInterface|null $current_user
    */
-  public function __construct(
-    $plugin_id,
-    $plugin_definition,
-    FieldDefinitionInterface $field_definition,
-    array $settings,
-    $label,
-    string $view_mode,
-    array $third_party_settings,
-    ConfigFactoryInterface $config_factory,
-    AccountProxyInterface $current_user = NULL
-  ) {
-    parent::__construct(
-      $plugin_id,
-      $plugin_definition,
-      $field_definition,
-      $settings,
-      $label,
-      $view_mode,
-      $third_party_settings
-    );
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, string $view_mode, array $third_party_settings, ConfigFactoryInterface $config_factory, AccountInterface $current_user = NULL) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
     $this->iiifConfig = $config_factory->get('format_strawberryfield.iiif_settings');
     $this->currentUser = $current_user;
   }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Created by PhpStorm.
  * User: dpino
@@ -35,16 +36,15 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
    * {@inheritdoc}
    */
   public static function defaultSettings() {
-    return
-      parent::defaultSettings() + [
-        'json_key_source' => 'as:document',
-        'max_width' => '100%',
-        'max_height' => 0,
-        'initial_page' => 1,
-        'number_pages' => 1,
-        'quality' => 'default',
-        'rotation' => '0',
-      ];
+    return parent::defaultSettings() + [
+      'json_key_source' => 'as:document',
+      'max_width' => '100%',
+      'max_height' => 0,
+      'initial_page' => 1,
+      'number_pages' => 1,
+      'quality' => 'default',
+      'rotation' => '0',
+    ];
   }
 
   /**
@@ -222,7 +222,6 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
               // we should inform to logs and continue
               // Also check if user has access and the mimeType is of an PDF.
               if ($this->checkAccess($file) && $file->getMimeType() == 'application/pdf') {
-                $documenturl = $file->getFileUri();
                 // We assume here file could not be accessible publicly
                 $route_parameters = [
                   'node' => $nodeid,
@@ -230,9 +229,7 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
                   'format' => 'default.'. pathinfo($file->getFilename(), PATHINFO_EXTENSION)
                 ];
                 $publicurl = Url::fromRoute('format_strawberryfield.iiifbinary', $route_parameters);
-                $uniqueid =
-                  'pdf-' . $items->getName(
-                  ) . '-' . $nodeuuid . '-' . $delta . '-document' . $i;
+                $uniqueid = 'pdf-' . $items->getName() . '-' . $nodeuuid . '-' . $delta . '-document' . $i;
 
                 //@TODO make a select component that is ajax driven.
                 // If we have more than a single Document, simply rebuild and reload the given $delta instead of rendering
@@ -250,9 +247,6 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
                 } else {
                   $css_style = "width:{$max_width_css}; height:{$max_height}px";
                 }
-
-
-
 
                 $elements[$delta]['pdf' . $i] = [
                   '#type' => 'html_tag',
@@ -307,4 +301,5 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
     }
     return $elements;
   }
+
 }


### PR DESCRIPTION
- Adds file cache tags to the render array of the paged formatter
- Adds new method "getFile" that could be reused on the base formatter
- Minor cleanup on baseformatter, pdf and video

Resolves #138 