### PR TITLE
ISSUE-221 --- ADO Type condition plugin.

### DIFF
--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -614,3 +614,14 @@ field.formatter.settings.strawberry_citation_formatter:
         label: 'style'
     localekey:
       type: string
+condition.plugin.ado_type_condition:
+  type: condition.plugin
+  label: 'ADO Type Condition'
+  mapping:
+    ado_types:
+      type: array
+      label: 'ADO Type'
+    recurse_ado_types:
+      type: boolean
+      label: 'Recurse metadata'
+

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -619,8 +619,10 @@ condition.plugin.ado_type_condition:
   label: 'ADO Type Condition'
   mapping:
     ado_types:
-      type: array
+      type: sequence
       label: 'ADO Type'
+      sequence:
+        type: string
     recurse_ado_types:
       type: boolean
       label: 'Recurse metadata'

--- a/src/Plugin/Condition/AdoType.php
+++ b/src/Plugin/Condition/AdoType.php
@@ -7,7 +7,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
 use Drupal\strawberryfield\StrawberryfieldUtilityService;
-use Drupal\webform\Entity\WebformOptions;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/src/Plugin/Condition/AdoType.php
+++ b/src/Plugin/Condition/AdoType.php
@@ -6,6 +6,7 @@ use Drupal\Core\Condition\ConditionPluginBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
+use Drupal\strawberryfield\StrawberryfieldUtilityService;
 use Drupal\webform\Entity\WebformOptions;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -31,9 +32,11 @@ class AdoType extends ConditionPluginBase implements ContainerFactoryPluginInter
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
+   * @param \Drupal\strawberryfield\StrawberryfieldUtilityService $strawberryfieldUtilityService
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, StrawberryfieldUtilityService $strawberryfieldUtilityService) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->strawberryfieldUtilityService = $strawberryfieldUtilityService;
   }
 
   /**
@@ -43,7 +46,8 @@ class AdoType extends ConditionPluginBase implements ContainerFactoryPluginInter
     return new static(
       $configuration,
       $plugin_id,
-      $plugin_definition
+      $plugin_definition,
+      $container->get('strawberryfield.utility')
     );
   }
 
@@ -91,7 +95,7 @@ class AdoType extends ConditionPluginBase implements ContainerFactoryPluginInter
     $entity = $this->getContextValue('node');
 
     $ado_types = [];
-    if ($sbf_fields = \Drupal::service('strawberryfield.utility')->bearsStrawberryfield($entity)) {
+    if ($sbf_fields = $this->strawberryfieldUtilityService->bearsStrawberryfield($entity)) {
       foreach ($sbf_fields as $field_name) {
         /* @var \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem $field */
         $field = $entity->get($field_name);

