### PR TITLE
ISSUE-135: Lazy load first attempt + Memory usage on Pannellum/Cantaloupe and regression on ISSUE-138 

### DIFF
--- a/format_strawberryfield.libraries.yml
+++ b/format_strawberryfield.libraries.yml
@@ -240,7 +240,7 @@ universalviewer:
   version: 4.0.0-pre.49
   license:
     name: MIT
-    url: hhttps://cdn.jsdelivr.net/npm/universalviewer@4.0.0-pre.49/LICENSE.txt
+    url: https://cdn.jsdelivr.net/npm/universalviewer@4.0.0-pre.49/LICENSE.txt
     gpl-compatible: true
   js:
     https://cdn.jsdelivr.net/npm/universalviewer@4.0.0-pre.49/dist/uv-dist-umd/UV.min.js: { external: true, minified: true, preprocess: false}
@@ -291,3 +291,21 @@ code_mirror_autosave:
     - core/drupal
     - core/drupalSettings
     - codemirror_editor/editor
+
+lozad:
+  version: 1.16.0
+  license:
+    name: MIT
+    url: https://github.com/ApoorvSaxena/lozad.js/blob/master/LICENSE
+    gpl-compatible: true
+  js:
+    https://cdn.jsdelivr.net/npm/lozad@1.16.0/dist/lozad.min.js: { external: true, minified: true, preprocess: false }
+
+lazyload_strawberry:
+  version: 1.0
+  js:
+    js/lazyload_strawberry.js: { minified: false }
+  dependencies:
+    - format_strawberryfield/lozad
+    - core/jquery
+    - core/drupal

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -30,6 +30,7 @@ function format_strawberryfield_page_attachments(array &$page) {
   $page['#attached']['library'][] = 'format_strawberryfield/iiif_iabookreader';
   $page['#attached']['library'][] = 'format_strawberryfield/pannellum';
   $page['#attached']['library'][] = 'format_strawberryfield/jsm_modeler';
+  $page['#attached']['library'][] = 'format_strawberryfield/lazyload_strawberry';
   $page['#attached']['library'][] = 'core/jquery';
   $page['#attached']['library'][] = 'core/drupal.dialog.ajax';
   $page['#attached']['library'][] = 'core/drupal.ajax';

--- a/js/iiif-iabookreader_strawberry.js
+++ b/js/iiif-iabookreader_strawberry.js
@@ -36,9 +36,21 @@
                 };
                 var br = new BookReader(options);
                 br.init();
+                // Check if Book has or not OCR using Ajax callback
+                $.ajax({
+                  type: 'GET',
+                  url: '/do/' + node_uuid + '/flavorcount/ocr/',
+                  success: function (data) {
+                    {
+                      if (data.count == 0) {
+                        $('#' + element_id + ' .BRtoolbarSectionSearch').hide();
+                      }
+                    }
+                  }
+                });
 
                 if (strawberrySettings.enableSearchArchipelago === false) {
-                  $('#' + element_id + ' .BRtoolbarSectionSearch').hide();
+
                 }
               }
           })}}

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -53,6 +53,14 @@
             });
           }
 
+          // Check what is the max canvas size this Browser/WebGL impl. allows before committing to doom the navigator.
+          var canvas = document.createElement('canvas'); // or reuse the existing
+          var gl = canvas.getContext('webgl');
+          if (gl) {
+            console.log('Max webGL texture size is' +
+              gl.getParameter(gl.MAX_TEXTURE_SIZE));
+          }
+
           const $haov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.haov;
           const $vaov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.vaov;
           const $minYaw = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.minYaw;

--- a/js/lazyload_strawberry.js
+++ b/js/lazyload_strawberry.js
@@ -1,0 +1,18 @@
+(function ($, Drupal, lozad) {
+
+    'use strict';
+
+    Drupal.behaviors.format_strawberryfield_lazyload = {
+        attach: function(context) {
+          if ($(context).find('img.iiif-lazy').length > 0) {
+                  console.log('Loading Lazy Load for Images with iiif-lazy class');
+                  const observer = lozad('img.iiif-lazy', {
+                    rootMargin: '100px 0px', // syntax similar to that of CSS Margin
+                    threshold: 0.1, // ratio of element convergence
+                    enableAutoReload: true // it will reload the new image when validating attributes changes
+                  });
+                  observer.observe();
+                };
+        }
+    };
+})(jQuery, Drupal, lozad);

