### PR TITLE
ISSUE-151: Hot Spot URLs and Fixes IABookreader load search and Mode (1up) from URL

### DIFF
--- a/format_strawberryfield.libraries.yml
+++ b/format_strawberryfield.libraries.yml
@@ -21,30 +21,30 @@ iiif_openseadragon_strawberry:
 
 iiif_iabookreader:
   remote: https://openlibrary.org/dev/docs/bookreader
-  version: 4.21.0
+  version: 4.40.3
   license:
     name: GNU Affero General Public License v3.0
-    url: https://github.com/internetarchive/bookreader/blob/4.21.0/LICENSE
+    url: https://github.com/internetarchive/bookreader/blob/4.40.3/LICENSE
     gpl-compatible: true
   header: true
   css:
     component:
       css/iabookreader.css: {}
-      https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.21.0/BookReader/BookReader.css: { external: true}
+      https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.40.3/BookReader/BookReader.css: { external: true}
   js:
     js/jquery_dollar.js: {preprocess: false, minified: false, weight: -10}
     https://cdn.jsdelivr.net/npm/jquery.dragscrollable@1.0.0/dragscrollable.min.js: { external: true, minified: true, preprocess: false}
     https://cdn.jsdelivr.net/npm/jquery-colorbox@1.6.4/jquery.colorbox.min.js: { external: true, minified: true, preprocess: false}
     https://cdn.jsdelivr.net/npm/jquery.mmenu@7.3.3/dist/jquery.mmenu.all.min.js: { external: true, minified: true, preprocess: false}
     https://cdn.jsdelivr.net/npm/jquery.mmenu@7.3.3/dist/addons/navbars/jquery.mmenu.navbars.js: { external: true, minified: true, preprocess: false}
-    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.21.0/BookReader/jquery-ui-1.12.0.min.js: { external: true, minified: true, preprocess: false}
-    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.21.0/BookReader/dragscrollable-br.js: { external: true, minified: false, preprocess: false}
-    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.21.0/BookReader/BookReader.js: { external: true, minified: false, preprocess: false,  weight: -9}
-    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.21.0/BookReader/plugins/plugin.url.js: { external: true, minified: false, preprocess: false, weight: -8}
-    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.21.0/BookReader/plugins/plugin.resume.js: { external: true, minified: false, preprocess: false, weight: -8}
-    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.21.0/BookReader/plugins/plugin.mobile_nav.js: { external: true, minified: false, preprocess: false, weight: -8}
-    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.21.0/BookReader/plugins/plugin.chapters.js: { external: true, minified: false, preprocess: false, weight: -8}
-    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.21.0/BookReader/plugins/plugin.search.js: { external: true, minified: false, preprocess: false, weight: -8}
+    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.40.3/BookReader/jquery-ui-1.12.0.min.js: { external: true, minified: true, preprocess: false}
+    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.40.3/BookReader/dragscrollable-br.js: { external: true, minified: false, preprocess: false}
+    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.40.3/BookReader/BookReader.js: { external: true, minified: false, preprocess: false,  weight: -9}
+    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.40.3/BookReader/plugins/plugin.url.js: { external: true, minified: false, preprocess: false, weight: -8}
+    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.40.3/BookReader/plugins/plugin.resume.js: { external: true, minified: false, preprocess: false, weight: -8}
+    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.40.3/BookReader/plugins/plugin.mobile_nav.js: { external: true, minified: false, preprocess: false, weight: -8}
+    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.40.3/BookReader/plugins/plugin.chapters.js: { external: true, minified: false, preprocess: false, weight: -8}
+    https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.40.3/BookReader/plugins/plugin.search.js: { external: true, minified: false, preprocess: false, weight: -8}
   dependencies:
     - core/jquery
     - core/jquery.ui

--- a/js/iiif-iabookreader_strawberry.js
+++ b/js/iiif-iabookreader_strawberry.js
@@ -49,9 +49,6 @@
                   }
                 });
 