--- a/src/Plugin/Condition/AdoType.php
+++ b/src/Plugin/Condition/AdoType.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Drupal\format_strawberryfield\Plugin\Condition;
+
+use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\webform\Entity\WebformOptions;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides the 'ADO Type' condition.
+ *
+ * @Condition(
+ *   id = "ado_type_condition",
+ *   label = @Translation("ADO Type"),
+ *   context_definitions = {
+ *     "node" = @ContextDefinition("entity:node", label = @Translation("node"))
+ *   }
+ * )
+ */
+class AdoType extends ConditionPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Creates a new AdoType instance.
+   *
+   * @param array $configuration
+   *   The plugin configuration.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $type_options = [];
+    foreach(['schema_org_creative_works', 'schema_org_cw_collections'] as $webform_option_list_id) {
+      $webform_option_list = WebformOptions::load($webform_option_list_id);
+      if (!empty($webform_option_list)) {
+        $type_options = array_merge($type_options, $webform_option_list->getOptions());
+      }
+    }
+    asort($type_options);
+    $form['ado_types'] = [
+      '#title' => $this->pluginDefinition['label'],
+      '#type' => 'checkboxes',
+      '#options' => $type_options,
+      '#default_value' => $this->configuration['ado_types'],
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->configuration['ado_types'] = array_filter($form_state->getValue('ado_types'));
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    // Returns true if no ado types are selected and negate option is disabled.
+    if (empty($this->configuration['ado_types']) && !$this->isNegated()) {
+      return TRUE;
+    }
+    /** @var \Drupal\node\Entity\Node $node */
+    $node = $this->getContextValue('node');
+
+    // Get the ADO type from the entity.
+    if ($node->hasField('field_descriptive_metadata')) {
+      $metadata = $node->get('field_descriptive_metadata')->getString();
+      if (!empty($metadata)) {
+        $metadata = json_decode($metadata);
+        if(!empty($metadata->type)) {
+          // Return true if the `type` value from the json matches a selected ado_type.
+          return !empty($this->configuration['ado_types'][$metadata->type]);
+        }
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  // TODO: This seems to require javascript to display, though it seems pretty superfluous.
+  public function summary() {
+    if (count($this->configuration['ado_types']) > 1) {
+      $ado_types = $this->configuration['ado_types'];
+      $last = array_pop($ado_types);
+      $ado_types = implode(', ', $ado_types);
+
+      if (empty($this->configuration['negate'])) {
+        return $this->t('@type is @ado_types or @last', [
+          '@type' => $this->pluginDefinition['label'],
+          '@ado_types' => $ado_types,
+          '@last' => $last,
+        ]);
+      }
+      else {
+        return $this->t('@type is not @ado_types or @last', [
+          '@type' => $this->pluginDefinition['label'],
+          '@ado_types' => $ado_types,
+          '@last' => $last,
+        ]);
+      }
+    }
+    $ado_type = reset($this->configuration['ado_types']);
+
+    if (empty($this->configuration['negate'])) {
+      return $this->t('@type is @ado_type', [
+        '@type' => $this->pluginDefinition['label'],
+        '@ado_type' => $ado_type,
+      ]);
+    }
+    else {
+      return $this->t('@type is not @ado_type', [
+        '@type' => $this->pluginDefinition['label'],
+        '@ado_type' => $ado_type,
+      ]);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+        'ado_types' => [],
+      ] + parent::defaultConfiguration();
+  }
+
+}

--- a/src/Plugin/Condition/AdoType.php
+++ b/src/Plugin/Condition/AdoType.php
@@ -75,6 +75,7 @@ class AdoType extends ConditionPluginBase implements ContainerFactoryPluginInter
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     $this->configuration['ado_types'] = array_filter(array_map('trim', explode(PHP_EOL, $form_state->getValue('ado_types'))));
+    $this->configuration['recurse_ado_types'] = $form_state->getValue('recurse_ado_types');
     parent::submitConfigurationForm($form, $form_state);
   }
 
@@ -165,6 +166,7 @@ class AdoType extends ConditionPluginBase implements ContainerFactoryPluginInter
   public function defaultConfiguration() {
     return [
         'ado_types' => [],
+        'recurse_ado_types' => 0,
       ] + parent::defaultConfiguration();
   }
 

--- a/src/Plugin/Condition/AdoType.php
+++ b/src/Plugin/Condition/AdoType.php
@@ -69,7 +69,7 @@ class AdoType extends ConditionPluginBase implements ContainerFactoryPluginInter
       '#title' => t("Recurse metadata"),
       '#description' => t('Do you want this condition to look for type values everywhere in the ADO metadata, instead of just at the top level? For example, entering "Image" would cause this condition to match an ADO having an attached image file if this option is checked.'),
       '#type' => 'checkbox',
-      '#default_value' => $this->configuration['recurse_ado_types'],
+      '#default_value' => (bool) $this->configuration['recurse_ado_types'],
     ];
     return parent::buildConfigurationForm($form, $form_state);
   }
@@ -79,7 +79,7 @@ class AdoType extends ConditionPluginBase implements ContainerFactoryPluginInter
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     $this->configuration['ado_types'] = array_filter(array_map('trim', explode(PHP_EOL, $form_state->getValue('ado_types'))));
-    $this->configuration['recurse_ado_types'] = $form_state->getValue('recurse_ado_types');
+    $this->configuration['recurse_ado_types'] = (bool) $form_state->getValue('recurse_ado_types');
     parent::submitConfigurationForm($form, $form_state);
   }
 
@@ -170,7 +170,7 @@ class AdoType extends ConditionPluginBase implements ContainerFactoryPluginInter
   public function defaultConfiguration() {
     return [
         'ado_types' => [],
-        'recurse_ado_types' => 0,
+        'recurse_ado_types' => FALSE,
       ] + parent::defaultConfiguration();
   }
 


### PR DESCRIPTION
This is a fairly simple condition plugin that permits conditioning block display and contexts on the ADO Type of the current node.

See https://github.com/esmero/format_strawberryfield/issues/221

Potential changes/improvements:
- Use a solr facet search to create the list of ADO Types for the configuration form, rather than depending on the presence of the two webform options lists.
- Would changing to a solr search for the current node's ADO type be more performant? Or caching?
- I didn't bother implementing javascript to display the context summary, which seems superfluous. Is that needed?

Requesting review from @aksm