### PR TITLE
WIP: Issue 145 -- Add twig extension for load entity ids by entity label

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "ml/json-ld": "^1.2",
         "mtdowling/jmespath.php":"^2.5",
         "strawberryfield/strawberryfield":"dev-1.0.0-RC2",
-        "drupal/twig_tweak": "^2.6",
         "drupal/webform": "^5.23 || ^6.0",
         "ext-json": "*"
     }

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "ml/json-ld": "^1.2",
         "mtdowling/jmespath.php":"^2.5",
         "strawberryfield/strawberryfield":"dev-1.0.0-RC2",
+        "drupal/twig_tweak": "^2.6",
         "drupal/webform": "^5.23 || ^6.0",
         "ext-json": "*"
     }

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -44,44 +44,40 @@ class TwigExtension extends \Twig_Extension {
    *   An array of entity objects or NULL if no entity with label exists.
    */
   public function load_entities_by_label(string $label, string $entity_type, string $bundle_identifier = '', $limit = 1, $langcode = NULL): ?array {
-    $database = \Drupal::database();
+    $label = \Drupal::database()->escapeLike($label);
     switch($entity_type) {
       case 'node':
-        $query = $database->select('node_field_data', 'n')
-          ->addField('n', 'nid', 'id')
-          ->condition('n.title', $database->escapeLike($label), 'LIKE')
+        $query = \Drupal::entityQuery('node')
+          ->condition('title', $label, 'LIKE')
           ->range(0,$limit);
         if($bundle_identifier) {
-          $query->condition('n.type', $bundle_identifier);
+          $query->condition('type', $bundle_identifier);
         }
-        $ids = $query->execute()->fetchCol();
+        $ids = $query->execute();
         break;
       case 'taxonomy_term':
-        $query = $database->select('taxonomy_term_field_data', 't')
-          ->addField('t', 'tid', 'id')
-          ->condition('t.name', $database->escapeLike($label), 'LIKE')
+        $query = \Drupal::entityQuery('taxonomy_term')
+          ->condition('name', $label, 'LIKE')
           ->range(0,$limit);
         if($bundle_identifier) {
-          $query->condition('t.vid', $bundle_identifier);
+          $query->condition('vid', $bundle_identifier);
         }
-        $ids = $query->execute()->fetchCol();
+        $ids = $query->execute();
         break;
       case 'group':
-        $query = $database->select('groups_field_data', 'g')
-          ->addField('g', 'id', 'id')
-          ->condition('g.label', $database->escapeLike($label), 'LIKE')
+        $query = \Drupal::entityQuery('group')
+          ->condition('label', $label, 'LIKE')
           ->range(0,$limit);
         if($bundle_identifier) {
-          $query->condition('g.type', $bundle_identifier);
+          $query->condition('type', $bundle_identifier);
         }
-        $ids = $query->execute()->fetchCol();
+        $ids = $query->execute();
         break;
       case 'user':
-        $query = $database->select('users_field_data', 'u')
-          ->addField('u', 'uid', 'id')
-          ->condition('u.name', $database->escapeLike($label), 'LIKE')
+        $query = \Drupal::entityQuery('user')
+          ->condition('name', $label, 'LIKE')
           ->range(0,$limit);
-        $ids = $query->execute()->fetchCol();
+        $ids = $query->execute();
         break;
     }
 

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -25,7 +25,7 @@ class TwigExtension extends \Twig_Extension {
   }
 
   /**
-   * Returns entity objects with matching title/name/label in the specified language context.
+   * Returns render arrays of entities with matching title/name/label in the specified view mode and language context.
    *
    * Supported entity types are node, taxonomy_term, group, and user.
    *
@@ -45,13 +45,12 @@ class TwigExtension extends \Twig_Extension {
    *   (optional) For which language the entity should be rendered, defaults to
    *   the current content language.
    *
-   * @return null|[Drupal\Core\Entity\EntityInterface]
-   *   An array of entity objects or NULL if no entity with label exists.
-   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
-   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @return null|array
+   *   An array of render arrays for the entities found, or NULL if the entity does not exist.
    */
   public function load_entities_by_label(string $label, string $entity_type, string $bundle_identifier = '', $view_mode = 'default', $check_access = TRUE, $limit = 1, $langcode = NULL): ?array {
     $label = \Drupal::database()->escapeLike($label);
+    /** @var \Drupal\Core\Entity\Query\QueryInterface $query */
     switch($entity_type) {
       case 'node':
         $query = \Drupal::entityTypeManager()->getStorage('node')->getQuery();

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -26,6 +26,15 @@ class TwigExtension extends \Twig_Extension {
   }
 
   /**
+   * @inheritDoc
+   */
+  public function getFunctions() {
+    return [
+        new \Twig_SimpleFunction('sbf_entity_ids_by_label', [$this, 'entityIdsByLabel']),
+      ];
+  }
+
+  /**
    * Returns entity ids of entities with matching title/name/label.
    *
    * Supported entity types are node, taxonomy_term, group, and user.
@@ -36,80 +45,56 @@ class TwigExtension extends \Twig_Extension {
    *   The entity type.
    * @param  string  $bundle_identifier
    *   The entity bundle (may be empty)
-   * @param  bool  $check_access
-   *   Whether to check for entity access permission (default TRUE).
    * @param  int  $limit
    *   Restrict to number of results. Capped at no more than 100.
-   * @param  null  $langcode
-   *   (optional) For which language the entity should be rendered, defaults to
-   *   the current content language.
    *
    * @return null|array
    *   An array of render arrays for the entities found, or NULL if the entity does not exist.
    */
-  public function sbf_entity_ids_by_label(string $label, string $entity_type, string $bundle_identifier = '', $check_access = TRUE, $limit = 1, $langcode = NULL): ?array {
-    $label = \Drupal::database()->escapeLike($label);
-    $limit = min($limit, 100);
-    /** @var \Drupal\Core\Entity\Query\QueryInterface $query */
-    try {
-      switch($entity_type) {
-        case 'node':
-          $query = \Drupal::entityTypeManager()->getStorage('node')->getQuery();
-          $query->condition('title', $label, 'LIKE')
-            ->accessCheck($check_access)
-            ->range(0,$limit);
-          if($bundle_identifier) {
-            $query->condition('type', $bundle_identifier);
-          }
-          $ids = $query->execute();
-          break;
-        case 'taxonomy_term':
-          $query = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->getQuery();
-          $query->condition('name', $label, 'LIKE')
-            ->accessCheck($check_access)
-            ->range(0,$limit);
-          if($bundle_identifier) {
-            $query->condition('vid', $bundle_identifier);
-          }
-          $ids = $query->execute();
-          break;
-        case 'group':
-          $query = \Drupal::entityTypeManager()->getStorage('group')->getQuery();
-          $query->condition('label', $label, 'LIKE')
-            ->accessCheck($check_access)
-            ->range(0,$limit);
-          if($bundle_identifier) {
-            $query->condition('type', $bundle_identifier);
-          }
-          $ids = $query->execute();
-          break;
-        case 'user':
-          $query = \Drupal::entityTypeManager()->getStorage('user')->getQuery();
-          $query->condition('name', $label, 'LIKE')
-            ->accessCheck($check_access)
-            ->range(0,$limit);
-          $ids = $query->execute();
-          break;
+  public function entityIdsByLabel(
+    string $label,
+    string $entity_type,
+    string $bundle_identifier = '',
+    $limit = 1
+  ): ?array {
+    $fields = [
+      'node' => ['title', 'type'],
+      'taxonomy_term' => ['name', 'vid'],
+      'group' => ['label', 'type'],
+      'user' => ['name', NULL],
+    ];
+    $label_field = $fields[$entity_type][0] ?? NULL;
+    if ($label_field) {
+      $bundle_field = $fields[$entity_type][1] ?? NULL;
+      $limit = min($limit, 100);
+      /** @var \Drupal\Core\Entity\Query\QueryInterface $query */
+      try {
+        $query = \Drupal::entityTypeManager()->getStorage('node')->getQuery();
+        $query->condition($label_field, $label);
+        $query->range(0, $limit);
+        if ($bundle_identifier && $bundle_field) {
+          $query->condition($bundle_field, $bundle_identifier);
+        }
+        $ids = $query->execute();
+
+      } catch (\Exception $exception) {
+        $responseMessage = $exception->getMessage();
+        $message = t('@exception_type thrown in @file:@line while querying for @entity_type entity ids matching "@label". Message: @response',
+          [
+            '@exception_type' => get_class($exception),
+            '@file' => $exception->getFile(),
+            '@line' => $exception->getLine(),
+            '@entity_type' => $entity_type,
+            '@label' => $label,
+            '@response' => $responseMessage,
+          ]);
+        \Drupal::logger('format_strawberryfield')->warning($message);
+        return NULL;
       }
-    }
 
-    catch(\Exception $exception) {
-      $responseMessage = $exception->getMessage();
-      $message = $this->t('@exception_type thrown in @file:@line while querying for @entity_type entity ids matching "@label". Message: @response',
-        [
-          '@exception_type' => get_class($exception),
-          '@file' => $exception->getFile(),
-          '@line' => $exception->getLine(),
-          '@entity_type' => $entity_type,
-          '@label' => $label,
-          '@response' => $responseMessage
-        ]);
-      \Drupal::logger('format_strawberryfield')->warning($message);
-      return NULL;
-    }
-
-    if(!empty($ids)) {
-      return $ids;
+      if (!empty($ids)) {
+        return $ids;
+      }
     }
     return NULL;
   }

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -48,57 +48,91 @@ class TwigExtension extends \Twig_Extension {
    * @return null|array
    *   An array of render arrays for the entities found, or NULL if the entity does not exist.
    */
-  public function load_entities_by_label(string $label, string $entity_type, string $bundle_identifier = '', $view_mode = 'default', $check_access = TRUE, $limit = 1, $langcode = NULL): ?array {
+  public function format_strawberryfield_load_entities_by_label(string $label, string $entity_type, string $bundle_identifier = '', $view_mode = 'default', $check_access = TRUE, $limit = 1, $langcode = NULL): ?array {
     $label = \Drupal::database()->escapeLike($label);
     $limit = min($limit, 100);
     /** @var \Drupal\Core\Entity\Query\QueryInterface $query */
-    switch($entity_type) {
-      case 'node':
-        $query = \Drupal::entityTypeManager()->getStorage('node')->getQuery();
-        $query->condition('title', $label, 'LIKE')
-          ->accessCheck($check_access)
-          ->range(0,$limit);
-        if($bundle_identifier) {
-          $query->condition('type', $bundle_identifier);
-        }
-        $ids = $query->execute();
-        break;
-      case 'taxonomy_term':
-        $query = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->getQuery();
-        $query->condition('name', $label, 'LIKE')
-          ->accessCheck($check_access)
-          ->range(0,$limit);
-        if($bundle_identifier) {
-          $query->condition('vid', $bundle_identifier);
-        }
-        $ids = $query->execute();
-        break;
-      case 'group':
-        $query = \Drupal::entityTypeManager()->getStorage('group')->getQuery();
-        $query->condition('label', $label, 'LIKE')
-          ->accessCheck($check_access)
-          ->range(0,$limit);
-        if($bundle_identifier) {
-          $query->condition('type', $bundle_identifier);
-        }
-        $ids = $query->execute();
-        break;
-      case 'user':
-        $query = \Drupal::entityTypeManager()->getStorage('user')->getQuery();
-        $query->condition('name', $label, 'LIKE')
-          ->accessCheck($check_access)
-          ->range(0,$limit);
-        $ids = $query->execute();
-        break;
+    try {
+      switch($entity_type) {
+        case 'node':
+          $query = \Drupal::entityTypeManager()->getStorage('node')->getQuery();
+          $query->condition('title', $label, 'LIKE')
+            ->accessCheck($check_access)
+            ->range(0,$limit);
+          if($bundle_identifier) {
+            $query->condition('type', $bundle_identifier);
+          }
+          $ids = $query->execute();
+          break;
+        case 'taxonomy_term':
+          $query = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->getQuery();
+          $query->condition('name', $label, 'LIKE')
+            ->accessCheck($check_access)
+            ->range(0,$limit);
+          if($bundle_identifier) {
+            $query->condition('vid', $bundle_identifier);
+          }
+          $ids = $query->execute();
+          break;
+        case 'group':
+          $query = \Drupal::entityTypeManager()->getStorage('group')->getQuery();
+          $query->condition('label', $label, 'LIKE')
+            ->accessCheck($check_access)
+            ->range(0,$limit);
+          if($bundle_identifier) {
+            $query->condition('type', $bundle_identifier);
+          }
+          $ids = $query->execute();
+          break;
+        case 'user':
+          $query = \Drupal::entityTypeManager()->getStorage('user')->getQuery();
+          $query->condition('name', $label, 'LIKE')
+            ->accessCheck($check_access)
+            ->range(0,$limit);
+          $ids = $query->execute();
+          break;
+      }
+    }
+    catch(\Exception $exception) {
+      $responseMessage = $exception->getMessage();
+      $message = $this->t('@exception_type thrown in @file:@line while querying for @entity_type entity ids matching "@label". Message: @response',
+        [
+          '@exception_type' => get_class($exception),
+          '@file' => $exception->getFile(),
+          '@line' => $exception->getLine(),
+          '@entity_type' => $entity_type,
+          '@label' => $label,
+          '@response' => $responseMessage
+        ]);
+      \Drupal::logger('format_strawberryfield')->warning($message);
+      return NULL;
     }
 
     if(!empty($ids)) {
-      $entities = [];
-      $twig_tweak = new TwigTweakExtension();
-      foreach($ids as $id) {
-        $entities[$id] = $twig_tweak->drupalEntity($entity_type, $id, $view_mode, $langcode);
+      try {
+        $entities = [];
+        $twig_tweak = new TwigTweakExtension();
+        foreach ($ids as $id) {
+          $entities[$id] = $twig_tweak->drupalEntity($entity_type, $id,
+            $view_mode, $langcode);
+        }
+        return $entities;
       }
-      return $entities;
+      catch(\Exception $exception) {
+        $responseMessage = $exception->getMessage();
+        $message = $this->t('@exception_type thrown in @file:@line while attempting to render @entity_type with id @id using Drupal\twig_tweak\TwigExtension::drupalEntity. Message: @response',
+          [
+            '@exception_type' => get_class($exception),
+            '@file' => $exception->getFile(),
+            '@line' => $exception->getLine(),
+            '@entity_type' => $entity_type,
+            '@id' => $id,
+            '@response' => $responseMessage
+          ]);
+        \Drupal::logger('format_strawberryfield')->warning($message);
+        return NULL;
+
+      }
     }
 
     return NULL;

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -42,12 +42,11 @@ class TwigExtension extends \Twig_Extension {
   /**
    * Returns entity ids of entities with matching title/name/label.
    *
-   * Supported entity types are node, taxonomy_term, group, and user.
-   *
    * @param  string  $label
    *   The entity label that we're looking for
    * @param  string  $entity_type
    *   The entity type.
+   *   Supported entity types are node, taxonomy_term, group, and user.
    * @param  string  $bundle_identifier
    *   The entity bundle (may be empty)
    * @param  int  $limit
@@ -75,7 +74,7 @@ class TwigExtension extends \Twig_Extension {
       $limit = min($limit, 100);
       /** @var \Drupal\Core\Entity\Query\QueryInterface $query */
       try {
-        $query = \Drupal::entityTypeManager()->getStorage('node')->getQuery();
+        $query = \Drupal::entityTypeManager()->getStorage($entity_type)->getQuery();
         $query->condition($label_field, $label);
         $query->range(0, $limit);
         if ($bundle_identifier && $bundle_field) {
@@ -84,7 +83,6 @@ class TwigExtension extends \Twig_Extension {
         $ids = $query->execute();
 
       } catch (\Exception $exception) {
-        $responseMessage = $exception->getMessage();
         $message = t('@exception_type thrown in @file:@line while querying for @entity_type entity ids matching "@label". Message: @response',
           [
             '@exception_type' => get_class($exception),
@@ -92,7 +90,7 @@ class TwigExtension extends \Twig_Extension {
             '@line' => $exception->getLine(),
             '@entity_type' => $entity_type,
             '@label' => $label,
-            '@response' => $responseMessage,
+            '@response' => $exception->getMessage(),
           ]);
         \Drupal::logger('format_strawberryfield')->warning($message);
         return NULL;

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -38,9 +38,9 @@ class TwigExtension extends \Twig_Extension {
    * @param  string  $view_mode
    *   The view mode for the render array that should be returned for each entity.
    * @param  bool  $check_access
-   *
+   *   Whether to check for entity access permission (default TRUE).
    * @param  int  $limit
-   *   Restrict to number of results.
+   *   Restrict to number of results. Capped at no more than 100.
    * @param  null  $langcode
    *   (optional) For which language the entity should be rendered, defaults to
    *   the current content language.
@@ -50,6 +50,7 @@ class TwigExtension extends \Twig_Extension {
    */
   public function load_entities_by_label(string $label, string $entity_type, string $bundle_identifier = '', $view_mode = 'default', $check_access = TRUE, $limit = 1, $langcode = NULL): ?array {
     $label = \Drupal::database()->escapeLike($label);
+    $limit = min($limit, 100);
     /** @var \Drupal\Core\Entity\Query\QueryInterface $query */
     switch($entity_type) {
       case 'node':

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -22,4 +22,86 @@ class TwigExtension extends \Twig_Extension {
       || (\function_exists($func = 'is_'.$type) && $func($value))
       || $value instanceof $type;
   }
+
+  /**
+   * Returns entity objects with matching title/name/label in the specified language context.
+   *
+   * Supported entity types are node, taxonomy_term, group, and user.
+   *
+   * @param  string  $label
+   *   The entity label that we're looking for
+   * @param  string  $entity_type
+   *   The entity type.
+   * @param  string  $bundle_identifier
+   *   The entity bundle (may be empty)
+   * @param  numeric  $limit
+   *   Restrict to number of results.
+   * @param  null  $langcode
+   *   (optional) For which language the entity should be rendered, defaults to
+   *   the current content language.
+   *
+   * @return null|[Drupal\Core\Entity\EntityInterface]
+   *   An array of entity objects or NULL if no entity with label exists.
+   */
+  public function load_entities_by_label(string $label, string $entity_type, string $bundle_identifier = '', $limit = 1, $langcode = NULL): ?array {
+    $database = \Drupal::database();
+    switch($entity_type) {
+      case 'node':
+        $query = $database->select('node_field_data', 'n')
+          ->addField('n', 'nid', 'id')
+          ->condition('n.title', $database->escapeLike($label), 'LIKE')
+          ->range(0,$limit);
+        if($bundle_identifier) {
+          $query->condition('n.type', $bundle_identifier);
+        }
+        $ids = $query->execute()->fetchCol();
+        break;
+      case 'taxonomy_term':
+        $query = $database->select('taxonomy_term_field_data', 't')
+          ->addField('t', 'tid', 'id')
+          ->condition('t.name', $database->escapeLike($label), 'LIKE')
+          ->range(0,$limit);
+        if($bundle_identifier) {
+          $query->condition('t.vid', $bundle_identifier);
+        }
+        $ids = $query->execute()->fetchCol();
+        break;
+      case 'group':
+        $query = $database->select('groups_field_data', 'g')
+          ->addField('g', 'id', 'id')
+          ->condition('g.label', $database->escapeLike($label), 'LIKE')
+          ->range(0,$limit);
+        if($bundle_identifier) {
+          $query->condition('g.type', $bundle_identifier);
+        }
+        $ids = $query->execute()->fetchCol();
+        break;
+      case 'user':
+        $query = $database->select('users_field_data', 'u')
+          ->addField('u', 'uid', 'id')
+          ->condition('u.name', $database->escapeLike($label), 'LIKE')
+          ->range(0,$limit);
+        $ids = $query->execute()->fetchCol();
+        break;
+    }
+
+    if(!empty($ids)) {
+      $entities = $this->getEntityTypeManager()->getStorage($entity_type)->loadMultiple($ids);
+      if (empty($entities)) {
+        return NULL;
+      }
+
+      // Get the entities in the specified context language.
+      $entityRepository = $this->getEntityRepository();
+      $translated_entities = [];
+      foreach($entities as $entity) {
+        $translated_entities[$entity->id()] = $entityRepository->getTranslationFromContext($entity, $langcode);
+      }
+      return $translated_entities;
+    }
+
+    return NULL;
+
+  }
+
 }

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace Drupal\format_strawberryfield;
-use Drupal\Core\Access\AccessResult;
-use Drupal\Core\Cache\CacheableMetadata;
+
 use Twig\TwigTest;
 
 /**
@@ -11,17 +11,21 @@ use Twig\TwigTest;
  */
 class TwigExtension extends \Twig_Extension {
 
-  public function getTests(): array
-  {
+  public function getTests(): array {
     return [
       new TwigTest('instanceof', [$this, 'is_instanceof']),
     ];
   }
 
-  public function is_instanceof($value, string $type): bool
-  {
-    return ('null' === $type && null === $value)
-      || (\function_exists($func = 'is_'.$type) && $func($value))
+  /**
+   * @param $value
+   * @param  string  $type
+   *
+   * @return bool
+   */
+  public function is_instanceof($value, string $type): bool {
+    return ('null' === $type && NULL === $value)
+      || (\function_exists($func = 'is_' . $type) && $func($value))
       || $value instanceof $type;
   }
 
@@ -30,8 +34,9 @@ class TwigExtension extends \Twig_Extension {
    */
   public function getFunctions() {
     return [
-        new \Twig_SimpleFunction('sbf_entity_ids_by_label', [$this, 'entityIdsByLabel']),
-      ];
+      new \Twig_SimpleFunction('sbf_entity_ids_by_label',
+        [$this, 'entityIdsByLabel']),
+    ];
   }
 
   /**
@@ -49,7 +54,8 @@ class TwigExtension extends \Twig_Extension {
    *   Restrict to number of results. Capped at no more than 100.
    *
    * @return null|array
-   *   An array of render arrays for the entities found, or NULL if the entity does not exist.
+   *   An array of render arrays for the entities found, or NULL if the entity
+   *   does not exist.
    */
   public function entityIdsByLabel(
     string $label,


### PR DESCRIPTION
# What?

This is a simplified version of the original feature request: https://github.com/esmero/format_strawberryfield/issues/145. Rather than load entity data, this twig extension just loads entity ids of entities whose labels match the provided name.

# To test
Put something like the following example into your twig template, with tests for each of the supported entity types: node, taxonomy_term, user, group. 

Example: Given a field in the twig data with a name of a taxonomy term, get the first taxonomy term ids from all terms with that label in a particular vocabulary:
```
{% if data.term_name %}
    {% set terms = sbf_entity_ids_by_label(data.term_name, 'taxonomy_term', 'my_vocabulary') %}
    {% if terms[0] %}
    "my_term":  {{ terms[0]|json_encode|raw }},
    {% endif %}
{% endif %}
```