### PR TITLE
ISSUE-155: Add new JSON_DECODE twig filter and parent ship Cache tags for Metadatadisplay

### DIFF
--- a/format_strawberryfield.services.yml
+++ b/format_strawberryfield.services.yml
@@ -8,6 +8,11 @@ services:
     tags:
       - {name: event_subscriber}
     arguments: ['@string_translation', '@messenger', '@logger.factory', '@tempstore.private']
+  format_strawberryfield.invalidatemetadatacache_subscriber:
+    class: Drupal\format_strawberryfield\EventSubscriber\formatStrawberryfieldInvalidateMetadataCaches
+    tags:
+      - { name: event_subscriber }
+    arguments: [ '@string_translation', '@messenger', '@logger.factory' ]
   format_strawberryfield.view_mode_resolver:
     class: Drupal\format_strawberryfield\ViewModeResolver
     arguments: ['@strawberryfield.utility', '@config.factory']

--- a/src/Controller/MetadataExposeDisplayController.php
+++ b/src/Controller/MetadataExposeDisplayController.php
@@ -257,6 +257,9 @@ class MetadataExposeDisplayController extends ControllerBase {
           $response->addCacheableDependency($node);
           $response->addCacheableDependency($metadatadisplay_entity);
           $response->addCacheableDependency($metadataexposeconfig_entity);
+          $metadata_cache_tag = 'node_metadatadisplay:'. $node->id();
+          $response->getCacheableMetadata()->addCacheTags([$metadata_cache_tag]);
+          $response->getCacheableMetadata()->addCacheContexts(['user.roles']);
         }
         return $response;
 

--- a/src/Entity/MetadataDisplayEntity.php
+++ b/src/Entity/MetadataDisplayEntity.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\format_strawberryfield\Entity;
 
+use Drupal\Core\Cache\Cache;
 use Twig\Node\ModuleNode;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
@@ -358,14 +359,26 @@ class MetadataDisplayEntity extends ContentEntityBase implements MetadataDisplay
     $twigtemplate = $this->get('twig')->getValue();
     $twigtemplate = !empty($twigtemplate) ? $twigtemplate[0]['value'] : "{{ 'empty' }}";
     // @TODO should we have a custom theme hint here?
+    $node = $context['node'] ?? NULL;
+    $nodeid = $node instanceof  \Drupal\Core\Entity\FieldableEntityInterface ? $node->id() : NULL;
+    if ($nodeid) {
+      $cache_tags = Cache::mergeTags(
+        $this->getCacheTags(),
+        ['node_metadatadisplay:'. $nodeid]
+      );
+    }
+    else {
+      $cache_tags = $this->getCacheTags();
+    }
     $templaterenderelement = [
       '#type' => 'inline_template',
       '#template' => $twigtemplate,
       '#context' => $context,
       '#cache' => [
-        'tags' => $this->getCacheTags(),
+        'tags' => $cache_tags
       ],
     ];
+
     return $templaterenderelement;
   }
 

