### PR TITLE
ISSUE-244 --- Workaround Mirador to allow mutiple Audios on Chrome/Firefox

### DIFF
--- a/js/mirador_strawberry.js
+++ b/js/mirador_strawberry.js
@@ -90,6 +90,14 @@
                                     }
                                 });
                             }
+                            let mirador_audios = document.querySelectorAll(".mirador-viewer audio source");
+                            if (mirador_audios.length) {
+                                mutations.forEach(function (mutation) {
+                                    if ((mutation.target.localName == "audio") && (mutation.addedNodes.length > 0) && (typeof(mutation.target.lastChild.src) != "undefined" )) {
+                                        mutation.target.src = mutation.target.lastChild.getAttribute('src');
+                                    }
+                                });
+                            }
                         });
                         observer.observe(mirador_window, {
                             childList: true,


### PR DESCRIPTION
See https://github.com/esmero/format_strawberryfield/issues/244

I replicated Diego's [solution for video player links in Mirador](https://github.com/esmero/format_strawberryfield/commit/c823b3eb459bf1327619a0064dc9c3e9b951c6b2) to work for audio player links.

To test, create an ADO with multiple audio files and configure the ADO type to display using the Mirador viewer and IIIF Presentation 3.0 API. 