--- a/src/Form/IiifSettingsForm.php
+++ b/src/Form/IiifSettingsForm.php
@@ -56,12 +56,12 @@ class IiifSettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('format_strawberryfield.iiif_settings');
     $form['info'] = [
-      '#markup' => $this->t('This IIIF Server configuration URLs are used as defaults for field formatters using IIIF, but can be overriden on a one by one basis when setting up your formatters for each Display Mode.'),
+      '#markup' => $this->t('This IIIF Server configuration URLs are used as defaults for field formatters using IIIF, but can be overridden on a one by one basis when setting up your formatters for each Display Mode.'),
       ];
 
     $form['pub_server_url'] = [
       '#type' => 'url',
-      '#title' => $this->t('Base URL of your IIIF Media Server public accesible from the Outside World.'),
+      '#title' => $this->t('Base URL of your IIIF Media Server public accessible from the Outside World.'),
       '#description' => $this->t('Please provide a publicly accessible IIIF server URL. This URL will be used for AJAX and JS calls. Trailing Slashes will be removed.'),
       '#default_value' => !empty($config->get('pub_server_url')) ? $config->get('pub_server_url') : 'http://localhost:8183/iiif/2',
       '#required' => TRUE
@@ -70,7 +70,7 @@ class IiifSettingsForm extends ConfigFormBase {
     $form['int_server_url'] = [
       '#type' => 'url',
       '#title' => $this->t('Base URL of your IIIF Media Server accesible from inside this Webserver.'),
-      '#description' => $this->t('Please provide Internal IIIF server URL. This URL will be used by Internal Server calls and needs to be locally accesible by your server, e.g 127.0.0.1 or an local Docker alias. Trailing Slashes will be removed.'),
+      '#description' => $this->t('Please provide Internal IIIF server URL. This URL will be used by Internal Server calls and needs to be locally accessible by your server, e.g 127.0.0.1 or an local Docker alias. Trailing Slashes will be removed.'),
       '#default_value' => !empty($config->get('int_server_url')) ? $config->get('int_server_url') : 'http://esmero-cantaloupe:8182/iiif/2',
       '#required' => TRUE
     ];

--- a/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
@@ -439,7 +439,6 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
           // parameter, it doesn't work properly at the moment and we have opened an
           // issue to fix it, meanwhile it's hidden via jQuery.
           // @see https://github.com/internetarchive/bookreader/pull/613
-          'enableSearchArchipelago' => $this->searchEnabled($item),
         ];
       }
     }
@@ -503,7 +502,6 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
             'width' => $max_width_css,
             'height' => max($max_height, 520),
             // @see self::processElementforMetadatadisplays()
-            'enableSearchArchipelago' => $this->searchEnabled($item),
           ];
         }
       }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -21,8 +21,9 @@ use Drupal\Core\StreamWrapper\StreamWrapperManager;
  *
  * @FieldFormatter(
  *   id = "strawberry_pannellum_formatter",
- *   label = @Translation("Strawberry Field Panorama Formatter using Pannellum and IIIF"),
- *   class = "\Drupal\format_strawberryfield\Plugin\Field\FieldFormatter\StrawberryPannellumFormatter",
+ *   label = @Translation("Strawberry Field Panorama Formatter using Pannellum
+ *   and IIIF"), class =
+ *   "\Drupal\format_strawberryfield\Plugin\Field\FieldFormatter\StrawberryPannellumFormatter",
  *   field_types = {
  *     "strawberryfield_field"
  *   },
@@ -293,7 +294,8 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
                   $iiifsizes = array_reverse($iiifsizes);
                   foreach ($iiifsizes as $iiifsize) {
                     $max_iiif_sizes = $iiifsize;
-                    if (round($iiifsize['height'] * $iiifsize['width'] * 16 / 8 / 1024 / 1024) <= 256) {
+                    // 16 bits, 3 Channels. If PNG it should be 4 channels.
+                    if (round($iiifsize['height'] * $iiifsize['width'] * 16 * 3 / 8 / 1024 / 1024) <= 256) {
                       break;
                     }
                   }
@@ -318,7 +320,8 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
                     );
                   }
                   // Pannellum recommends max 4096 pixel width images for WebGl. Lets use that as max.
-                  $max_width_source_comp = ($max_iiif_sizes['width'] >= 32768) ? '32768,' : $max_iiif_sizes['width'] . ',';
+                  // Standard webGL Max is 16384 but Modern OSX with newer Intel reports double.
+                  $max_width_source_comp = ($max_iiif_sizes['width'] >= 16384) ? '16384,' : $max_iiif_sizes['width'] . ',';
                   $max_width_source_mob = ($max_iiif_sizes['width'] >= 4096) ? '4096,' : $max_iiif_sizes['width'] . ',';
                   $iiifserverimg = "{$this->getIiifUrls()['public']}/{$iiifidentifier}" . "/full/{$max_width_source_comp}/0/default.jpg";
                   $iiifserverimg_mobile = "{$this->getIiifUrls()['public']}/{$iiifidentifier}" . "/full/{$max_width_source_mob}/0/default.jpg";


### PR DESCRIPTION
# What is this?

See #135. Simple Lazyload using a class iiid-lazy. If `data-src` is used instead of `src` attributes in an `img` tag are used then we will only load those images once they enter then Viewport (+100px). had to make some small JS changes to deal also with Views that refresh via Ajax, and we may do better.

Also:

Fix on how we calculate memory usage for Large Panoramas. I now multiply by 3x (RGB) and stay as "discrete" as I can. This will need in the future a real setting based on how much XMX we gave Cantaloupe. For now 256mb is as conservative as we can go for large images. Images less than 16K can use 'MAX' to avoid derivative processing of course.

Last:

I tackled here (quickly) ISSUE-138 via Ajax @pcambra. Why? On large Objects, clearing caches the whole time while the NODE nor the image was really changing was affecting performance. I feel performance is key. Once I do a full review of the cache tagging I may go back but via Ajax/Controller this works for now without affecting cache.





