### PR TITLE
Issue 248 patch - Update JMESPaths

### DIFF
--- a/src/Controller/MetadataDisplaySearchController.php
+++ b/src/Controller/MetadataDisplaySearchController.php
@@ -23,7 +23,7 @@ class MetadataDisplaySearchController extends
   /**
    * A JMESPATH to fetch Canvas IDs, Item Ids, Images and Service(Images) for IIIF Presentation 3.x
    */
-  CONST IIIF_V3_JMESPATH = "items[?type == 'Canvas'].{\"canvas_id\":id ,\"items\": items[?type == 'AnnotationPage'].{\"id\":id,\"image_ids\": items[?motivation == 'painting'].body.id, \"service_ids\": items[?motivation == 'painting'].body.service[*][]|[?contains(type, 'ImageService')]|[*].id }}";
+  CONST IIIF_V3_JMESPATH = "items[?type == 'Canvas'].{\"canvas_id\":id ,\"items\": items[?type == 'AnnotationPage'].{\"id\":id,\"image_ids\": items[?motivation == 'painting'].body.id, \"service_ids\": items[?motivation == 'painting'].body.service[].{type:({t: type, at: \"@type\"}).not_null(t, at), id:({id: id, atid: \"@id\"}).not_null(id, atid)}[?starts_with(type, 'ImageService')].id }}";
 
   /**
    * Mime type guesser service.

--- a/src/Controller/MetadataDisplaySearchController.php
+++ b/src/Controller/MetadataDisplaySearchController.php
@@ -18,7 +18,7 @@ class MetadataDisplaySearchController extends
   /**
    * A JMESPATH to fetch Canvas IDs, Item Ids, Images and Service(Images) for IIIF Presentation 2.x
    */
-  CONST IIIF_V2_JMESPATH = "sequences[].canvases[?\"@type\" == 'sc:Canvas'][].{\"canvas_id\":\"@id\", \"items\": images[?motivation == 'sc:painting'].{\"id\":\"@id\", \"image_ids\":[resource.\"@id\"], \"service_ids\":[resource.service.\"@id\"]}}";
+  CONST IIIF_V2_JMESPATH = "sequences[].canvases[?\"@type\" == 'sc:Canvas'][].{\"canvas_id\":\"@id\", \"items\": images[?motivation == 'sc:painting'].{\"id\":\"@id\", \"image_ids\":[resource.\"@id\"], \"service_ids\":[resource.service][?starts_with(\"@context\", 'http://iiif.io/api/image/')].\"@id\"}}";
 
   /**
    * A JMESPATH to fetch Canvas IDs, Item Ids, Images and Service(Images) for IIIF Presentation 3.x


### PR DESCRIPTION
This PR updates the JMESPath constants for both IIIF Presentation v2 and v3 to fix some potential issues.

### Presentation v2:
**Problem:** Non-Image services could be picked up by the selector.
**Fix:** Add a filter clause to make sure the `@context` block of the service is for an Image API version. The reason for using this field is per [Presentation 2.1.1 section 5.4](https://iiif.io/api/presentation/2.1/#image-resources): "A reference to the Image API context document **MUST** be included", so on a valid Manifest it will be present.
**Playgrounds:**
1) Current code, picking up Search service in third canvas: http://play.jmespath.org/?u=926ccfd3-0b1f-43b2-b431-b9c9b3bdbf93
2) Fixed code, picking up Image services for Canvas 1+2, and not the Search service in Canvas 3: http://play.jmespath.org/?u=cccfd941-f3c7-418f-844f-44b85ddee0f4

### Presentation v3:
**Problem 1:** Current selector only works if _all_ services are v3 (i.e with `id` and `type`). Having even a single v2 service (with `@type`) causes the whole selector to fail on the `contains` conditional and return a single `null` for the entire manifest (not just the one block).
**Problem 2:** Assuming above fixed, current selector only returns `id` for the service, meaning it misses v2 services with `@id`.
**Fix 1:** Push both `type` and `@type` into a hash, and use the `not_null` function to select the one that actually exists, and then assign it to `type`, then use this for the conditional selection of only Image services.
**Fix 2:** Repeat the same push-to-hash/`not_null` trick with `id` and `@id`, ensuring that `id` will then have the value from whichever one exists.
**Playgrounds:** (n.b. each of these has a third canvas which should never get a `service_id` as it only contains a Search service)
1) Current code, working with only v3 services: https://play.jmespath.org/?u=1a017e4f-064e-48fb-b469-1cbfac6f8b71
2) Current code, failing to `null` when one v2 service exists: https://play.jmespath.org/?u=07998489-58d0-47cb-b4ba-5b7dd5278431
3) Fixed code, working with both v2 and v3 services and returning consistent output regardless of whether `@` is present in input keys or not: https://play.jmespath.org/?u=b0d17ada-8b30-4f8f-a2cd-9f8296b90b78