### PR TITLE
ISSUE-227: Add citeproc-php to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
         "erusev/parsedown": "^1.7",
         "drupal/webform": "^5.23 || ^6.0",
         "ext-json": "*",
-	"seboettg/citeproc-php": "master"
+	"seboettg/citeproc-php": "dev-master"
     }
 }


### PR DESCRIPTION
Resolves #227. The original merge was reverted because it wasn't tested, but this one has been tested. composer.lock and composer.default.lock files will have to be updated  (and tested) on archipelago-deployment and archipelago-deployment-live.