-                if (strawberrySettings.enableSearchArchipelago === false) {
-
-                }
               }
           })}}
 })(jQuery, Drupal, drupalSettings);

--- a/js/iiif-iabookreader_strawberry.js
+++ b/js/iiif-iabookreader_strawberry.js
@@ -27,7 +27,7 @@
                   iiifmanifest: strawberrySettings['manifest'],
                   iiifdefaultsequence: null, //If null given will use the first sequence found.
                   maxWidth: 800,
-                  imagesBaseURL: 'https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.21.0/BookReader/images/',
+                  imagesBaseURL: 'https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.40.3/BookReader/images/',
                   server: server,
                   bookId: node_uuid,
                   enableSearch: true,

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -117,7 +117,7 @@
             ) {
               $.each(drupalSettings.format_strawberryfield.pannellum[element_id].hotspots, function (id, hotspotdata) {
                 // Also add Popups for Standalone Panoramas if they have an URL.
-                if (hotspotdata.hasOwnProperty('URL')) {
+                if (hotspotdata.hasOwnProperty('URL') && hotspotdata.URL !== null) {
                   if (hotspotdata.URL.indexOf('http://') === 0 || hotspotdata.URL.indexOf('https://') === 0) {
                     hotspotdata.text = hotspotdata.text + Drupal.t(' (External URL)');
                   }
@@ -165,7 +165,7 @@
                 // Add Model Window Behaviour to hotSpots with Links
                 if (data.hasOwnProperty('hotSpots')) {
                   $.each(data.hotSpots, function (hotspotid, hotspotdata) {
-                    if (hotspotdata.hasOwnProperty('URL')) {
+                    if (hotspotdata.hasOwnProperty('URL') && hotspotdata.URL !== null) {
                       if (hotspotdata.URL.indexOf('http://') === 0 || hotspotdata.URL.indexOf('https://') === 0) {
                         hotspotdata.text = hotspotdata.text + Drupal.t(' (External URL)');
                       }

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -17,19 +17,60 @@
 
   function FormatStrawberryfieldhotspotPopUp(event, url) {
     if (url !== null) {
-      var $myDialog = $('<div class="format-strawberryfield-hotspot-dialog"></div>').appendTo('body');
-      var ajaxObject = Drupal.ajax({
-        url: url,
-        dialogType: 'modal',
-        dialog: {width: '800px'},
-        progress: {
-          type: 'fullscreen',
-          message: Drupal.t('Please wait...')
+      let fullscreenelement = document.fullscreenElement || document.mozFullScreen || document.webkitFullscreenElement || document.msFullscreenElement;
+      if (url.indexOf('http://') === 0 || url.indexOf('https://') === 0) {
+        var open = confirm(Drupal.t('Confirm to open URL ' + url + ' in a new Window'));
+        if (open == true) {
+          window.open(url, '_blank');
+        } else {
+          if (typeof (fullscreenelement) != 'undefined') {
+            event.preventDefault();
+            // Let's delay the back to Fullscreen to give the cancel some time to return
+            setTimeout(function () {
+              var $fse = document.querySelector('#' + fullscreenelement.id);
+              try {
+                if ($fse.requestFullscreen) {
+                  $fse.requestFullscreen();
+                } else if ($fse.mozRequestFullScreen) {
+                  $fse.mozRequestFullScreen();
+                } else if ($fse.msRequestFullscreen) {
+                  $fse.msRequestFullscreen();
+                } else {
+                  document.webkitCancelFullScreen();
+                  $fse.webkitRequestFullScreen();
+                }
+              } catch (event) {
+                // Fullscreen doesn't work
+              }
+              // Add tasks to do
+            }, 100);
+
+            return false;
+          }
         }
-      });
-      ajaxObject.execute();
-      event.preventDefault();
+      }
+      else {
+        var ajaxObject = Drupal.ajax({
+          url: url,
+          dialogType: 'modal',
+          dialog: {width: '800px'},
+          progress: {
+            type: 'fullscreen',
+            message: Drupal.t('Please wait...')
+          }
+        });
+        if (typeof (fullscreenelement) != 'undefined') {
+          try {
+            document.webkitCancelFullScreen();
+          }
+          catch (event) {
+            // Fullscreen doesn't work
+          }
+        }
+        ajaxObject.execute();
+      }
     }
+    event.preventDefault();
   }
 
 
@@ -77,6 +118,12 @@
               $.each(drupalSettings.format_strawberryfield.pannellum[element_id].hotspots, function (id, hotspotdata) {
                 // Also add Popups for Standalone Panoramas if they have an URL.
                 if (hotspotdata.hasOwnProperty('URL')) {
+                  if (hotspotdata.URL.indexOf('http://') === 0 || hotspotdata.URL.indexOf('https://') === 0) {
+                    hotspotdata.text = hotspotdata.text + Drupal.t(' (External URL)');
+                  }
+                  else {
+                    hotspotdata.text = hotspotdata.text + Drupal.t(' (Digital Object)');
+                  }
                   hotspotdata.clickHandlerFunc = Drupal.FormatStrawberryfieldhotspotPopUp;
                   hotspotdata.clickHandlerArgs = hotspotdata.URL;
                 }
@@ -119,12 +166,16 @@
                 if (data.hasOwnProperty('hotSpots')) {
                   $.each(data.hotSpots, function (hotspotid, hotspotdata) {
                     if (hotspotdata.hasOwnProperty('URL')) {
+                      if (hotspotdata.URL.indexOf('http://') === 0 || hotspotdata.URL.indexOf('https://') === 0) {
+                        hotspotdata.text = hotspotdata.text + Drupal.t(' (External URL)');
+                      }
+                      else {
+                        hotspotdata.text = hotspotdata.text + Drupal.t(' (Digital Object)');
+                      }
                       drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes[sceneid].hotSpots[hotspotid].clickHandlerFunc = Drupal.FormatStrawberryfieldhotspotPopUp;
                       drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes[sceneid].hotSpots[hotspotid].clickHandlerArgs = hotspotdata.URL;
                     }
-
                   });
-
                 }
               });
               var viewer = window.pannellum.viewer(element_id, drupalSettings.format_strawberryfield.pannellum[element_id].tour);

--- a/js/plugin.iiif-iabookreader_strawberry.js
+++ b/js/plugin.iiif-iabookreader_strawberry.js
@@ -46,12 +46,6 @@ BookReader.prototype.init = (function(super_) {
   return function (options) {
     this.loadManifest();
     super_.call(this, options);
-    if (this.options.enableSearch && this.options.initialSearchTerm) {
-      this.search(
-        this.options.initialSearchTerm,
-        { goToFirstResult: this.goToFirstResult, suppressFragmentChange: true }
-      );
-    }
   };
 })(BookReader.prototype.init);
 
@@ -475,7 +469,6 @@ BookReader.prototype.search =  (function(super_) {
         if (null == searchInsideResults) return;
 
         var searchInsideResultsScale = {};
-
         searchInsideResults.matches.forEach(function(match,index,array) {
           match.par[0].boxes.forEach(function(box,index,array) {
             var pageindex = self.leafNumToIndex(array[index].page);


### PR DESCRIPTION
See #151 and https://github.com/esmero/webform_strawberryfield/issues/98

@giancarlobi this also fixes the IABookreader Search/Mode from URL autoloading. Issue was quite simple but it took me some time.
Since we are extending .init() and the search() we do not need to call the 
```JS
if (this.options.enableSearch && this.options.initialSearchTerm) {
      this.search(
        this.options.initialSearchTerm,
        { goToFirstResult: this.goToFirstResult, suppressFragmentChange: true }
      );
    }
```

During init(). That is called by the main/extended `_super` method

Please give it a test, at least here all worked!
