### PR TITLE
ISSUE-164: Add Autoload property for global Tour Viewer

### DIFF
--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -178,6 +178,8 @@
                   });
                 }
               });
+             // Add Autoload property for global Tour Viewer
+              drupalSettings.format_strawberryfield.pannellum[element_id].tour.autoLoad = Boolean(drupalSettings.format_strawberryfield.pannellum[element_id].settings.autoLoad); 
               var viewer = window.pannellum.viewer(element_id, drupalSettings.format_strawberryfield.pannellum[element_id].tour);
             }
             FormatStrawberryfieldPanoramas.panoramas.set(element_id, new FormatStrawberryfieldPanoramas(viewer));


### PR DESCRIPTION
See #164

# What is this?

Adds Autoload property for global Tour Viewer from the global settings as we do for individual Panoramas.

Its a single line so not a big issue but super needed.