### PR TITLE
ISSUE-187: Wrong key value collection for UUID based Metadata Display Entity Autocomplete element

### DIFF
--- a/src/Element/EntityAutocompleteUUID.php
+++ b/src/Element/EntityAutocompleteUUID.php
@@ -186,7 +186,7 @@ class EntityAutocompleteUUID extends Textfield {
     $data = serialize($selection_settings) . $element['#target_type'] . $element['#selection_handler'];
     $selection_settings_key = Crypt::hmacBase64($data, Settings::getHashSalt());
 
-    $key_value_storage = \Drupal::keyValue('sbf_entity_autocomplete');
+    $key_value_storage = \Drupal::keyValue('entity_autocomplete');
     if (!$key_value_storage->has($selection_settings_key)) {
       $key_value_storage->set($selection_settings_key, $selection_settings);
     }


### PR DESCRIPTION
See #187 

@patdunlavey @alliomeria and thanks for @aksm to hitting this one. So annoying!

PS: when coming from an early RC3 or a RC2 the key value will be already filled and it won't fail of course.