### PR TITLE
ISSUE-249 --- removed '#required' from the 'ado_types' field in the ADOType condition configuration form

### DIFF
--- a/src/Plugin/Condition/AdoType.php
+++ b/src/Plugin/Condition/AdoType.php
@@ -113,8 +113,15 @@ class AdoType extends ConditionPluginBase implements ContainerFactoryPluginInter
         }
       }
     }
+    else {
+      // This not an entity type that bears a strawberryfield. Therefore, this condition can not apply.
+      // However, it could still be negated and cause in a "TRUE" evaluation to flip and result in the "FALSE"
+      // being returned. Deal with that by removing the negation.
+      unset($this->configuration['negate']);
+      return TRUE;
+    }
     if(!empty($ado_types)) {
-      // Return true if the any of the entity's types are in the condition's ado_types.
+      // Return true if any of the entity's types are in the condition's ado_types.
       return (count(array_intersect($this->configuration['ado_types'], $ado_types)) > 0);
     }
     // Default, return not matched.

--- a/src/Plugin/Condition/AdoType.php
+++ b/src/Plugin/Condition/AdoType.php
@@ -62,7 +62,6 @@ class AdoType extends ConditionPluginBase implements ContainerFactoryPluginInter
       ),
       '#type' => 'textarea',
       '#default_value' => implode(PHP_EOL, $this->configuration['ado_types']),
-      '#required' => TRUE,
     ];
     $form['recurse_ado_types'] = [
       '#title' => t("Recurse metadata"),


### PR DESCRIPTION
See https://github.com/esmero/format_strawberryfield/issues/249

Requiring the 'ado_types' field to be required causes drupal's block configuration forms to become unsubmittable, and context conditions to sometimes become unsubmittable if the form tab is hidden when the user tries to submit the form. This PR solves the problem simply by removing the "required" attribute, since `format_strawberryfield\Plugin\Condition\AdoType::evaluate` handles the case of this field being empty just fine.