### PR TITLE
Small improvement to `IIIF_V3_JMESPATH`

### DIFF
--- a/src/Controller/MetadataDisplaySearchController.php
+++ b/src/Controller/MetadataDisplaySearchController.php
@@ -23,7 +23,7 @@ class MetadataDisplaySearchController extends
   /**
    * A JMESPATH to fetch Canvas IDs, Item Ids, Images and Service(Images) for IIIF Presentation 3.x
    */
-  CONST IIIF_V3_JMESPATH = "items[?type == 'Canvas'].{\"canvas_id\":id ,\"items\": items[?type == 'AnnotationPage'].{\"id\":id,\"image_ids\": items[?motivation == 'painting'].body.id, \"service_ids\": items[?motivation == 'painting'].body.service[].{type:({t: type, at: \"@type\"}).not_null(t, at), id:({id: id, atid: \"@id\"}).not_null(id, atid)}[?starts_with(type, 'ImageService')].id }}";
+  CONST IIIF_V3_JMESPATH = "items[?type == 'Canvas'].{\"canvas_id\":id ,\"items\": items[?type == 'AnnotationPage'].{\"id\":id,\"image_ids\": items[?motivation == 'painting'].body.id, \"service_ids\": items[?motivation == 'painting'].body.service[].{type: not_null(type, \"@type\"), id: not_null(id, \"@id\")}[?starts_with(type, 'ImageService')].id }}";
 
   /**
    * Mime type guesser service.


### PR DESCRIPTION
A small optimisation to the V3 path that avoids the need to store `@id`/`id` and `@type`/`type` in temporary hashes, and just assigns them straight away.

Playground: https://play.jmespath.org/?u=5ad1f201-12d6-46aa-96bf-9174c6541a7a