--- a/src/EventSubscriber/formatStrawberryfieldDeleteTmpStorage.php
+++ b/src/EventSubscriber/formatStrawberryfieldDeleteTmpStorage.php
@@ -47,6 +47,11 @@ class formatStrawberryfieldDeleteTmpStorage implements EventSubscriberInterface 
   protected $tempStoreFactory;
 
   /**
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  private $loggerFactory;
+
+  /**
    * StrawberryfieldEventInsertSubscriberDepositDO constructor.
    *
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation

--- a/src/EventSubscriber/formatStrawberryfieldInvalidateMetadataCaches.php
+++ b/src/EventSubscriber/formatStrawberryfieldInvalidateMetadataCaches.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Drupal\format_strawberryfield\EventSubscriber;
+
+use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Cache\Cache;
+
+/**
+ * Event subscriber that deletes format temp storage for SBF bearing entities.
+ *
+ * The actual deletion only happens after persistance of a Node.
+ *
+ */
+class formatStrawberryfieldInvalidateMetadataCaches implements EventSubscriberInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * @var int
+   */
+  protected static $priority = -700;
+
+  /**
+   * The messenger.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * The serializer.
+   * @var \Symfony\Component\Serializer\SerializerInterface;
+   */
+  protected $serializer;
+
+  /**
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  private $loggerFactory;
+
+  /**
+   * formatStrawberryfieldInvalidateMetadataCaches constructor.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   */
+  public function __construct(
+    TranslationInterface $string_translation,
+    MessengerInterface $messenger,
+    LoggerChannelFactoryInterface $logger_factory
+  ) {
+    $this->stringTranslation = $string_translation;
+    $this->messenger = $messenger;
+    $this->loggerFactory = $logger_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+
+    // @TODO check event priority and adapt to future D9 needs.
+    $events[StrawberryfieldEventType::SAVE][] = ['onEntityOp', static::$priority];
+    $events[StrawberryfieldEventType::DELETE][] = ['onEntityOp', static::$priority];
+    $events[StrawberryfieldEventType::INSERT][] = ['onEntityOp', static::$priority];
+    return $events;
+  }
+
+
+  /**
+   * Method called when Save/Update Event occurs.
+   *
+   * @param \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent $event
+   */
+  public function onEntityOp(StrawberryfieldCrudEvent $event) {
+     /* @var $entity \Drupal\Core\Entity\ContentEntityInterface */
+    $entity = $event->getEntity();
+    $this->invalidate_cache($entity);
+    $current_class = get_called_class();
+    $event->setProcessedBy($current_class, true);
+  }
+
+  protected function invalidate_cache(ContentEntityInterface $entity) {
+    try {
+      $field = $entity->get('field_sbf_nodetonode');
+      foreach ($field->getIterator() as $delta => $itemfield) {
+        $tags[] = 'node_metadatadisplay:' . $itemfield->target_id;
+      }
+      if (!empty($tags)) {
+        Cache::invalidateTags($tags);
+      }
+    }
+    catch (\Exception $exception) {
+      $this->loggerFactory->get('strawberryfield')->error($this->t('Error invalidating Caches for parent Nodes for Node ID @node', ['@node' => $entity->id()]));
+    }
+  }
+}

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -2,7 +2,10 @@
 
 namespace Drupal\format_strawberryfield;
 
+use Twig\Markup;
 use Twig\TwigTest;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 /**
  * Class TwigExtension.
@@ -34,8 +37,17 @@ class TwigExtension extends \Twig_Extension {
    */
   public function getFunctions() {
     return [
-      new \Twig_SimpleFunction('sbf_entity_ids_by_label',
+      new TwigFunction('sbf_entity_ids_by_label',
         [$this, 'entityIdsByLabel']),
+    ];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getFilters() {
+    return [
+      new TwigFilter('sbf_json_decode', [$this, 'sbfJsonDecode'])
     ];
   }
 
@@ -105,4 +117,34 @@ class TwigExtension extends \Twig_Extension {
     }
     return NULL;
   }
+
+  /**
+   * JSON Decodes a string.
+   *
+   * To make this function safe we define a 64 max depth, always associative
+   * array and fail on non Valid UTF8. No user provided Bit Masks are allowed
+   *
+   * @param mixed $value the value to decode
+   *
+   * @return mixed The JSON decoded value
+   *    - NULL if failure, not the right type (e.g Iterable) or if NULL
+   *    - TRUE/FALSE
+   *    - An array
+   */
+  public function sbfJsonDecode($value) {
+    error_log(var_export($value, true));
+    if ($value instanceof Markup) {
+      $value = (string) $value;
+    }
+    elseif (\is_iterable($value)) {
+      // Do not fail, return an empty array;
+      return NULL;
+    }
+    try {
+      return json_decode($value, TRUE, 64, JSON_INVALID_UTF8_IGNORE | JSON_OBJECT_AS_ARRAY);
+    } catch (\Exception $exception) {
+      return NULL;
+    }
+  }
+
 }

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -132,7 +132,6 @@ class TwigExtension extends \Twig_Extension {
    *    - An array
    */
   public function sbfJsonDecode($value) {
-    error_log(var_export($value, true));
     if ($value instanceof Markup) {
       $value = (string) $value;
     }


### PR DESCRIPTION
# What?
See #155 but also new here:

New Cache tags that complement the the normal `Node` ones, that allows us to invalidate the Metadata Displays and exposed metadata Displays render caches on a Child Object change. This is needed to allow fast refreshing/real time changes on IIIF Manifests shown on a Creative Works Series or a Collection ADO when a new Child is added/deleted or updated since the Viewer (Mirador or any other IIIF Compliant one) will be cached based on the current Node(a.k.a the Collection) and since that one won't have changed (just the child pointing back) the data/images will be stuck

This includes a Invalidation  Event Subscribers and makes use of a Computed Field we have that  tracks all related ADOs to ADOs relationships across a whole SBF JSON

I also added a user.role context to the exposed metadata endpoint controller to make sure  exclusions (e.g Draft Objects) are only cached for those without permissions and not for others.

Thanks!

@patdunlavey @giancarlobi @alliomeria this is really really cool. Depends on the just merged https://github.com/esmero/strawberryfield/pull/181