### PR TITLE
ISSUE-177: Initialize embargo cache arrays sooner

### DIFF
--- a/src/Controller/MetadataExposeDisplayController.php
+++ b/src/Controller/MetadataExposeDisplayController.php
@@ -141,6 +141,8 @@ class MetadataExposeDisplayController extends ControllerBase {
       );
     }
     $context = [];
+    $embargo_context = [];
+    $embargo_tags = [];
     if ($sbf_fields = $this->strawberryfieldUtility->bearsStrawberryfield(
       $node
     )) {
@@ -210,11 +212,9 @@ class MetadataExposeDisplayController extends ControllerBase {
           }
 
           $embargo_info = $this->embargoResolver->embargoInfo($node->uuid(), $jsondata);
-          $embargo_context = [];
           // This one is for the Twig template
           // We do not need the IP here. No use of showing the IP at all?
           $context_embargo = ['data_embargo' => ['embargoed' => false, 'until' => NULL]];
-          $embargo_tags = [];
           if (is_array($embargo_info)) {
             $embargoed = $embargo_info[0];
             $context_embargo['data_embargo']['embargoed'] = $embargoed;

--- a/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
@@ -127,6 +127,8 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
     $upload_keys = explode(',', $upload_keys_string);
     $upload_keys = array_filter($upload_keys);
     $upload_keys = array_map('trim', $upload_keys);
+    $embargo_context = [];
+    $embargo_tags = [];
 
     $embargo_upload_keys_string = strlen(trim($this->getSetting('embargo_json_key_source'))) > 0 ? trim($this->getSetting('embargo_json_key_source')) : NULL;
     $embargo_upload_keys_string = explode(',', $embargo_upload_keys_string);
@@ -170,8 +172,6 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
       }*/
       $embargo_info = $this->embargoResolver->embargoInfo($items->getEntity()->uuid(), $jsondata);
       // Check embargo
-      $embargo_context = [];
-      $embargo_tags = [];
       if (is_array($embargo_info)) {
         $embargoed = $embargo_info[0];
         $embargo_tags[] = 'format_strawberryfield:all_embargo';

--- a/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
@@ -127,6 +127,8 @@ class StrawberryAudioFormatter extends StrawberryDirectJsonFormatter {
     $upload_keys_string = strlen(trim($this->getSetting('upload_json_key_source'))) > 0 ? trim($this->getSetting('upload_json_key_source')) : NULL;
     $upload_keys = explode(',', $upload_keys_string);
     $upload_keys = array_filter($upload_keys);
+    $embargo_context = [];
+    $embargo_tags = [];
 
     $embargo_upload_keys_string = strlen(trim($this->getSetting('embargo_json_key_source'))) > 0 ? trim($this->getSetting('embargo_json_key_source')) : NULL;
     $embargo_upload_keys_string = explode(',', $embargo_upload_keys_string);
@@ -187,8 +189,6 @@ class StrawberryAudioFormatter extends StrawberryDirectJsonFormatter {
 
       $embargo_info = $this->embargoResolver->embargoInfo($items->getEntity()->uuid(), $jsondata);
       // Check embargo
-      $embargo_context = [];
-      $embargo_tags = [];
       if (is_array($embargo_info)) {
         $embargoed = $embargo_info[0];
         $embargo_tags[] = 'format_strawberryfield:all_embargo';

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -169,6 +169,8 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
     $upload_keys = explode(',', $upload_keys_string);
     $upload_keys = array_filter($upload_keys);
     $upload_keys = array_map('trim', $upload_keys);
+    $embargo_context = [];
+    $embargo_tags = [];
 
     $embargo_upload_keys_string = strlen(trim($this->getSetting('embargo_json_key_source'))) > 0 ? trim($this->getSetting('embargo_json_key_source')) : NULL;
     $embargo_upload_keys_string = explode(',', $embargo_upload_keys_string);
@@ -204,8 +206,6 @@ class StrawberryMediaFormatter extends StrawberryBaseFormatter {
       $embargo_info = $this->embargoResolver->embargoInfo($items->getEntity()
         ->uuid(), $jsondata);
       // Check embargo
-      $embargo_context = [];
-      $embargo_tags = [];
       if (is_array($embargo_info)) {
         $embargoed = $embargo_info[0];
         $embargo_tags[] = 'format_strawberryfield:all_embargo';

--- a/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
@@ -194,6 +194,8 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
     $usemetadatalabel = $this->getSetting('metadatadisplayentity_uselabel');
     $metadatadisplayentity_uuid = $this->getSetting('metadatadisplayentity_uuid');
     $nodeid = $items->getEntity()->id();
+    $embargo_context = [];
+    $embargo_tags = [];
 
     foreach ($items as $delta => $item) {
       $main_property = $item->getFieldDefinition()->getFieldStorageDefinition()->getMainPropertyName();
@@ -229,11 +231,10 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
         return $elements[$delta] = ['#markup' => $message];
       }
       $embargo_info = $this->embargoResolver->embargoInfo($items->getEntity()->uuid(), $jsondata);
-      $embargo_context = [];
       // This one is for the Twig template
       // We do not need the IP here. No use of showing the IP at all?
       $context_embargo = ['data_embargo' => ['embargoed' => false, 'until' => NULL]];
-      $embargo_tags = [];
+
       if (is_array($embargo_info)) {
         $embargoed = $embargo_info[0];
         $context_embargo['data_embargo']['embargoed'] = $embargoed;

--- a/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
@@ -378,6 +378,8 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
     $max_width = $this->getSetting('max_width');
     $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
     $max_height = $this->getSetting('max_height');
+    $embargo_context = [];
+    $embargo_tags = [];
 
     if ($this->getSetting('metadatadisplayentity_uuid')) {
       /* @var $metadatadisplayentity \Drupal\format_strawberryfield\Entity\MetadataDisplayEntity */
@@ -395,11 +397,10 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
         StrawberryfieldJsonHelper::orderSequence($jsondata, $mainkey, $ordersubkey);
 
         $embargo_info = $this->embargoResolver->embargoInfo($item->getEntity()->uuid(), $jsondata);
-        $embargo_context = [];
         // This one is for the Twig template
         // We do not need the IP here. No use of showing the IP at all?
         $context_embargo = ['data_embargo' => ['embargoed' => false, 'until' => NULL]];
-        $embargo_tags = [];
+
         if (is_array($embargo_info)) {
           $embargoed = $embargo_info[0];
           $context_embargo['data_embargo']['embargoed'] = $embargoed;

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -263,6 +263,8 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
     $upload_keys = explode(',', $upload_keys_string);
     $upload_keys = array_filter($upload_keys);
     $upload_keys = array_map('trim', $upload_keys);
+    $embargo_context = [];
+    $embargo_tags = [];
 
     $embargo_upload_keys_string = strlen(trim($this->getSetting('embargo_json_key_source'))) > 0 ? trim($this->getSetting('embargo_json_key_source')) : NULL;
     $embargo_upload_keys_string = explode(',', $embargo_upload_keys_string);
@@ -297,11 +299,10 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
       }
 
       $embargo_info = $this->embargoResolver->embargoInfo($item->getEntity()->uuid(), $jsondata);
-      $embargo_context = [];
       // This one is for the Twig template
       // We do not need the IP here. No use of showing the IP at all?
       $context_embargo = ['data_embargo' => ['embargoed' => false, 'until' => NULL]];
-      $embargo_tags = [];
+
       if (is_array($embargo_info)) {
         $embargoed = $embargo_info[0];
         $context_embargo['data_embargo']['embargoed'] = $embargoed;

--- a/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
@@ -158,6 +158,8 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
     $upload_keys_string = strlen(trim($this->getSetting('upload_json_key_source'))) > 0 ? trim($this->getSetting('upload_json_key_source')) : NULL;
     $upload_keys = explode(',', $upload_keys_string);
     $upload_keys = array_filter($upload_keys);
+    $embargo_context = [];
+    $embargo_tags = [];
 
     $embargo_upload_keys_string = strlen(trim($this->getSetting('embargo_json_key_source'))) > 0 ? trim($this->getSetting('embargo_json_key_source')) : NULL;
     $embargo_upload_keys_string = explode(',', $embargo_upload_keys_string);
@@ -209,11 +211,9 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
       },
       }*/
       $embargo_info = $this->embargoResolver->embargoInfo($items->getEntity()->uuid(), $jsondata);
-      $embargo_context = [];
       // This one is for the Twig template
       // We do not need the IP here. No use of showing the IP at all?
       $context_embargo = ['data_embargo' => ['embargoed' => false, 'until' => NULL]];
-      $embargo_tags = [];
       if (is_array($embargo_info)) {
         $embargoed = $embargo_info[0];
         $context_embargo['data_embargo']['embargoed'] = $embargoed;

--- a/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
@@ -156,6 +156,8 @@ class StrawberryVideoFormatter extends StrawberryDirectJsonFormatter {
     $upload_keys_string = strlen(trim($this->getSetting('upload_json_key_source'))) > 0 ? trim($this->getSetting('upload_json_key_source')) : NULL;
     $upload_keys = explode(',', $upload_keys_string);
     $upload_keys = array_filter($upload_keys);
+    $embargo_context = [];
+    $embargo_tags = [];
 
     $embargo_upload_keys_string = strlen(trim($this->getSetting('embargo_json_key_source'))) > 0 ? trim($this->getSetting('embargo_json_key_source')) : NULL;
     $embargo_upload_keys_string = explode(',', $embargo_upload_keys_string);
@@ -221,8 +223,6 @@ class StrawberryVideoFormatter extends StrawberryDirectJsonFormatter {
       $embargo_info = $this->embargoResolver->embargoInfo($items->getEntity()
         ->uuid(), $jsondata);
       // Check embargo
-      $embargo_context = [];
-      $embargo_tags = [];
       if (is_array($embargo_info)) {
         $embargoed = $embargo_info[0];
         $embargo_tags[] = 'format_strawberryfield:all_embargo';

--- a/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
@@ -154,6 +154,8 @@ class StrawberryWarcFormatter extends StrawberryDirectJsonFormatter {
     $nodeid = $items->getEntity()->id();
     $number_media = $this->getSetting('number_media') ?? 1;
     $key = $this->getSetting('json_key_source');
+    $embargo_context = [];
+    $embargo_tags = [];
 
     $nodeuuid = $items->getEntity()->uuid();
     $nodeid = $items->getEntity()->id();
@@ -195,8 +197,6 @@ class StrawberryWarcFormatter extends StrawberryDirectJsonFormatter {
       $embargo_info = $this->embargoResolver->embargoInfo($items->getEntity()
         ->uuid(), $jsondata);
       // Check embargo
-      $embargo_context = [];
-      $embargo_tags = [];
       if (is_array($embargo_info)) {
         $embargoed = $embargo_info[0];
         $embargo_tags[] = 'format_strawberryfield:all_embargo';


### PR DESCRIPTION
See #177. This really applies to any Formatter and only fails if there is no media at all to show. This fixes it but @aksm @alliomeria @giancarlobi I'm not totally happy still with the refactor for formatters. I might push another (different issue) before 1.0.0

@giancarlobi can you please test tomorrow?

Thx