### PR TITLE
ISSUE-260: Views and Facets  + advanced search

### DIFF
--- a/format_strawberryfield.links.task.yml
+++ b/format_strawberryfield.links.task.yml
@@ -31,6 +31,6 @@ metadatadisplay.admin:
 format_strawberry.display_settings:
   route_name: format_strawberryfield.display_settings
   base_route: entity.node.canonical
-  title: 'Display settings'
+  title: 'Active Display settings'
   class: '\Drupal\format_strawberryfield\Plugin\Menu\LocalTask\ViewModeLocalTask'
   weight: 5

--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -14,6 +14,7 @@ entity.metadatadisplay_entity.collection:
     _title: 'Metadata Display List'
   requirements:
     _permission: 'administer metadatadisplay entity'
+  _admin_route: TRUE
 
 format_strawberryfield.metadatadisplay_add:
   path: '/metadatadisplay/add'
@@ -247,12 +248,13 @@ format_strawberryfield.display_settings:
   path: '/node/{node}/{bundle}/display-settings/{view_mode_name}'
   defaults:
     _entity_form: 'entity_view_display.edit'
-    _title: 'Display settings'
+    _title: 'Active Display settings'
     entity_type_id: 'node'
   requirements:
     _entity_access: 'node.update'
     _permission: 'administer node display'
   options:
+    _admin_route: TRUE
     _node_operation_route: TRUE
     parameters:
       node:

--- a/modules/format_strawberryfield_facets/config/schema/format_strawberryfield_facets.schema.yml
+++ b/modules/format_strawberryfield_facets/config/schema/format_strawberryfield_facets.schema.yml
@@ -1,0 +1,53 @@
+# Config schema for slider, you can find the implementation in
+# Drupal\facets_range\Plugin\facets\widget\SliderWidget.
+facet.widget.config.format_strawberryfield_dateslider:
+  type: facet.widget.default_config
+  label: 'List of range widget configuration'
+  mapping:
+    prefix:
+      type: label
+      label: 'Prefix'
+    suffix:
+      type: label
+      label: 'Suffix'
+    min_type:
+      type: string
+      label: 'Minimum type'
+    min_value:
+      type: float
+      label: 'Minimum value'
+    max_type:
+      type: string
+      label: 'Maximum type'
+    max_value:
+      type: float
+      label: 'Maximum value'
+    step:
+      type: float
+      label: 'Step'
+
+facet.widget.config.format_strawberryfield_daterange_slider:
+  type: facet.widget.default_config
+  label: 'List of range widget configuration'
+  mapping:
+    prefix:
+      type: label
+      label: 'Prefix'
+    suffix:
+      type: label
+      label: 'Suffix'
+    min_type:
+      type: string
+      label: 'Minimum type'
+    min_value:
+      type: float
+      label: 'Minimum value'
+    max_type:
+      type: string
+      label: 'Maximum type'
+    max_value:
+      type: float
+      label: 'Maximum value'
+    step:
+      type: float
+      label: 'Step'

--- a/modules/format_strawberryfield_facets/css/slider.css
+++ b/modules/format_strawberryfield_facets/css/slider.css
@@ -1,0 +1,9 @@
+.facet-slider {
+  margin-top: 40px;
+}
+
+.facet-slider.ui-slider-float .ui-slider-tip {
+  visibility: visible;
+  opacity: 1;
+  top: -30px;
+}

--- a/modules/format_strawberryfield_facets/format_strawberryfield_facets.info.yml
+++ b/modules/format_strawberryfield_facets/format_strawberryfield_facets.info.yml
@@ -1,0 +1,9 @@
+name: 'Format Strawberry Field Facets Widgets and Processors'
+type: module
+description: 'Provides Facet Widgets for the Format Strawberry Module'
+core_version_requirement: ^9.4 || ^10.0
+package: Search
+dependencies:
+  - facets:facets
+  - jquery_ui_slider:jquery_ui_slider
+  - jquery_ui_touch_punch:jquery_ui_touch_punch

--- a/modules/format_strawberryfield_facets/format_strawberryfield_facets.install
+++ b/modules/format_strawberryfield_facets/format_strawberryfield_facets.install
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Contains install hooks for facets range widget.
+ */
+
+/**
+ * Implements hook_requirements().
+ */
+function format_strawberryfield_facets_requirements() {
+  $library_name = 'jquery-ui-slider-pips';
+  $library_path = '/libraries/' . $library_name;
+  $library_exists = (file_exists(DRUPAL_ROOT . $library_path)) ? TRUE : FALSE;
+
+  // If library is not found, look in the current profile libraries path.
+  if (!$library_exists) {
+    $profile = \Drupal::installProfile();
+    $profile_path = Drupal::service('extension.list.profile')->getPath($profile);
+    $profile_path .= $library_path;
+    $library_exists = file_exists($profile_path);
+  }
+
+  $requirements = [];
+  if (!$library_exists) {
+    $arguments = [
+      ':docs' => 'https://www.drupal.org/docs/8/theming-drupal-8/adding-stylesheets-css-and-javascript-js-to-a-drupal-8-theme#external',
+      ':readme' => 'http://cgit.drupalcode.org/facets/tree/modules/facets_range_widget/README.txt',
+    ];
+    $requirements['format_strawberryfield_facets_pips_slider'] = [
+      'title' => t('Format Strawberryfield Facets'),
+      'value' => t('The jquery ui slider pips library is not installed.'),
+      'severity' => REQUIREMENT_ERROR,
+      'description' => t('The range slider library is not installed, check the <a href=":readme">README.txt for more information</a> and <a href=":docs">the documentation for information on how to install a library</a>.', $arguments),
+    ];
+  }
+
+  return $requirements;
+}

--- a/modules/format_strawberryfield_facets/format_strawberryfield_facets.libraries.yml
+++ b/modules/format_strawberryfield_facets/format_strawberryfield_facets.libraries.yml
@@ -1,0 +1,37 @@
+jquery.ui.slider.pips:
+  remote: http://simeydotme.github.io/jQuery-ui-Slider-Pips/
+  version: v1.11.3
+  license:
+    name: MIT
+    url: https://github.com/simeydotme/jQuery-ui-Slider-Pips/blob/v1.11.3/README.md
+    gpl-compatible: true
+  js:
+    /libraries/jquery-ui-slider-pips/dist/jquery-ui-slider-pips.min.js: { minified: true, attributes: { defer: true } }
+  css:
+    component:
+      /libraries/jquery-ui-slider-pips/dist/jquery-ui-slider-pips.min.css: { minified: true }
+  dependencies:
+    - jquery_ui_slider/slider
+
+slider:
+  version: VERSION
+  js:
+    js/slider.js: { attributes: { defer: true } }
+  css:
+    component:
+      css/slider.css: {}
+  dependencies:
+    - core/drupal
+    - core/drupalSettings
+    - core/jquery.once
+    - format_strawberryfield_facets/jquery.ui.slider.pips
+    - jquery_ui_touch_punch/touch-punch
+
+date-range:
+  version: VERSION
+  js:
+    js/date-range.js: { attributes: { defer: true } }
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/drupalSettings

--- a/modules/format_strawberryfield_facets/js/date-range.js
+++ b/modules/format_strawberryfield_facets/js/date-range.js
@@ -18,11 +18,10 @@
 
       function autoSubmit($widget) {
         var facetId = $widget.attr("data-drupal-facet-id");
-        var daterange = settings.facets.sbfdaterange[facetId];
-        console.log($("input[id=".concat(facetId, "_min]")).val());
+        var submiturl = $("input[id=".concat(facetId, "_min]")).attr("data-drupal-url");
         var min = toTimestamp($("input[id=".concat(facetId, "_min]")).val()) || "";
         var max = toTimestamp($("input[id=".concat(facetId, "_max]")).val()) || "";
-        return daterange.url.replace("__date_range_min__", min).replace("__date_range_max__", max);
+        return submiturl.replace("__date_range_min__", min).replace("__date_range_max__", max);
       }
 
       if ($dateRangeFacets.length > 0) {

--- a/modules/format_strawberryfield_facets/js/date-range.js
+++ b/modules/format_strawberryfield_facets/js/date-range.js
@@ -1,0 +1,58 @@
+/**
+* @preserve
+**/
+
+(function ($) {
+  Drupal.facets = Drupal.facets || {};
+
+  Drupal.behaviors.sbfFacetsDateRange = {
+    attach: function attach(context, settings) {
+      var $dateRangeFacets = $('.js-facets-sbf-daterange', context)
+        .once('js-facets-sbf-daterange-on-click');
+
+
+      function toTimestamp(strDate) {
+        var datum = Date.parse(strDate);
+        return datum / 1000;
+      }
+
+      function autoSubmit($widget) {
+        var facetId = $widget.attr("data-drupal-facet-id");
+        var daterange = settings.facets.sbfdaterange[facetId];
+        console.log($("input[id=".concat(facetId, "_min]")).val());
+        var min = toTimestamp($("input[id=".concat(facetId, "_min]")).val()) || "";
+        var max = toTimestamp($("input[id=".concat(facetId, "_max]")).val()) || "";
+        return daterange.url.replace("__date_range_min__", min).replace("__date_range_max__", max);
+      }
+
+      if ($dateRangeFacets.length > 0) {
+        $dateRangeFacets
+          .each(function (index, widget) {
+            var $widget = $(widget);
+            // Click on link will call Facets JS API on widget element.
+            var changeHandler = function (e) {
+              //e.preventDefault();
+              $widget.trigger('facets_filter', [autoSubmit($widget)]);
+            };
+            // Add correct CSS selector for the widget. The Facets JS API will
+            // register handlers on that element.
+            $widget.addClass('js-facets-widget');
+
+            // Add handler for change on range inputs.
+            $("input.facet-date-range", context).on("change", changeHandler);
+            $("input.facet-date-range", context).on("keypress", function (e) {
+              $(this).off("change blur");
+              $(this).on("blur", changeHandler);
+              if (e.keyCode === 13) {
+                changeHandler();
+              }
+            });
+
+            // We have to trigger attaching of behaviours, so that Facets JS API can
+            // register handlers on link widgets.
+            Drupal.attachBehaviors(this.parentNode, Drupal.settings);
+          });
+      }
+    }
+  };
+})(jQuery);

--- a/modules/format_strawberryfield_facets/js/slider.js
+++ b/modules/format_strawberryfield_facets/js/slider.js
@@ -1,0 +1,48 @@
+/**
+ * @file
+ * Provides the slider functionality.
+ */
+
+(function ($) {
+
+  'use strict';
+
+  Drupal.facets = Drupal.facets || {};
+
+  Drupal.behaviors.facet_slider = {
+    attach: function (context, settings) {
+      if (settings.facets !== 'undefined' && settings.facets.sliders !== 'undefined') {
+        $.each(settings.facets.sliders, function (facet, settings) {
+          Drupal.facets.addSlider(facet, settings);
+        });
+      }
+    }
+  };
+
+  Drupal.facets.addSlider = function (facet, settings) {
+    var defaults = {
+      stop: function (event, ui) {
+        if (settings.range) {
+          window.location.href = settings.url.replace('__range_slider_min__', ui.values[0]).replace('__range_slider_max__', ui.values[1]);
+        }
+        else {
+          window.location.href = settings.urls['f_' + ui.value];
+        }
+      }
+    };
+
+    $.extend(defaults, settings);
+
+    $('[id^="' + facet + '"][id$="' + facet + '"]').slider(defaults)
+    .slider('pips', {
+      prefix: settings.prefix,
+      suffix: settings.suffix
+    })
+    .slider('float', {
+      prefix: settings.prefix,
+      suffix: settings.suffix,
+      labels: settings.labels
+    });
+  };
+
+})(jQuery);

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/processor/DateRangeProcessor.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/processor/DateRangeProcessor.php
@@ -68,12 +68,13 @@ class DateRangeProcessor extends ProcessorPluginBase implements PreQueryProcesso
       }
       elseif (is_array($item)) {
 
-        /*   $item = [
-              $matches[1],
-              $matches[2],
-              'min' => $matches[1],
-              'max' => $matches[2],
-            ];
+        /*
+        $item = [
+           $matches[1],
+           $matches[2],
+           'min' => $matches[1],
+           'max' => $matches[2],
+        ];
         */
         // Inverse min max if min > max
         if (isset($item[0]) && isset($item[1]) && $item[0] > $item[1]) {

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/processor/DateRangeProcessor.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/processor/DateRangeProcessor.php
@@ -118,8 +118,6 @@ class DateRangeProcessor extends ProcessorPluginBase implements PreQueryProcesso
       $result->setUrl($url);
     }
     if (count($results)) {
-      $urlProcessorManager = \Drupal::service('plugin.manager.facets.url_processor');
-      $url_processor = $urlProcessorManager->createInstance($facet->getFacetSourceConfig()->getUrlProcessorName(), ['facet' => $facet]);
       $active_filters = $url_processor->getActiveFilters();
       unset($active_filters[$facet->id()]);
       $urlGenerator = \Drupal::service('facets.utility.url_generator');

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/processor/DateRangeProcessor.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/processor/DateRangeProcessor.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\format_strawberryfield_facets\Plugin\facets\processor;
+
+use Drupal\facets\FacetInterface;
+use Drupal\facets\Processor\PreQueryProcessorInterface;
+use Drupal\facets\Processor\ProcessorPluginBase;
+use Drupal\facets\Processor\BuildProcessorInterface;
+
+/**
+ * Provides a processor that show all values between a range of dates.
+ *
+ * @FacetsProcessor(
+ *   id = "sbf_date_range",
+ *   label = @Translation("Format Strawberryfield Date Range Picker"),
+ *   description = @Translation("Show all content between min and max range dates."),
+ *   stages = {
+ *     "pre_query" = 60,
+ *     "build" = 20
+ *   }
+ * )
+ */
+class DateRangeProcessor extends ProcessorPluginBase implements PreQueryProcessorInterface, BuildProcessorInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preQuery(FacetInterface $facet): void {
+    $active_items = $facet->getActiveItems();
+
+    array_walk($active_items, function (&$item) {
+      if (is_string($item)) {
+        if (preg_match('/\(min:([^,]*),max:(.*)\)/i', $item, $matches)) {
+          if (!empty($matches[1]) && !empty($matches[2])) {
+            $item = [
+              $matches[1],
+              $matches[2],
+              'min' => $matches[1],
+              'max' => $matches[2],
+            ];
+          }
+          elseif (!empty($matches[1]) && empty($matches[2])) {
+            $item = [
+              $matches[1],
+              date('U', strtotime('+100 years')),
+              'min' => $matches[1],
+            ];
+          }
+          elseif (empty($matches[1]) && !empty($matches[2])) {
+            $item = [
+              date('U', 0),
+              $matches[2],
+              'max' => $matches[2],
+            ];
+          }
+          else {
+            $item = [
+              date('U', 0),
+              date('U', strtotime('+100 years')),
+            ];
+          }
+        }
+        else {
+          $item = [];
+        }
+      }
+      elseif (is_array($item)) {
+
+        /*   $item = [
+              $matches[1],
+              $matches[2],
+              'min' => $matches[1],
+              'max' => $matches[2],
+            ];
+        */
+        // Inverse min max if min > max
+        if (isset($item[0]) && isset($item[1]) && $item[0] > $item[1]) {
+          $item = [
+            $item[1],
+            $item[0],
+            'min' => $item[1],
+            'max' => $item[0],
+            ];
+        }
+        else {
+          $item = $item;
+        }
+      }
+      else {
+        $item = [];
+      }
+    });
+    $facet->setActiveItems($active_items);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(FacetInterface $facet, array $results): array {
+    /** @var \Drupal\facets\Plugin\facets\processor\UrlProcessorHandler $url_processor_handler */
+    $url_processor_handler = $facet->getProcessors()['url_processor_handler'];
+    $url_processor = $url_processor_handler->getProcessor();
+    $filter_key = $url_processor->getFilterKey();
+
+    /** @var \Drupal\facets\Result\ResultInterface[] $results */
+    foreach ($results as &$result) {
+      $url = $result->getUrl();
+      $query = $url->getOption('query');
+
+      // Remove all the query filters for the field of the facet.
+      if (isset($query[$filter_key])) {
+        foreach ($query[$filter_key] as $id => $filter) {
+          if (strpos($filter . $url_processor->getSeparator(), $facet->getUrlAlias()) === 0) {
+            unset($query[$filter_key][$id]);
+          }
+        }
+      }
+
+      $query[$filter_key][] = $facet->getUrlAlias() . $url_processor->getSeparator() . '(min:__date_range_min__,max:__date_range_max__)';
+      $url->setOption('query', $query);
+      $result->setUrl($url);
+    }
+    return $results;
+  }
+
+}

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/processor/DateRangeProcessor.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/processor/DateRangeProcessor.php
@@ -136,14 +136,16 @@ class DateRangeProcessor extends ProcessorPluginBase implements PreQueryProcesso
         $url_active->setOption('query', $params);
       }
       $range = [];
-      $range[] = $this->getRangeFromResults($results);
+      $range = $facet->getActiveItems();
+      if (isset($range[0])) {
+        $range[0]['count'] = array_sum(array_map(function ($item) {
+          return $item->getCount();
+        }, $results));
+      }
       if (count($range) == 0) {
         // Means we are already are not inside a valid range, give this a 0 count
         // Just to allow people to reset this.
-        $range = $facet->getActiveItems();
-        if (isset($range[0])) {
-          $range[0]['count'] = 0;
-        }
+        $range[] = $this->getRangeFromResults($results);
       }
       // generate an active value for the active facet
       foreach ($range as $range_entry) {

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/processor/RangeSliderProcessor.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/processor/RangeSliderProcessor.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\format_strawberryfield_facets\Plugin\facets\processor;
+
+use Drupal\facets\FacetInterface;
+use Drupal\facets\Processor\BuildProcessorInterface;
+use Drupal\facets\Processor\PreQueryProcessorInterface;
+
+/**
+ * Provides a processor that adds all range values between an min and max range.
+ *
+ * @FacetsProcessor(
+ *   id = "sbf_date_range_slider",
+ *   label = @Translation("Format Strawberryfield Date Range slider"),
+ *   description = @Translation("Add range Date results for all the steps between min and max range."),
+ *   stages = {
+ *     "pre_query" =60,
+ *     "post_query" = 60,
+ *     "build" = 20
+ *   }
+ * )
+ */
+class RangeSliderProcessor extends SliderProcessor implements PreQueryProcessorInterface, BuildProcessorInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preQuery(FacetInterface $facet) {
+    $active_items = $facet->getActiveItems();
+
+    array_walk($active_items, function (&$item) {
+      if (preg_match('/\(min:((?:-)?[\d\.]+),max:((?:-)?[\d\.]+)\)/i', $item, $matches)) {
+        $item = [$matches[1], $matches[2]];
+      }
+      else {
+        $item = NULL;
+      }
+    });
+    $facet->setActiveItems($active_items);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(FacetInterface $facet, array $results) {
+    /** @var \Drupal\facets\Plugin\facets\processor\UrlProcessorHandler $url_processor_handler */
+    $url_processor_handler = $facet->getProcessors()['url_processor_handler'];
+    $url_processor = $url_processor_handler->getProcessor();
+    $active_filters = $url_processor->getActiveFilters();
+
+    if (isset($active_filters[''])) {
+      unset($active_filters['']);
+    }
+
+    /** @var \Drupal\facets\Result\ResultInterface[] $results */
+    foreach ($results as &$result) {
+      $new_active_filters = $active_filters;
+      unset($new_active_filters[$facet->id()]);
+      // Add one generic query filter with the min and max placeholder.
+      $new_active_filters[$facet->id()][] = '(min:__range_slider_min__,max:__range_slider_max__)';
+      $url = \Drupal::service('facets.utility.url_generator')->getUrl($new_active_filters, FALSE);
+      $result->setUrl($url);
+    }
+
+    return $results;
+  }
+
+}

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/processor/SliderProcessor.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/processor/SliderProcessor.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\format_strawberryfield_facets\Plugin\facets\processor;
+
+use Drupal\facets\FacetInterface;
+use Drupal\facets\Processor\PostQueryProcessorInterface;
+use Drupal\facets\Processor\ProcessorPluginBase;
+use Drupal\facets\Result\Result;
+
+/**
+ * Provides a processor that adds all values between an min and max range.
+ *
+ * @FacetsProcessor(
+ *   id = "sbf_date_slider",
+ *   label = @Translation("Format Strawberryfield Date Slider"),
+ *   description = @Translation("Add Date results for all the steps between min and max range."),
+ *   stages = {
+ *     "post_query" = 60
+ *   }
+ * )
+ */
+class SliderProcessor extends ProcessorPluginBase implements PostQueryProcessorInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function postQuery(FacetInterface $facet) {
+    $widget = $facet->getWidgetInstance();
+    $config = $widget->getConfiguration();
+    $simple_results = [];
+
+    // Generate all the "results" between min and max, with the configured step.
+    foreach ($facet->getResults() as $result) {
+      $simple_results['f_' . (float) $result->getRawValue()] = [
+        'value' => (float) $result->getRawValue(),
+        'count' => (int) $result->getCount(),
+      ];
+    }
+    uasort($simple_results, function ($a, $b) {
+      return (int) $a['value'] - $b['value'];
+    });
+
+    $step = $config['step'];
+    if ($config['min_type'] == 'fixed') {
+      $min = $config['min_value'];
+      $max = $config['max_value'];
+    }
+    else {
+      $min = reset($simple_results)['value'] ?? 0;
+      $max = end($simple_results)['value'] ?? 0;
+      // If max is not divisible by step, we should add the remainder to max to
+      // make sure that we don't lose any possible values.
+      if ($max % $step !== 0) {
+        $max = $max + ($step - $max % $step);
+      }
+    }
+
+    // Creates an array of all results between min and max by the step from the
+    // configuration.
+    $new_results = [];
+    for ($i = $min; $i <= $max; $i += $step) {
+      $count = isset($simple_results['f_' . $i]) ? $simple_results['f_' . $i]['count'] : 0;
+      $new_results[] = new Result($facet, (float) $i, (float) $i, $count);
+    }
+
+    // Overwrite the current facet values with the generated results.
+    $facet->setResults($new_results);
+  }
+
+}

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeWidget.php
@@ -90,13 +90,6 @@ class DateRangeWidget extends WidgetPluginBase {
           'data-type' => 'date-range-max',
         ],
       ],
-      /*'filter' => [
-        '#type' => 'link',
-        '#url' => $url,
-        '#title' => t('Filter'),
-        '#options' => ['attributes' => ['class' => ['block-demo-backlink']]],
-        '#weight' => -10,
-      ],*/
     ];
     if ($this->getConfiguration()['show_reset_link'] && (!$this->getConfiguration()['hide_reset_when_no_selection'] || $facet->getActiveItems())) {
       // Add reset link even  if there are no results. Given that user might bypass completely the values
@@ -237,6 +230,9 @@ class DateRangeWidget extends WidgetPluginBase {
     $min = NULL;
     $max = NULL;
     foreach ($results as $result) {
+      if ($result->getRawValue() == 'summary_date_facet') {
+        continue;
+      }
       $min = $min ?? $result->getRawValue();
       $max = $max ?? $result->getRawValue();
       $min = $min < $result->getRawValue() ? $min : $result->getRawValue();

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeWidget.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\format_strawberryfield_facets\Plugin\facets\widget;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\facets\FacetInterface;
+use Drupal\facets\Result\Result;
+use Drupal\facets\Result\ResultInterface;
+use Drupal\facets\Widget\WidgetPluginBase;
+
+/**
+ * The Date Range widget.
+ *
+ * @FacetsWidget(
+ *   id = "sbf_date_range",
+ *   label = @Translation("Format Strawberryfield Date Range Picker"),
+ *   description = @Translation("A widget that shows a Date Range Picker."),
+ * )
+ */
+class DateRangeWidget extends WidgetPluginBase {
+
+  public function defaultConfiguration() {
+    return [
+        'show_reset_link' => FALSE,
+        'hide_reset_when_no_selection' => FALSE,
+        'reset_text' => $this->t('Show all'),
+      ] + parent::defaultConfiguration();
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function build(FacetInterface $facet): array {
+    $build = parent::build($facet);
+    $results = $facet->getResults();
+    $range = $this->getRangeFromResults($results);
+    if (empty($results)) {
+      return $build;
+    }
+
+    ksort($results);
+
+    $active = $facet->getActiveItems();
+    $real_min = $range['min'] ?? NULL;
+    $real_max = $range['max'] ?? NULL;
+
+    $min = reset($active)['min'] ?? $real_min;
+    $max = reset($active)['max'] ?? $real_max;
+    if ($real_min && $this->getConfiguration()['set_defaults_from_results']) {
+      $min = $min < $real_min ? $real_min : $min;
+    }
+    if ($real_max && $this->getConfiguration()['set_defaults_from_results']) {
+      $max = $max > $real_max ? $real_max : $max;
+    }
+
+    if (isset($min) && !empty($min)) {
+      $min = date('Y-m-d', (int) $min);
+    }
+    if (isset($max) && !empty($max)) {
+      $max = date('Y-m-d', (int) $max);
+    }
+
+
+
+    $build['#items'] = [
+      'min' => [
+        '#type' => 'date',
+        '#title' => $this->t('Date from'),
+        '#value' => $min,
+        '#attributes' => [
+          'class' => ['facet-date-range'],
+          'id' => $facet->id() . '_min',
+          'name' => $facet->id() . '_min',
+          'min' => $min,
+          'max' => $max,
+          'data-type' => 'date-range-min',
+        ],
+      ],
+      'max' => [
+        '#type' => 'date',
+        '#title' => $this->t('Date to'),
+        '#value' => $max,
+        '#attributes' => [
+          'class' => ['facet-date-range'],
+          'id' => $facet->id() . '_max',
+          'name' => $facet->id() . '_max',
+          'min' => $min,
+          'max' => $max,
+          'data-type' => 'date-range-max',
+        ],
+      ],
+      /*'filter' => [
+        '#type' => 'link',
+        '#url' => $url,
+        '#title' => t('Filter'),
+        '#options' => ['attributes' => ['class' => ['block-demo-backlink']]],
+        '#weight' => -10,
+      ],*/
+    ];
+    if ($this->getConfiguration()['show_reset_link'] && (!$this->getConfiguration()['hide_reset_when_no_selection'] || $facet->getActiveItems())) {
+      // Add reset link even  if there are no results. Given that user might bypass completely the values
+      // By using the GET arguments.
+      $max_items = array_sum(array_map(function ($item) {
+        return $item->getCount();
+      }, $results));
+
+      $urlProcessorManager = \Drupal::service('plugin.manager.facets.url_processor');
+      $url_processor = $urlProcessorManager->createInstance($facet->getFacetSourceConfig()->getUrlProcessorName(), ['facet' => $facet]);
+      $active_filters = $url_processor->getActiveFilters();
+
+      unset($active_filters[$facet->id()]);
+
+      $urlGenerator = \Drupal::service('facets.utility.url_generator');
+      if ($active_filters) {
+        $url = $urlGenerator->getUrl($active_filters, FALSE);
+      }
+      else {
+        $request = \Drupal::request();
+        $facet_source = $facet->getFacetSource();
+        $url = $urlGenerator->getUrlForRequest($request, $facet_source ? $facet_source->getPath() : NULL);
+        $params = $request->query->all();
+        unset($params[$url_processor->getFilterKey()]);
+        if (\array_key_exists('page', $params)) {
+          // Go back to the first page on reset.
+          unset($params['page']);
+        }
+        $url->setRouteParameter('facets_query', '');
+        $url->setOption('query', $params);
+      }
+
+      $result_item = new Result($facet, 'reset_all', $this->getConfiguration()['reset_text'], $max_items);
+      $result_item->setActiveState(FALSE);
+      $result_item->setUrl($url);
+
+      // Check if any other facet is in use.
+      $none_active = TRUE;
+      foreach ($results as $result) {
+        if ($result->isActive() || $result->hasActiveChildren()) {
+          $none_active = FALSE;
+          break;
+        }
+      }
+
+      // Add an is-active class when no other facet is in use.
+      if ($none_active) {
+        $result_item->setActiveState(TRUE);
+      }
+
+      // Build item.
+      $item = $this->buildListItems($facet, $result_item);
+
+      // Add a class for the reset link wrapper.
+      $item['#wrapper_attributes']['class'][] = 'facets-reset';
+
+      // Put reset facet link on first place.
+      array_unshift($build['#items'], $item);
+    }
+
+
+
+    $url = array_shift($results)->getUrl()->toString();
+    $build['#attached']['library'][] = 'format_strawberryfield_facets/date-range';
+    $build['#attached']['drupalSettings']['facets']['sbfdaterange'][$facet->id()] = [
+      'url' => $url,
+    ];
+    $build['#attributes']['class'][] = 'js-facets-links';
+    $build['#attributes']['class'][] = 'js-facets-sbf-daterange';
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isPropertyRequired($name, $type): bool {
+    return $name === 'sbf_date_range' && $type === 'processors';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQueryType(): string {
+    return 'range';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state, FacetInterface $facet): array {
+
+    $form['set_defaults_from_results'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Use results to set max/min date values'),
+      '#description' => $this->t('When selected, show Reset will be always enabled'),
+      '#default_value' => $this->getConfiguration()['set_defaults_from_results'],
+    ];
+    $form['show_reset_link'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show reset link'),
+      '#default_value' => $this->getConfiguration()['show_reset_link'],
+      '#states' => [
+        'required' => [
+          ':input[name="widget_config[set_defaults_from_results]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+    $form['reset_text'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Reset text'),
+      '#default_value' => $this->getConfiguration()['reset_text'],
+      '#states' => [
+        'visible' => [
+          ':input[name="widget_config[show_reset_link]"]' => ['checked' => TRUE],
+        ],
+        'required' => [
+          ':input[name="widget_config[show_reset_link]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+    $form['hide_reset_when_no_selection'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Hide reset link when no facet item is selected'),
+      '#default_value' => $this->getConfiguration()['hide_reset_when_no_selection'],
+    ];
+    $form += parent::buildConfigurationForm($form, $form_state, $facet);
+
+    $message = $this->t('To achieve the standard behavior of a Format Strawberryfield Date Range Picker, you need to enable the facet setting below <em>"Format Strawberryfield Date Range Picker"</em>.');
+    $form['warning'] = [
+      '#markup' => '<div class="messages messages--warning">' . $message . '</div>',
+    ];
+
+    return $form;
+  }
+
+  protected function getRangeFromResults(array $results) {
+    /* @var \Drupal\facets\Result\ResultInterface[] $results */
+    $min = NULL;
+    $max = NULL;
+    foreach ($results as $result) {
+      $min = $min ?? $result->getRawValue();
+      $max = $max ?? $result->getRawValue();
+      $min = $min < $result->getRawValue() ? $min : $result->getRawValue();
+      $max = $max > $result->getRawValue() ? $max : $result->getRawValue();
+    }
+    return ['min' => $min, 'max' => $max];
+  }
+
+}

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeWidget.php
@@ -37,6 +37,7 @@ class DateRangeWidget extends WidgetPluginBase {
     if (empty($results)) {
       return $build;
     }
+
     $range = $this->getRangeFromResults($results);
 
 
@@ -96,7 +97,7 @@ class DateRangeWidget extends WidgetPluginBase {
     $urlProcessorManager = \Drupal::service('plugin.manager.facets.url_processor');
     $url_processor = $urlProcessorManager->createInstance($facet->getFacetSourceConfig()->getUrlProcessorName(), ['facet' => $facet]);
     $urlGenerator = \Drupal::service('facets.utility.url_generator');
-
+    $url = NULL;
     if ($this->getConfiguration()['show_reset_link'] && (!$this->getConfiguration()['hide_reset_when_no_selection'] || $facet->getActiveItems())) {
       // Add reset link even  if there are no results. Given that user might bypass completely the values
       // By using the GET arguments.
@@ -151,9 +152,20 @@ class DateRangeWidget extends WidgetPluginBase {
     }
 
 
-    $url = array_shift($results)->getUrl()->toString();
-    $build['#items']['min']['#attributes']['data-drupal-url'] = $url;
-    $build['#attached']['library'][] = 'format_strawberryfield_facets/date-range';
+    if (!empty($results) && count($results) > 0) {
+      $result = array_shift($results);
+      $url_for_js = $result->getUrl();
+      if (!$url_for_js) {
+        $url_for_js = $url;
+      }
+      if ($url_for_js && $url_for_js instanceof \Drupal\core\Url) {
+        $url = $url_for_js->toString();
+        $build['#items']['min']['#attributes']['data-drupal-url'] = $url;
+        $build['#attached']['library'][]
+          = 'format_strawberryfield_facets/date-range';
+      }
+    }
+
     // Drupal never updates the drupalSettings after the first load/after the Ajax call gets done.
     $build['#attributes']['class'][] = 'js-facets-links';
     $build['#attributes']['class'][] = 'js-facets-sbf-daterange';

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/RangeSliderWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/RangeSliderWidget.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\format_strawberryfield_facets\Plugin\facets\widget;
+
+use Drupal\facets\FacetInterface;
+
+/**
+ * The range slider widget.
+ *
+ * @FacetsWidget(
+ *   id = "sbf_range_date_slider",
+ *   label = @Translation("Format Strawberryfield Date Range slider"),
+ *   description = @Translation("A widget that shows a range slider for Dates."),
+ * )
+ */
+class RangeSliderWidget extends SliderWidget {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(FacetInterface $facet) {
+    $build = parent::build($facet);
+
+    if (empty($facet->getResults())) {
+      return $build;
+    }
+
+    $active = $facet->getActiveItems();
+    $facet_settings = &$build['#attached']['drupalSettings']['facets']['sliders'][$facet->id()];
+
+    $facet_settings['range'] = TRUE;
+    $facet_settings['url'] = reset($facet_settings['urls']);
+
+    unset($facet_settings['value']);
+    unset($facet_settings['urls']);
+
+    $min = $facet_settings['min'];
+    $max = $facet_settings['max'];
+    $facet_settings['values'] = [
+      isset($active[0][0]) ? (float) $active[0][0] : $min,
+      isset($active[0][1]) ? (float) $active[0][1] : $max,
+    ];
+
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isPropertyRequired($name, $type) {
+    if ($name === 'sbf_date_range_slider' && $type === 'processors') {
+      return TRUE;
+    }
+    if ($name === 'show_only_one_result' && $type === 'settings') {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQueryType() {
+    //* See \Drupal\facets\Plugin\facets\facet_source\SearchApiDisplay::getQueryTypesForDataType
+    return 'range';
+  }
+
+}

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/SliderWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/SliderWidget.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Drupal\format_strawberryfield_facets\Plugin\facets\widget;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\facets\FacetInterface;
+use Drupal\facets\Widget\WidgetPluginBase;
+
+/**
+ * The slider widget.
+ *
+ * @FacetsWidget(
+ *   id = "sbf_date_slider",
+ *   label = @Translation("Format Strawberryfield Date Range slider"),
+ *   description = @Translation("A widget that shows a slider for Dates."),
+ * )
+ */
+class SliderWidget extends WidgetPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'prefix' => '',
+      'suffix' => '',
+      'min_type' => 'search_result',
+      'min_value' => 0,
+      'max_type' => 'search_result',
+      'max_value' => 10,
+      'step' => 1,
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(FacetInterface $facet) {
+    $build = parent::build($facet);
+
+    $results = $facet->getResults();
+    if (empty($results)) {
+      return $build;
+    }
+    ksort($results);
+
+    $show_numbers = $facet->getWidgetInstance()->getConfiguration()['show_numbers'];
+    $urls = [];
+    $labels = [];
+
+    foreach ($results as $result) {
+      $urls['f_' . $result->getRawValue()] = $result->getUrl()->toString();
+      $labels[] = $result->getDisplayValue() . ($show_numbers ? ' (' . $result->getCount() . ')' : '');
+    }
+    // The results set on the facet are sorted where the minimum is the first
+    // item and the last one is the one with the highest results, so it's safe
+    // to use min/max.
+    $min = (float) reset($results)->getRawValue();
+    $max = (float) end($results)->getRawValue();
+
+    $build['#items'] = [
+      [
+        '#type' => 'html_tag',
+        '#tag' => 'div',
+        '#attributes' => [
+          'class' => ['facet-slider'],
+          'id' => $facet->id(),
+        ],
+      ],
+    ];
+
+    $active = $facet->getActiveItems();
+
+    $build['#attached']['library'][] = 'format_strawberryfield_facets/slider';
+    $build['#attached']['drupalSettings']['facets']['sliders'][$facet->id()] = [
+      'min' => $min,
+      'max' => $max,
+      'value' => isset($active[0]) ? (float) $active[0] : '',
+      'urls' => $urls,
+      'prefix' => $this->getConfiguration()['prefix'],
+      'suffix' => $this->getConfiguration()['suffix'],
+      'step' => $this->getConfiguration()['step'],
+      'labels' => $labels,
+    ];
+
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state, FacetInterface $facet) {
+    $config = $this->getConfiguration();
+    $form = parent::buildConfigurationForm($form, $form_state, $facet);
+
+    $form['prefix'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Value prefix'),
+      '#size' => 5,
+      '#default_value' => $config['prefix'],
+    ];
+
+    $form['suffix'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Value suffix'),
+      '#size' => 5,
+      '#default_value' => $config['suffix'],
+    ];
+
+    $form['min_type'] = [
+      '#type' => 'radios',
+      '#options' => [
+        'fixed' => $this->t('Fixed value'),
+        'search_result' => $this->t('Based on search result'),
+      ],
+      '#title' => $this->t('Minimum value type'),
+      '#default_value' => $config['min_type'],
+    ];
+
+    $form['min_value'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Minimum value'),
+      '#default_value' => $config['min_value'],
+      '#size' => 10,
+      '#states' => [
+        'visible' => [
+          'input[name="widget_config[min_type]"]' => ['value' => 'fixed'],
+        ],
+      ],
+    ];
+
+    $form['max_type'] = [
+      '#type' => 'radios',
+      '#options' => [
+        'fixed' => $this->t('Fixed value'),
+        'search_result' => $this->t('Based on search result'),
+      ],
+      '#title' => $this->t('Maximum value type'),
+      '#default_value' => $config['max_type'],
+    ];
+
+    $form['max_value'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Maximum value'),
+      '#default_value' => $config['max_value'],
+      '#size' => 5,
+      '#states' => [
+        'visible' => [
+          'input[name="widget_config[max_type]"]' => ['value' => 'fixed'],
+        ],
+      ],
+    ];
+
+    $form['step'] = [
+      '#type' => 'number',
+      '#step' => 0.001,
+      '#title' => $this->t('slider step'),
+      '#default_value' => $config['step'],
+      '#size' => 2,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isPropertyRequired($name, $type) {
+    if ($name === 'sbf_date_slider' && $type === 'processors') {
+      return TRUE;
+    }
+    if ($name === 'show_only_one_result' && $type === 'settings') {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+}

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/SliderWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/SliderWidget.php
@@ -11,7 +11,7 @@ use Drupal\facets\Widget\WidgetPluginBase;
  *
  * @FacetsWidget(
  *   id = "sbf_date_slider",
- *   label = @Translation("Format Strawberryfield Date Range slider"),
+ *   label = @Translation("Format Strawberryfield Date slider"),
  *   description = @Translation("A widget that shows a slider for Dates."),
  * )
  */

--- a/modules/format_strawberryfield_facets/src/Plugin/facets_summary/processor/LastActiveFacetsProcessor.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets_summary/processor/LastActiveFacetsProcessor.php
@@ -1,0 +1,340 @@
+<?php
+
+namespace Drupal\format_strawberryfield_facets\Plugin\facets_summary\processor;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
+use Drupal\facets\Exception\InvalidProcessorException;
+use Drupal\facets\Plugin\facets\query_type\SearchApiDate;
+use Drupal\facets\Processor\ProcessorInterface;
+use Drupal\facets_summary\FacetsSummaryInterface;
+use Drupal\facets_summary\Processor\BuildProcessorInterface;
+use Drupal\facets_summary\Processor\ProcessorPluginBase;
+
+/**
+ * Provides a processor that adds Date ranges as a facet summary.
+ *
+ * @SummaryProcessor(
+ *   id = "sbf_last_active_facets",
+ *   label = @Translation("Adds Option to remove selected facets when there are no results at all"),
+ *   description = @Translation("When checked and no resilts, this facet will add a summary of previously selected facets."),
+ *   stages = {
+ *     "build" = 60
+ *   }
+ * )
+ */
+class LastActiveFacetsProcessor extends ProcessorPluginBase implements BuildProcessorInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(FacetsSummaryInterface $facets_summary, array $build, array $facets) {
+    $config = $facets_summary->getProcessorConfigs()[$this->getPluginId()];
+    $results_count = array_sum(array_map(function ($it) {
+      /** @var \Drupal\facets\FacetInterface $it */
+      return count($it->getResults());
+    }, $facets));
+
+    if (($results_count == 0 ) || ($config['settings']['enable_query'] ?? FALSE)) {
+      /** @var \drupal\facets\FacetSource\FacetSourcePluginInterface $facet_source_plugin */
+      $facet_source_plugin = \Drupal::service(
+        'plugin.manager.facets.facet_source'
+      )->createInstance($facets_summary->getFacetSourceId());
+      $search_id = $facet_source_plugin->getDisplay()->getPluginId();
+      $results_query = \Drupal::service('search_api.query_helper')->getResults(
+        $search_id
+      );
+    }
+
+    if ($results_count == 0) {
+      $results = [];
+      foreach ($facets as $facet) {
+        $build_stage_processors = $facet->getProcessorsByStage(ProcessorInterface::STAGE_BUILD);
+        $active_values = $facet->getActiveItems();
+        // Need to reset this bc each facet might have a different Query processor.
+        $facet_results = [];
+        if (empty($active_values)) {
+          continue;
+        }
+        foreach ($active_values as $active_value) {
+          if ($facet->getQueryType() == 'search_api_date' && !is_array($active_value)) {
+            if (in_array(
+              'date_item', array_keys($build_stage_processors)
+            )
+            ) {
+              try {
+                $active_value = $this->getTimestamp($active_value, $build_stage_processors['date_item']->getConfiguration()['granularity'] ?? 1);
+              } catch (\Exception $exception) {
+                // Do nothing if the String to Timestamp Date failed.
+                continue;
+              }
+            }
+          }
+          $facet_results[] = [
+            'filter' => $active_value,
+            'count'  => 1,
+          ];
+        }
+
+        $configuration = [
+          'query' => $results_query->getQuery(),
+          'facet' => $facet,
+          'results' => $facet_results ?? [],
+        ];
+
+        $query_type = \Drupal::service('plugin.manager.facets.query_type')
+          ->createInstance(
+            $facet->getQueryType(), $configuration
+          );
+        $query_type->getConfiguration();
+        $query_type->build();
+        // This will just rebuild the widget bc the facets
+        // were already built and statically cached so ...\Drupal::service('facets.manager')->build($facet);
+        $facet_results = $facet->getResults();
+        foreach ($build_stage_processors as $processor) {
+          if (!$processor instanceof
+            \Drupal\facets\Processor\BuildProcessorInterface
+          ) {
+            throw new InvalidProcessorException("The processor {$processor->getPluginDefinition()['id']} has a build definition but doesn't implement the required BuildProcessorInterface interface");
+          }
+          $facet_results = $processor->build($facet, $facet_results);
+        }
+        $facet->setResults($facet_results);
+        // Accumulate URLs?
+        foreach( $facet->getResults() as $result) {
+          $urls[] = $result->getUrl();
+        }
+
+        $results = array_merge(
+          $results, $this->buildResultTree($facet->getResults())
+        );
+      }
+
+      $build['#items'] = $results;
+      if ($config['settings']['enable_empty_message'] ?? FALSE) {
+        $item = [
+          '#theme' => 'facets_summary_empty',
+          '#message' => [
+            '#type' => 'processed_text',
+            '#text' => $config['settings']['text']['value'],
+            '#format' => $config['settings']['text']['format'],
+          ],
+        ];
+        array_unshift($build['#items'], $item);
+      }
+    }
+
+    if ($config['settings']['enable_query'] ?? FALSE) {
+      $facet_filter_keys = [];
+      foreach ($facets as $facet) {
+        /** @var \Drupal\facets\UrlProcessor\UrlProcessorInterface $urlProcessor */
+        $urlProcessor = $facet->getProcessors(
+        )['url_processor_handler']->getProcessor();
+        $facet_filter_keys[] = $urlProcessor->getFilterKey();
+      }
+      $facet_filter_keys = array_unique($facet_filter_keys);
+      // The original View?
+      /** @var \Drupal\views\ViewExecutable $view */
+      $view = $results_query->getQuery()->getOptions()['search_api_view'];
+      if ($view->getDisplay()->displaysExposed()) {
+        $exposed_input = $view->getExposedInput();
+        $view->getRequest()->getRequestUri();
+        $keys_to_filter = [];
+        foreach ($view->getDisplay()->options['filters'] as $filter) {
+          if ($filter['plugin_id'] == 'search_api_fulltext') {
+            $keys_to_filter[] = $filter['expose']['operator_id'] ?? NULL;
+            $keys_to_filter[] = $filter['expose']['identifier'] ?? NULL;
+          }
+          elseif ($filter['plugin_id'] == 'sbf_advanced_search_api_fulltext'
+            && $filter['exposed']
+          ) {
+            $extra_keys_to_filter = [];
+            $keys_to_filter[] = $filter['expose']['operator_id'] ?? NULL;
+            $keys_to_filter[] = $filter['expose']['identifier'] ?? NULL;
+            $keys_to_filter[] = $filter['expose']['searched_fields_id'] ?? NULL;
+            $keys_to_filter[] = $filter['expose']['advanced_search_operator_id']
+              ?? NULL;
+
+            foreach ($keys_to_filter as $key_to_filter) {
+              for (
+                $i = 1;
+                $i < $filter['expose']['advanced_search_fields_count'] ?? 1;
+                $i++
+              ) {
+                $extra_keys_to_filter[] = $key_to_filter . '_' . $i;
+              }
+            }
+            $keys_to_filter = array_filter($keys_to_filter);
+            $keys_to_filter = array_merge(
+              $keys_to_filter, $extra_keys_to_filter
+            );
+          }
+        }
+
+        $request = $view->getRequest();
+        $facet_source = $facet->getFacetSource();
+
+        $urlGenerator = \Drupal::service('facets.utility.url_generator');
+        $url_active = $urlGenerator->getUrlForRequest(
+          $request, $facet_source ? $facet_source->getPath() : NULL
+        );
+        $params = $request->query->all();
+        $search_term = [];
+        foreach ($params as $key => $param) {
+          if (in_array($key, $keys_to_filter)) {
+            $search_term[] = $exposed_input[$key] ?? NULL;
+            unset($params[$key]);
+          }
+        }
+
+        $search_term = array_filter($search_term);
+
+        if (count($search_term)) {
+          $url_active->setOption('query', $params);
+          $item = [
+            '#theme' => 'facets_result_item__summary',
+            '#value' => implode(" ", $search_term),
+            '#show_count' => FALSE,
+            '#count' => 0,
+            '#is_active' => TRUE,
+          ];
+          $item = (new Link($item, $url_active))->toRenderable();
+          $item['#wrapper_attributes'] = [
+            'class' => [
+              'facet-summary-item--facet',
+              'facet-summary-item--query',
+            ],
+          ];
+          $build['#items'][] = $item;
+        }
+      }
+    }
+
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state, FacetsSummaryInterface $facets_summary) {
+    // By default, there should be no config form.
+    $config = $this->getConfiguration();
+    $build['message'] = [
+      '#type' => 'markdown',
+      '#markdown' => $this->t(' It is recommended to disable the `Show a text when there are no results` Processor when using this one.')
+    ];
+    $build['enable'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable Facet Summary when no results'),
+      '#default_value' => $config['enable'],
+    ];
+    $build['enable_query'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Provide a Summary for the associated Facet Source Query Terms. This might be enabled even if no Results'),
+      '#default_value' => $config['enable_query'],
+    ];
+
+    $build['enable_empty_message'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Provide a Facet Summary when no results'),
+      '#default_value' => $config['enable_empty_message'],
+    ];
+    $build['text'] = [
+      '#type' => 'text_format',
+      '#title' => $this->t('Empty text'),
+      '#format' => $config['text']['format'],
+      '#editor' => TRUE,
+      '#default_value' => $config['text']['value'],
+    ];
+
+
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'enable' => TRUE,
+      'enable_empty_message' => TRUE,
+      'enable_query' => FALSE,
+      'text' => [
+        'format' => 'plain_text',
+        'value' => $this->t('No results found.'),
+      ],
+    ];
+  }
+
+  /**
+   * Build result tree, taking possible children into account.
+   *
+   * @param bool $show_count
+   *   Show the count next to the facet.
+   * @param \Drupal\facets\Result\ResultInterface[] $results
+   *   Facet results array.
+   *
+   * @return array
+   *   The rendered links to the active facets.
+   */
+  protected function buildResultTree(array $results) {
+    $items = [];
+    foreach ($results as $result) {
+      if ($result->isActive()) {
+        $item = [
+          '#theme' => 'facets_result_item__summary',
+          '#value' => $result->getDisplayValue(),
+          '#show_count' => TRUE,
+          '#count' => 0,
+          '#is_active' => TRUE,
+          '#facet' => $result->getFacet(),
+          '#raw_value' => $result->getRawValue(),
+        ];
+        $item = (new Link($item, $result->getUrl()))->toRenderable();
+        $item['#wrapper_attributes'] = [
+          'class' => [
+            'facet-summary-item--facet',
+          ],
+        ];
+        $items[] = $item;
+      }
+      if ($children = $result->getChildren()) {
+        $items = array_merge($items, $this->buildResultTree($children));
+      }
+    }
+    return $items;
+  }
+
+  protected function getTimestamp($value, int $granularity) {
+
+    switch ($granularity) {
+      case SearchApiDate::FACETAPI_DATE_YEAR:
+        $format = 'Y';
+        break;
+      case SearchApiDate::FACETAPI_DATE_MONTH:
+        $format = 'Y-m';
+        break;
+
+      case SearchApiDate::FACETAPI_DATE_DAY:
+        $format = 'Y-m-d';
+        break;
+
+      case SearchApiDate::FACETAPI_DATE_HOUR:
+        $format = 'Y-m-d\TH';
+        break;
+
+      case SearchApiDate::FACETAPI_DATE_MINUTE:
+        $format = 'Y-m-d\TH:i';
+        break;
+
+      default:
+        $format = 'Y-m-d\TH:i:s';
+        break;
+    }
+
+    $date = \DateTime::createFromFormat($format, $value);
+    return $date->getTimestamp();
+  }
+
+}

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.libraries.yml
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.libraries.yml
@@ -9,3 +9,13 @@ leaflet_strawberry_views:
     - core/drupalSettings
     - core/views
     - format_strawberryfield/leaflet_ajax
+
+modal-exposed-form-views-ajax:
+  js:
+    js/modal-exposed-form-ajax.js: {}
+  dependencies:
+    - core/drupal
+    - core/jquery
+    - core/jquery.once
+    - core/drupalSettings
+    - core/drupal.ajax

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.libraries.yml
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.libraries.yml
@@ -17,5 +17,15 @@ modal-exposed-form-views-ajax:
     - core/drupal
     - core/jquery
     - core/jquery.once
+    - core/once
+    - core/drupalSettings
+    - core/views
+    - core/views.ajax
+modal-exposed-form-facet-views-ajax:
+  js:
+    js/facets-views-ajax.js: {}
+  dependencies:
+    - facets/widget
     - core/drupalSettings
     - core/drupal.ajax
+    - core/views.ajax

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.module
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.module
@@ -9,6 +9,11 @@ use Drupal\Core\Template\Attribute;
 use Drupal\Component\Utility\Html;
 use Drupal\views\ViewExecutable;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
+use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\search_api\Entity\Index;
+use Drupal\search_api\Query\QueryInterface;
+use Solarium\Component\ComponentAwareQueryInterface;
+use Solarium\Core\Query\QueryInterface as SolariumQueryInterface;
 
 /**
  * Implements hook_theme().
@@ -54,12 +59,12 @@ function template_preprocess_format_strawberryfield_views_leaflet(array &$variab
       }
       foreach ($variables['rows']['grouped'] ?? [] as $group => $views_result_entity_uuids) {
         foreach ($views_result_entity_uuids as $views_result_entity_uuid) {
-        $url = $entity->getUrlForItemFromNodeUUID(
-          $views_result_entity_uuid, TRUE
-        );
+          $url = $entity->getUrlForItemFromNodeUUID(
+            $views_result_entity_uuid, TRUE
+          );
           $geojsonsgrouped[$group][] = $url;
-          }
         }
+      }
     }
   }
   // Tried base64 but that expands 3 bytes into 4. Means it grows.
@@ -118,5 +123,101 @@ function format_strawberryfield_views_views_query_alter(ViewExecutable $view, Qu
   // Leaflet Display to avoid Solr errors
   if ($query->getPluginId() == 'search_api_query' && $view->getStyle()->getPluginId() == 'format_strawberryfield_views_leaflet') {
     $query->setOption('ocr_highlight', 'off');
+  }
+}
+
+/**
+ * Implements hook_block_view_BASE_BLOCK_ID_alter() for 'views_exposed_filter_block_sbf'.
+ */
+function format_strawberryfield_views_block_view_views_exposed_filter_block_sbf_alter(array &$build, BlockPluginInterface $block) {
+  if ($block->getBaseId() == 'views_exposed_filter_block_sbf') {
+    $build['#pre_render'][] = 'Drupal\format_strawberryfield_views\Plugin\Block\ViewsExposedFilterBlockModal::preRender';
+  }
+}
+
+/**
+ * Implements hook_views_data_alter().
+ */
+function format_strawberryfield_views_views_data_alter(array &$data) {
+  //@see search_api_views_data()
+  /** @var \Drupal\search_api\IndexInterface $index */
+  foreach (Index::loadMultiple() as $index) {
+    try {
+      $key = 'search_api_index_' . $index->id();
+      $table = &$data[$key];
+      $advanced_fulltext_field = _search_api_views_find_field_alias('sbf_advanced_search_api_fulltext', $table);
+      $table[$advanced_fulltext_field] = [
+        'title'  => t('Advanced Fulltext search'),
+        'group' => t('Search'),
+        'help' => t('Search several or all fulltext fields at once allowing also multiple operator separated entries'),
+        'filter' => [
+          'title' => t('Advanced Fulltext search'),
+          'field' => 'id',
+          'id'    => 'sbf_advanced_search_api_fulltext',
+        ],
+      ];
+      if ($advanced_fulltext_field != 'sbf_advanced_search_api_fulltext') {
+        $table[$advanced_fulltext_field]['real field'] = 'sbf_advanced_search_api_fulltext';
+      }
+      // @TODO add also an argument ID if relationships are enabled to
+      // $table[$advanced_fulltext_field]['argument']['id'] = 'sbf_advanced_search_api_fulltext';
+      // Requires a special Argument Plugin. Not needed right now.
+    }
+    catch (\Exception $e) {
+      $args = [
+        '%index' => $index->label(),
+      ];
+      watchdog_exception('format_strawberryfield_views', $e, '%type while computing Views data for index %index: @message in %function (line %line of %file).', $args);
+    }
+  }
+  return $data;
+}
+
+
+/**
+ * Finds an unused field alias for a field in a Views table definition.
+ *
+ * @param string $field_id
+ *   The original ID of the Search API field.
+ * @param array $table
+ *   The Views table definition.
+ *
+ * @return string
+ *   The field alias to use.
+ */
+function _format_strawberryfield_views_find_field_alias($field_id, array &$table) {
+  $base = $field_alias = preg_replace('/[^a-zA-Z0-9]+/S', '_', $field_id);
+  $i = 0;
+  while (isset($table[$field_alias])) {
+    $field_alias = $base . '_' . ++$i;
+  }
+  return $field_alias;
+}
+
+
+/**
+ * Implements hook_search_api_solr_query_alter().
+ *
+ * Let modules alter the Solarium select query before executing it.
+ *
+ * After this hook, the select query will be finally converted into an
+ * expression that will be processed by the lucene query parser. Therefore you
+ * can't modify the 'q' parameter here, because it gets overwritten by that
+ * conversion. If you need to modify the 'q' parameter you should implement an
+ * event listener instead of this hook that handles the solarium events (our
+ * connector injects the drupal event handler into solarium) or implement
+ * hook_search_api_solr_converted_query() instead. If you want to force a
+ * different parser like edismax you must set the 'defType' parameter
+ * accordingly.
+ */
+function format_strawberryfield_views_search_api_solr_converted_query_alter(SolariumQueryInterface $solarium_query, QueryInterface $query) {
+  // To get a list of solarium events:
+  // @see http://solarium.readthedocs.io/en/stable/customizing-solarium/#plugin-system
+  if ($query->getOption('sbf_advanced_search_filter')) {
+    $components = $solarium_query->getComponents();
+    if (isset($components['edismax'])) {
+      $solarium_query->removeComponent(ComponentAwareQueryInterface::COMPONENT_EDISMAX);
+      $solarium_query->addParam('defType','lucene');
+    }
   }
 }

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.module
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.module
@@ -226,11 +226,34 @@ function format_strawberryfield_views_search_api_solr_converted_query_alter(Sola
  * Implements hook_library_info_alter().
  */
 function  format_strawberryfield_views_library_info_alter(&$libraries, $module) {
-  if ($module === 'facets' && isset($libraries['drupal.facets.views-ajax'])) {
-    unset($libraries['drupal.facets.views-ajax']['js']);
-    $libraries['drupal.facets.views-ajax']['dependencies'][]
-      = 'format_strawberryfield_views/modal-exposed-form-facet-views-ajax';
-    $libraries['drupal.facets.views-ajax']['dependencies'][]
-      = 'format_strawberryfield_views/modal-exposed-form-views-ajax';
+  // Update imaginary library 'foo' to version 2.0.
+  if ($extension === 'facets' && isset($libraries['drupal.facets.views-ajax'])) {
+
+      $libraries['drupal.facets.views-ajax']['version'] = '1.x';
+
+      // To accurately replace library files, the order of files and the options
+      // of each file have to be retained; e.g., like this:
+      $old_path = '/js';
+
+      // Since the replaced library files are no longer located in a directory
+      // relative to the original extension, specify an absolute path (relative
+      // to DRUPAL_ROOT / base_path()) to the new location.
+      $new_path = '/' . \Drupal::service('extension.list.module')
+          ->getPath('format_strawberryfield_views') . '/js';
+      $new_js = [];
+      $replacements = [
+        $old_path . '/facets-views-ajax.js' => $new_path . '/facets-views-ajax.js',
+      ];
+      foreach ($libraries['drupal.facets.views-ajax']['js'] as $source => $options) {
+        if (isset($replacements[$source])) {
+          $new_js[$replacements[$source]] = $options;
+        }
+        else {
+          $new_js[$source] = $options;
+        }
+      }
+      $libraries['drupal.facets.views-ajax']['js'] = $new_js;
+      $libraries['drupal.facets.views-ajax']['dependencies'][] = 'format_strawberryfield_views/modal-exposed-form-views-ajax';
+      array_unshift($libraries['drupal.facets.views-ajax']['dependencies'], 'core/views.ajax');
   }
 }

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.module
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.module
@@ -135,6 +135,22 @@ function format_strawberryfield_views_block_view_views_exposed_filter_block_sbf_
   }
 }
 
+
+/**
+ * Implements hook_block_view_BASE_BLOCK_ID_alter() for 'views_exposed_filter_block_sbf'.
+ */
+function format_strawberryfield_views_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if ($form_id == 'views_exposed_form') {
+    foreach ($form as $key => $value) {
+      if (is_array($value) && isset ($value['#group']) && isset($value['#type']) && $value['#group'] == 'actions' && $value['#type'] == 'submit') {
+        $form['actions'][$key] = $value;
+        unset($form[$key]);
+      }
+    }
+  }
+
+}
+
 /**
  * Implements hook_views_data_alter().
  */

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.module
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.module
@@ -225,15 +225,12 @@ function format_strawberryfield_views_search_api_solr_converted_query_alter(Sola
 /**
  * Implements hook_library_info_alter().
  */
-function  format_strawberryfield_views_library_info_alter(&$libraries, $module) {
-  // Update imaginary library 'foo' to version 2.0.
+function  format_strawberryfield_views_library_info_alter(&$libraries, $extension) {
   if ($extension === 'facets' && isset($libraries['drupal.facets.views-ajax'])) {
 
       $libraries['drupal.facets.views-ajax']['version'] = '1.x';
 
-      // To accurately replace library files, the order of files and the options
-      // of each file have to be retained; e.g., like this:
-      $old_path = '/js';
+      $old_path = 'js';
 
       // Since the replaced library files are no longer located in a directory
       // relative to the original extension, specify an absolute path (relative
@@ -254,6 +251,9 @@ function  format_strawberryfield_views_library_info_alter(&$libraries, $module) 
       }
       $libraries['drupal.facets.views-ajax']['js'] = $new_js;
       $libraries['drupal.facets.views-ajax']['dependencies'][] = 'format_strawberryfield_views/modal-exposed-form-views-ajax';
+      $libraries['drupal.facets.views-ajax']['dependencies'][] = 'facets/drupal.facets.dropdown-widget';
+      $libraries['drupal.facets.views-ajax']['dependencies'][] = 'facets/drupal.facets.link-widget';
+      $libraries['drupal.facets.views-ajax']['dependencies'][] = 'drupal.facets.checkbox-widget';
       array_unshift($libraries['drupal.facets.views-ajax']['dependencies'], 'core/views.ajax');
   }
 }

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.module
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.module
@@ -253,7 +253,7 @@ function  format_strawberryfield_views_library_info_alter(&$libraries, $extensio
       $libraries['drupal.facets.views-ajax']['dependencies'][] = 'format_strawberryfield_views/modal-exposed-form-views-ajax';
       $libraries['drupal.facets.views-ajax']['dependencies'][] = 'facets/drupal.facets.dropdown-widget';
       $libraries['drupal.facets.views-ajax']['dependencies'][] = 'facets/drupal.facets.link-widget';
-      $libraries['drupal.facets.views-ajax']['dependencies'][] = 'drupal.facets.checkbox-widget';
+      $libraries['drupal.facets.views-ajax']['dependencies'][] = 'facets/drupal.facets.checkbox-widget';
       array_unshift($libraries['drupal.facets.views-ajax']['dependencies'], 'core/views.ajax');
   }
 }

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.module
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.module
@@ -148,7 +148,6 @@ function format_strawberryfield_views_form_alter(&$form, FormStateInterface $for
       }
     }
   }
-
 }
 
 /**

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.module
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.module
@@ -221,3 +221,14 @@ function format_strawberryfield_views_search_api_solr_converted_query_alter(Sola
     }
   }
 }
+
+/**
+ * Implements hook_library_info_alter().
+ */
+function  format_strawberryfield_views_library_info_alter(&$libraries, $module) {
+  if ($module === 'facets' && isset($libraries['drupal.facets.views-ajax'])) {
+    unset($libraries['drupal.facets.views-ajax']['js']);
+    $libraries['drupal.facets.views-ajax']['dependencies'][]
+      = 'format_strawberryfield_views/modal-exposed-form-facet-views-ajax';
+  }
+}

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.module
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.module
@@ -230,5 +230,7 @@ function  format_strawberryfield_views_library_info_alter(&$libraries, $module) 
     unset($libraries['drupal.facets.views-ajax']['js']);
     $libraries['drupal.facets.views-ajax']['dependencies'][]
       = 'format_strawberryfield_views/modal-exposed-form-facet-views-ajax';
+    $libraries['drupal.facets.views-ajax']['dependencies'][]
+      = 'format_strawberryfield_views/modal-exposed-form-views-ajax';
   }
 }

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.routing.yml
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.routing.yml
@@ -1,0 +1,6 @@
+exposed_views_form_modal.block.ajax:
+  path: '/exposed-views-form-block-ajax'
+  defaults:
+    _controller: '\Drupal\format_strawberryfield_views\Controller\ViewsExposedFormModalBlockAjaxController::ajaxExposedFormBlockView'
+  requirements:
+    _access: 'TRUE'

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.services.yml
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.services.yml
@@ -1,0 +1,5 @@
+services:
+  format_strawberryfield_views.route_subscriber:
+    class: Drupal\format_strawberryfield_views\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/modules/format_strawberryfield_views/js/facets-views-ajax.js
+++ b/modules/format_strawberryfield_views/js/facets-views-ajax.js
@@ -127,16 +127,20 @@
 
     // Update facets summary block.
     if (this.updateFacetsSummaryBlock()) {
-      var facet_summary_wrapper_id = $('[data-drupal-facets-summary-id=' + settings.facets_views_ajax.facets_summary_ajax.facets_summary_id + ']').attr('id');
-      var facet_summary_block_id = '';
-      if (facet_summary_wrapper_id.indexOf('--') !== -1) {
-        facet_summary_block_id = facet_summary_wrapper_id.substring(0, facet_summary_wrapper_id.indexOf('--')).replace('block-', '');
-      } else {
-        facet_summary_block_id = facet_summary_wrapper_id.replace('block-', '');
+
+      var $facet_summary_wrapper = $('[data-drupal-facets-summary-id=' + settings.facets_views_ajax.facets_summary_ajax.facets_summary_id + ']');
+      if ($facet_summary_wrapper.length > 0) {
+        var facet_summary_wrapper_id = $facet_summary_wrapper.attr('id');
+        var facet_summary_block_id = '';
+        if (facet_summary_wrapper_id.indexOf('--') !== -1) {
+          facet_summary_block_id = facet_summary_wrapper_id.substring(0, facet_summary_wrapper_id.indexOf('--')).replace('block-', '');
+        } else {
+          facet_summary_block_id = facet_summary_wrapper_id.replace('block-', '');
+        }
+        facet_settings.submit.update_summary_block = true;
+        facet_settings.submit.facet_summary_block_id = facet_summary_block_id;
+        facet_settings.submit.facet_summary_wrapper_id = settings.facets_views_ajax.facets_summary_ajax.facets_summary_id;
       }
-      facet_settings.submit.update_summary_block = true;
-      facet_settings.submit.facet_summary_block_id = facet_summary_block_id;
-      facet_settings.submit.facet_summary_wrapper_id = settings.facets_views_ajax.facets_summary_ajax.facets_summary_id;
     }
     Drupal.ajax(facet_settings).execute();
   };

--- a/modules/format_strawberryfield_views/js/facets-views-ajax.js
+++ b/modules/format_strawberryfield_views/js/facets-views-ajax.js
@@ -1,0 +1,195 @@
+/**
+ * @file
+ * Facets views AJAX handling.
+ */
+
+
+(function ($, Drupal, drupalSettings) {
+  'use strict';
+
+  /**
+   * Keep the original beforeSend method to use it later.
+   */
+  var beforeSend = Drupal.Ajax.prototype.beforeSend;
+
+
+  /**
+   * Trigger views AJAX refresh on click.
+   */
+  Drupal.behaviors.facetsViewsAjax = {
+    attach: function (context, settings) {
+
+      // Loop through all facets.
+      $.each(settings.facets_views_ajax, function (facetId, facetSettings) {
+        // Get the View for the current facet.
+        var view, current_dom_id, view_path;
+        if (settings.views && settings.views.ajaxViews) {
+          $.each(settings.views.ajaxViews, function (domId, viewSettings) {
+            // Check if we have facet for this view.
+            if (facetSettings.view_id == viewSettings.view_name && facetSettings.current_display_id == viewSettings.view_display_id) {
+              view = $('.js-view-dom-id-' + viewSettings.view_dom_id);
+              current_dom_id = viewSettings.view_dom_id;
+              view_path = facetSettings.ajax_path;
+            }
+          });
+        }
+
+        if (!view || view.length != 1) {
+          return;
+        }
+
+        // Update view on summary block click.
+        if (Drupal.AjaxFacetsView.updateFacetsSummaryBlock() && (facetId === 'facets_summary_ajax')) {
+          $('[data-drupal-facets-summary-id=' + facetSettings.facets_summary_id + ']').children('ul').children('li').once().click(function (e) {
+            e.preventDefault();
+            var facetLink = $(this).find('a');
+            Drupal.AjaxFacetsView.UpdateView(facetLink.attr('href'), current_dom_id, view_path);
+          });
+        }
+        // Update view on facet item click.
+        else {
+          $('[data-drupal-facet-id=' + facetId + ']').each(function (index, facet_item) {
+            if ($(facet_item).hasClass('js-facets-widget')) {
+              $(facet_item).unbind('facets_filter.facets');
+              $(facet_item).on('facets_filter.facets', function (event, url) {
+                $('.js-facets-widget').trigger('facets_filtering');
+                Drupal.AjaxFacetsView.UpdateView(url, current_dom_id, view_path);
+              });
+            }
+          });
+        }
+      });
+    }
+  };
+
+  // Helper function to update views output & Ajax facets.
+  Drupal.AjaxFacetsView = {};
+
+  Drupal.AjaxFacetsView.UpdateView = function (href, current_dom_id, view_path) {
+    // Refresh view.
+    if (typeof(Drupal.views.instances['views_dom_id:' + current_dom_id]) !== 'undefined') {
+      var views_parameters = Drupal.Views.parseQueryString(href);
+      var views_arguments = Drupal.Views.parseViewArgs(href, 'search');
+      var views_settings = $.extend(
+        {},
+        Drupal.views.instances['views_dom_id:' + current_dom_id].settings,
+        views_arguments,
+        views_parameters
+      );
+
+      // Update View.
+      var views_ajax_settings = Drupal.views.instances['views_dom_id:' + current_dom_id].element_settings;
+      views_ajax_settings.submit = views_settings;
+      views_ajax_settings.url = view_path + '?q=' + href;
+
+      var viewRefreshAjaxObject = Drupal.ajax(views_ajax_settings);
+      viewRefreshAjaxObject.execute();
+
+      // Update url.
+      window.historyInitiated = true;
+      window.history.pushState(null, document.title, href);
+
+      // ToDo: Update views+facets with ajax on history back.
+      // For now we will reload the full page.
+      window.addEventListener("popstate", function (e) {
+        if (window.historyInitiated) {
+          window.location.reload();
+        }
+      });
+
+      // Refresh facets blocks.
+      this.updateFacetsBlocks(href, views_settings.view_name, views_settings.view_display_id);
+      Drupal.updateModalViewsFormBlocks(href, views_settings.view_name, views_settings.view_display_id);
+    }
+  }
+  Drupal.AjaxFacetsView.updateFacetsBlocks = function (href, view_id, current_display_id) {
+    var settings = drupalSettings;
+    var facets_blocks = this.facetsBlocks(view_id, current_display_id);
+
+    // Remove All Range Input Form Facet Blocks from being updated.
+    if(settings.facets && settings.facets.rangeInput) {
+      $.each(settings.facets.rangeInput, function (index, value) {
+        delete facets_blocks[value.facetId];
+      });
+    }
+    // Even if empty (e.g the query returns nothing/returned nothing before and all not visible)
+    // The summary might need to be updated anyhow.
+    // @TODO also do the same treatment for summary. Maybe we want to have multiple summaries in a single page?
+    // Update facet blocks.
+    var facet_settings = {
+      url: Drupal.url('facets-block-ajax'),
+      submit: {
+        facet_link: href,
+        facets_blocks: facets_blocks
+      }
+    };
+
+    // Update facets summary block.
+    if (this.updateFacetsSummaryBlock()) {
+      var facet_summary_wrapper_id = $('[data-drupal-facets-summary-id=' + settings.facets_views_ajax.facets_summary_ajax.facets_summary_id + ']').attr('id');
+      var facet_summary_block_id = '';
+      if (facet_summary_wrapper_id.indexOf('--') !== -1) {
+        facet_summary_block_id = facet_summary_wrapper_id.substring(0, facet_summary_wrapper_id.indexOf('--')).replace('block-', '');
+      } else {
+        facet_summary_block_id = facet_summary_wrapper_id.replace('block-', '');
+      }
+      facet_settings.submit.update_summary_block = true;
+      facet_settings.submit.facet_summary_block_id = facet_summary_block_id;
+      facet_settings.submit.facet_summary_wrapper_id = settings.facets_views_ajax.facets_summary_ajax.facets_summary_id;
+    }
+    Drupal.ajax(facet_settings).execute();
+  };
+
+  // Helper function to determine if we should update the summary block.
+  // Returns true or false.
+  Drupal.AjaxFacetsView.updateFacetsSummaryBlock = function () {
+    var settings = drupalSettings;
+    var update_summary = false;
+
+    if (settings.facets_views_ajax.facets_summary_ajax) {
+      update_summary = true;
+    }
+
+    return update_summary;
+  };
+
+  // Helper function, return facet blocks.
+  Drupal.AjaxFacetsView.facetsBlocks = function (view_id,current_display_id) {
+    // Get all ajax facets blocks from the current page.
+    var facets_blocks = {};
+    var facets_for_current_view = [];
+    $.each(drupalSettings.facets_views_ajax, function (facetId, facetSettings) {
+      if (facetSettings.view_id == view_id && current_display_id == facetSettings.current_display_id){
+        facets_for_current_view.push(facetId);
+      }
+    });
+
+    if (facets_for_current_view.length > 0) {
+      $('.block-facets-ajax').each(function (index) {
+        var $facet_found = false;
+        $(this).find('[data-drupal-facet-id]').each(function (index, value) {
+          var current_facet_id = $(this).data('drupal-facet-id');
+          if (facets_for_current_view.includes(current_facet_id)) {
+            $facet_found = true;
+          }
+          // We only need one. No reason to check every UL/LI of element
+          return false;
+        });
+
+        if ($facet_found) {
+          var block_id_start = 'js-facet-block-id-';
+          var block_id = $.map($(this).attr('class').split(' '), function (v, i) {
+            if (v.indexOf(block_id_start) > -1) {
+              return v.slice(block_id_start.length, v.length);
+            }
+          }).join();
+          var block_selector = '#' + $(this).attr('id');
+          facets_blocks[block_id] = block_selector;
+        }
+      });
+    }
+    return facets_blocks;
+  };
+
+
+})(jQuery, Drupal, drupalSettings);

--- a/modules/format_strawberryfield_views/js/facets-views-ajax.js
+++ b/modules/format_strawberryfield_views/js/facets-views-ajax.js
@@ -96,10 +96,11 @@
           window.location.reload();
         }
       });
-
-      // Refresh facets blocks.
       this.updateFacetsBlocks(href, views_settings.view_name, views_settings.view_display_id);
-      Drupal.updateModalViewsFormBlocks(href, views_settings.view_name, views_settings.view_display_id);
+      if (typeof(drupalSettings.format_strawberryfield_views) !== 'undefined') {
+        // Refresh facets blocks.
+        Drupal.updateModalViewsFormBlocks(href, views_settings.view_name, views_settings.view_display_id);
+      }
     }
   }
   Drupal.AjaxFacetsView.updateFacetsBlocks = function (href, view_id, current_display_id) {

--- a/modules/format_strawberryfield_views/js/facets-views-ajax.js
+++ b/modules/format_strawberryfield_views/js/facets-views-ajax.js
@@ -69,6 +69,8 @@
     // Refresh view.
     if (typeof(Drupal.views.instances['views_dom_id:' + current_dom_id]) !== 'undefined') {
       var views_parameters = Drupal.Views.parseQueryString(href);
+      // Note this is wrong. Assumes the Views Path is 'search'
+      // We should use view_path!
       var views_arguments = Drupal.Views.parseViewArgs(href, 'search');
       var views_settings = $.extend(
         {},
@@ -76,7 +78,7 @@
         views_arguments,
         views_parameters
       );
-
+      // Not even needed here if we are using the original element settings ....mmmm
       // Update View.
       var views_ajax_settings = Drupal.views.instances['views_dom_id:' + current_dom_id].element_settings;
       views_ajax_settings.submit = views_settings;

--- a/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
+++ b/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
@@ -170,10 +170,16 @@
           Drupal.AjaxFacetsView.updateFacetsBlocks(href, options.extraData.view_name, options.extraData.view_display_id);
         }
       }
+      var exposed_form_selector = '#views-exposed-form-' + options.extraData.view_name.replace(/_/g, '-') + '-' + options.extraData.view_display_id.replace(/_/g, '-');
+      var $exposed_form = $(exposed_form_selector).length;
+      if ($exposed_form > 0) {
+        $exposed_form = 1;
+      }
+      options.extraData.exposed_form = $exposed_form;
     }
 
     // Call the original Drupal method with the right context.
-    beforeSend.apply(this, arguments);
+    beforeSend.apply(this, [xmlhttprequest,options]);
   }
 
   // Helper function to add exposed form data to Modal Exposed Views Form url

--- a/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
+++ b/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
@@ -166,7 +166,6 @@
         }
       }
       if (typeof(settings.facets_views_ajax) !== 'undefined') {
-         console.log('defined!');
         var reloadfacets = false;
         $.each(settings.facets_views_ajax, function (facetId, facetSettings) {
           if (facetSettings.view_id == options.extraData.view_name && facetSettings.current_display_id == options.extraData.view_display_id) {
@@ -183,28 +182,43 @@
       const const_url_parts = options.url.split('?');
       if (const_url_parts[0] == '/views/ajax') {
         ajax_views_call = true;
-        const urlParams = new URLSearchParams('?' + options.data);
-        view_name = urlParams.get('view_name');
-        view_display_id = urlParams.get('view_display_id');
+        if (typeof(options.data) == 'string') {
+          const urlParams = new URLSearchParams('?' + options.data);
+          view_name = urlParams.get('view_name');
+          view_display_id = urlParams.get('view_display_id');
+        }
+        else {
+          view_name = options.data.hasOwnProperty('view_name') ?  options.data['view_name'] : null;
+          view_display_id = options.data.hasOwnProperty('view_display_id') ? options.data['view_display_id'] : null;
+        }
       }
     }
-    // Check if this is going into an ajax/views call.
 
+    // Check if this is going into an ajax/views call.
     if (ajax_views_call && view_name && view_display_id) {
       var exposed_form_selector = '#views-exposed-form-' + view_name.replace(/_/g, '-') + '-' + view_display_id.replace(/_/g, '-');
       var $exposed_form = $(exposed_form_selector).length;
+      console.log($exposed_form);
+      console.log(exposed_form_selector);
       if ($exposed_form > 0) {
         $exposed_form = 1;
       }
-      if (typeof(options.extraData) != 'undefined') {
+     if (typeof(options.extraData) != 'undefined') {
         options.extraData = {};
       }
       options.extraData = $.extend({}, options.extraData, {
         exposed_form_display: $exposed_form
       });
+
+     if (typeof(options.data) == 'string') {
+       var params = Drupal.Views.parseQueryString(options.data);
+       params['exposed_form_display'] = $exposed_form;
+       options.data = $.param(params);
+     }
+     else {
+       options.data['exposed_form_display'] = $exposed_form;
+     }
     }
-
-
     // Call the original Drupal method with the right context.
     beforeSend.apply(this, [xmlhttprequest,options]);
   }

--- a/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
+++ b/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
@@ -1,0 +1,235 @@
+/**
+ * @file
+ * Facets views AJAX handling.
+ */
+
+
+(function ($, Drupal) {
+  'use strict';
+
+  /**
+   * Keep the original beforeSend method to use it later.
+   */
+  var beforeSend = Drupal.Ajax.prototype.beforeSend;
+
+  var attachExposedFormAjax = Drupal.views.ajaxView.prototype.attachExposedFormAjax;
+
+  /**
+   * Trigger views AJAX refresh on click.
+   */
+  Drupal.behaviors.sbfModalExposedFormViewsAjax = {
+    attach: function (context, settings) {
+
+      // Loop through all facets.
+      $.each(settings.format_strawberryfield_views.modal_exposed_form_block, function (formId, blockSettings) {
+        // Get the View for the current facet.
+        var view, current_dom_id, view_path;
+        if (settings.views && settings.views.ajaxViews) {
+          $.each(settings.views.ajaxViews, function (domId, viewSettings) {
+            // Check if we have facet for this view.
+            if (blockSettings.view_id == viewSettings.view_name && blockSettings.current_display_id == viewSettings.view_display_id) {
+              view = $('.js-view-dom-id-' + viewSettings.view_dom_id);
+              current_dom_id = viewSettings.view_dom_id;
+              view_path = blockSettings.ajax_path;
+            }
+          });
+        }
+
+        if (!view || view.length != 1) {
+          return;
+        }
+        this.$view = view;
+
+        var ajaxPath = drupalSettings.views.ajax_path;
+
+        if (ajaxPath.constructor.toString().indexOf('Array') !== -1) {
+          ajaxPath = ajaxPath[0];
+        }
+
+        var queryString = window.location.search || '';
+
+        if (queryString !== '') {
+          queryString = queryString.slice(1).replace(/q=[^&]+&?|&?render=[^&]+/, '');
+
+          if (queryString !== '') {
+            queryString = (/\?/.test(ajaxPath) ? '&' : '?') + queryString;
+          }
+        }
+
+        this.element_settings = {
+          url: ajaxPath + queryString,
+          submit: settings,
+          setClick: true,
+          event: 'click',
+          selector: view,
+          progress: {
+            type: 'fullscreen'
+          }
+        };
+        this.settings = settings;
+        this.$exposed_form = $(formId);
+        once('exposed-form', this.$exposed_form).forEach($.proxy(attachExposedFormAjax, this));
+        var selfSettings = $.extend({}, this.element_settings, {
+          event: 'RefreshView',
+          base: this.selector,
+          element: this.$view.get(0)
+        });
+        this.refreshViewAjax = Drupal.ajax(selfSettings);
+
+
+      /*Drupal.views.ajaxView.prototype.attachExposedFormAjax = function () {
+        var that = this;
+        this.exposedFormAjax = [];
+
+        if (that.element_settings.submit) {
+          that.element_settings.submit.exposed_form_display = 1;
+        }
+
+        $('input[type=submit], button[type=submit], input[type=image]', this.$exposed_form).not('[data-drupal-selector=edit-reset]').each(function (index) {
+          var selfSettings = $.extend({}, that.element_settings, {
+            base: $(this).attr('id'),
+            element: this
+          });
+          that.exposedFormAjax[index] = Drupal.ajax(selfSettings);
+        });
+      };*/
+
+
+
+
+
+
+          /*$('[data-drupal-facet-id=' + facetId + ']').each(function (index, facet_item) {
+            if ($(facet_item).hasClass('js-facets-widget')) {
+              $(facet_item).unbind('facets_filter.facets');
+              $(facet_item).on('facets_filter.facets', function (event, url) {
+                $('.js-facets-widget').trigger('facets_filtering');
+                updateFacetsView(url, current_dom_id, view_path);
+              });
+            }
+          });*/
+      });
+    }
+  };
+
+  // Helper function to update views output & Ajax facets.
+  var updateFacetsView = function (href, current_dom_id, view_path, block_ids) {
+    // Refresh view.
+    var views_parameters = Drupal.Views.parseQueryString(href);
+    var views_arguments = Drupal.Views.parseViewArgs(href, 'search');
+    var views_settings = $.extend(
+      {},
+      Drupal.views.instances['views_dom_id:' + current_dom_id].settings,
+      views_arguments,
+      views_parameters
+    );
+
+    // Update View.
+    var views_ajax_settings = Drupal.views.instances['views_dom_id:' + current_dom_id].element_settings;
+    views_ajax_settings.submit = views_settings;
+    views_ajax_settings.url = view_path + '?q=' + href;
+
+    Drupal.ajax(views_ajax_settings).execute();
+
+    // Update url.
+    window.historyInitiated = true;
+    window.history.pushState(null, document.title, href);
+
+    // ToDo: Update views+facets with ajax on history back.
+    // For now we will reload the full page.
+    window.addEventListener("popstate", function (e) {
+      if (window.historyInitiated) {
+        window.location.reload();
+      }
+    });
+
+    // Refresh facets blocks.
+    updateModalViewsFormBlocks(href);
+  }
+
+  // Helper function, updates facet blocks.
+  var updateModalViewsFormBlocks = function (href, block_ids) {
+    var settings = drupalSettings;
+    var modalviews_blocks = block_ids;
+
+    // Update Modal Exposed Form Views blocks.
+    var modal_form_exposed_settings = {
+      url: Drupal.url('exposed-views-form-block-ajax'),
+      submit: {
+        exposedform_link: href,
+        modalviews_blocks: modalviews_blocks
+      }
+    };
+
+    Drupal.ajax(modal_form_exposed_settings).execute();
+  };
+
+
+  // Helper function, return facet blocks.
+  var modalViewsFormBlocks = function () {
+    // Get all ajax facets blocks from the current page.
+    var modalviews_blocks = {};
+
+    $('.block-modalformviews-ajax').each(function (index) {
+      var block_id_start = 'js-modal-form-views-block-id-';
+      var block_id = $.map($(this).attr('class').split(' '), function (v, i) {
+        if (v.indexOf(block_id_start) > -1) {
+          return v.slice(block_id_start.length, v.length);
+        }
+      }).join();
+      var block_selector = '#' + $(this).attr('id');
+      modalviews_blocks[block_id] = block_selector;
+    });
+
+    return modalviews_blocks;
+  };
+
+  /**
+   * Overrides beforeSend to trigger facetblocks update on exposed filter change.
+   *
+   * @param {XMLHttpRequest} xmlhttprequest
+   *   Native Ajax object.
+   * @param {object} options
+   *   jQuery.ajax options.
+   */
+  Drupal.Ajax.prototype.beforeSend = function (xmlhttprequest, options) {
+
+    // Get view from options.
+    if (typeof options.extraData !== 'undefined' && typeof options.extraData.view_name !== 'undefined') {
+      var href = window.location.href;
+      var settings = drupalSettings;
+
+      var reload = false;
+      var block_ids = {};
+      $.each(settings.format_strawberryfield_views.modal_exposed_form_block, function (formId, blockSettings) {
+        if (blockSettings.view_id == options.extraData.view_name && blockSettings.current_display_id == options.extraData.view_display_id) {
+          reload = true;
+          block_ids[formId] = blockSettings.block_id;
+        }
+
+      });
+
+      if (reload) {
+        href = addExposedFiltersToModalExposedViewsBlockUrl(href, options.extraData.view_name, options.extraData.view_display_id);
+        updateModalViewsFormBlocks(href, block_ids);
+      }
+    }
+
+    // Call the original Drupal method with the right context.
+    beforeSend.apply(this, arguments);
+  }
+
+  // Helper function to add exposed form data to Modal Exposed Views Form url
+  var addExposedFiltersToModalExposedViewsBlockUrl = function (href, view_name, view_display_id) {
+    var $exposed_form = $('form#views-exposed-form-' + view_name.replace(/_/g, '-') + '-' + view_display_id.replace(/_/g, '-'));
+
+    var params = Drupal.Views.parseQueryString(href);
+
+    $.each($exposed_form.serializeArray(), function () {
+      params[this.name] = this.value;
+    });
+
+    return href.split('?')[0] + '?' + $.param(params);
+  };
+
+})(jQuery, Drupal);

--- a/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
+++ b/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
@@ -69,23 +69,23 @@
           // Do what Drupal.views.ajaxView.prototype.attachExposedFormAjax does differently
 
           Object.keys(drupalSettings.views.ajaxViews || {}).forEach((i) => {
-              //var block_settings = drupalSettings.format_strawberryfield_views.modal_exposed_form_block[$modal_exposed_form_id];
-              if (Drupal.views.instances[i].settings.view_name == $view_parts[0] //block_settings.view_id
-                && Drupal.views.instances[i].settings.view_display_id == $view_parts[1]) { //block_settings.current_display_id) {
-                var exposed_form_selector = '#views-exposed-form-' + $view_parts[0].replace(/_/g, '-') + '-' +$view_parts[1].replace(/_/g, '-');
-                var $exposed_form = $(exposed_form_selector).length;
-                if ($exposed_form > 0) {
-                  $exposed_form = 1 ;
-                }
-                $('input[type=submit], button[type=submit], input[type=image]', $modal_exposed_form).not('[data-drupal-selector=edit-reset]').each(function (index) {
-                  var selfSettings = $.extend({}, Drupal.views.instances[i].element_settings, {
-                    base: $(this).attr('id'),
-                    element: this
-                  });
-                  selfSettings.submit.exposed_form_display = $exposed_form;
-                  $modal_exposed_form.exposedFormAjax[index] = Drupal.ajax(selfSettings);
-                });
+            //var block_settings = drupalSettings.format_strawberryfield_views.modal_exposed_form_block[$modal_exposed_form_id];
+            if (Drupal.views.instances[i].settings.view_name == $view_parts[0] //block_settings.view_id
+              && Drupal.views.instances[i].settings.view_display_id == $view_parts[1]) { //block_settings.current_display_id) {
+              var exposed_form_selector = '#views-exposed-form-' + $view_parts[0].replace(/_/g, '-') + '-' +$view_parts[1].replace(/_/g, '-');
+              var $exposed_form = $(exposed_form_selector).length;
+              if ($exposed_form > 0) {
+                $exposed_form = 1 ;
               }
+              $('input[type=submit], button[type=submit], input[type=image]', $modal_exposed_form).not('[data-drupal-selector=edit-reset]').each(function (index) {
+                var selfSettings = $.extend({}, Drupal.views.instances[i].element_settings, {
+                  base: $(this).attr('id'),
+                  element: this
+                });
+                selfSettings.submit.exposed_form_display = $exposed_form;
+                $modal_exposed_form.exposedFormAjax[index] = Drupal.ajax(selfSettings);
+              });
+            }
           });
         });
       }
@@ -138,20 +138,24 @@
     if (typeof options.extraData !== 'undefined' && typeof options.extraData.view_name !== 'undefined') {
       var href = window.location.href;
       var settings = drupalSettings;
+      const $current_form_params_as_array = this.$form.serializeArray();
+      href = addExposedFiltersToModalExposedViewsBlockUrl(href, options.extraData.view_name, options.extraData.view_display_id, $current_form_params_as_array);
 
-      var reload = false;
-      var block_ids = {};
-      $.each(settings.format_strawberryfield_views.modal_exposed_form_block, function (formId, blockSettings) {
-        if (blockSettings.view_id == options.extraData.view_name && blockSettings.current_display_id == options.extraData.view_display_id) {
-          reload = true;
-          block_ids[formId] = blockSettings.block_id;
+      if (typeof(settings.format_strawberryfield_views) !== 'undefined' && typeof(settings.format_strawberryfield_views.modal_exposed_form_block) !== 'undefined') {
+        var reload = false;
+        var block_ids = {};
+        $.each(settings.format_strawberryfield_views.modal_exposed_form_block, function (formId, blockSettings) {
+          if (blockSettings.view_id == options.extraData.view_name && blockSettings.current_display_id == options.extraData.view_display_id) {
+            reload = true;
+            block_ids[formId] = blockSettings.block_id;
+          }
+        });
+        if (reload) {
+          Drupal.updateModalViewsFormBlocks(href, options.extraData.view_name, options.extraData.view_display_id);
         }
-      });
-
-      if (reload) {
-        const $current_form_params_as_array = this.$form.serializeArray();
-        href = addExposedFiltersToModalExposedViewsBlockUrl(href, options.extraData.view_name, options.extraData.view_display_id, $current_form_params_as_array);
-        Drupal.updateModalViewsFormBlocks(href, options.extraData.view_name, options.extraData.view_display_id);
+      }
+      if (typeof(settings.facets_views_ajax) !== 'undefined') {
+         console.log('defined!');
         var reloadfacets = false;
         $.each(settings.facets_views_ajax, function (facetId, facetSettings) {
           if (facetSettings.view_id == options.extraData.view_name && facetSettings.current_display_id == options.extraData.view_display_id) {
@@ -159,6 +163,7 @@
           }
         });
         if (reloadfacets) {
+          console.log('reloading!');
           Drupal.AjaxFacetsView.updateFacetsBlocks(href, options.extraData.view_name, options.extraData.view_display_id);
         }
       }

--- a/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
+++ b/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
@@ -90,7 +90,7 @@
         });
       }
 
-      if (typeof(drupalSettings.views.ajaxViews) != 'undefined') {
+      if (typeof(drupalSettings.views) != 'undefined') {
         if ($context.is('div[data-drupal-modalblock-selector]')) {
           this.attachModalFormAjax($context);
         }

--- a/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
+++ b/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
@@ -116,7 +116,7 @@
     $('.block-modalformviews-ajax').each(function (index) {
       var block_id_start = 'js-modal-form-views-block-id-';
       var block_id = $.map($(this).attr('class').split(' '), function (v, i) {
-        if (v.indexOf(block_id_start) > -1) {
+        if (v.hasOwnProperty(indexOf) && v.indexOf(block_id_start) > -1) {
           return v.slice(block_id_start.length, v.length);
         }
       }).join();

--- a/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
+++ b/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
@@ -83,6 +83,23 @@
                       base: $(this).attr('id'),
                       element: this
                     });
+                    // We can't use the URL passed from the settings bc it might have the original
+                    // Arguments stuck and the Ajax Controller will not know if to enforce the GET
+                    // or POST ones.
+                    var inputs_in_form = {};
+                    $('input[type=select], input[type=hidden], input[type=text]', $modal_exposed_form).not('[data-drupal-selector=edit-reset]').each(function (index) {
+                        inputs_in_form[$(this).attr('name')] = $(this).attr('name');
+                      });
+                    var $clean_url_split = selfSettings.url.split('?');
+                    var $clean_url_base =  $clean_url_split.shift();
+                    var searchParams = new URLSearchParams(selfSettings.url.substring(selfSettings.url.indexOf('?')));
+                    Object.keys(inputs_in_form || {}).forEach(function (index) {
+                      if (searchParams.has(inputs_in_form[index])) {
+                        searchParams.delete(inputs_in_form[index]);
+                      }
+                    });
+                    var href = searchParams.toString();
+                    selfSettings.url = $clean_url_base + '?' + href;
                     selfSettings.submit.exposed_form_display = $exposed_form;
                     $modal_exposed_form.exposedFormAjax[index] = Drupal.ajax(selfSettings);
                   });

--- a/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
+++ b/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
@@ -67,26 +67,29 @@
           // Check which modal blocks (from the settings)
           // belong to it.
           // Do what Drupal.views.ajaxView.prototype.attachExposedFormAjax does differently
-
-          Object.keys(drupalSettings.views.ajaxViews || {}).forEach((i) => {
-            //var block_settings = drupalSettings.format_strawberryfield_views.modal_exposed_form_block[$modal_exposed_form_id];
-            if (Drupal.views.instances[i].settings.view_name == $view_parts[0] //block_settings.view_id
-              && Drupal.views.instances[i].settings.view_display_id == $view_parts[1]) { //block_settings.current_display_id) {
-              var exposed_form_selector = '#views-exposed-form-' + $view_parts[0].replace(/_/g, '-') + '-' +$view_parts[1].replace(/_/g, '-');
-              var $exposed_form = $(exposed_form_selector).length;
-              if ($exposed_form > 0) {
-                $exposed_form = 1 ;
+          if (typeof(drupalSettings.views) != 'undefined') {
+            Object.keys(drupalSettings.views.ajaxViews || {}).forEach((i) => {
+              //var block_settings = drupalSettings.format_strawberryfield_views.modal_exposed_form_block[$modal_exposed_form_id];
+              if ((typeof (Drupal.views.instances[i]) !== 'undefined') && Drupal.views.instances[i].hasOwnProperty("settings")) {
+                if (Drupal.views.instances[i].settings.view_name == $view_parts[0] //block_settings.view_id
+                  && Drupal.views.instances[i].settings.view_display_id == $view_parts[1]) { //block_settings.current_display_id) {
+                  var exposed_form_selector = '#views-exposed-form-' + $view_parts[0].replace(/_/g, '-') + '-' + $view_parts[1].replace(/_/g, '-');
+                  var $exposed_form = $(exposed_form_selector).length;
+                  if ($exposed_form > 0) {
+                    $exposed_form = 1;
+                  }
+                  $('input[type=submit], button[type=submit], input[type=image]', $modal_exposed_form).not('[data-drupal-selector=edit-reset]').each(function (index) {
+                    var selfSettings = $.extend({}, Drupal.views.instances[i].element_settings, {
+                      base: $(this).attr('id'),
+                      element: this
+                    });
+                    selfSettings.submit.exposed_form_display = $exposed_form;
+                    $modal_exposed_form.exposedFormAjax[index] = Drupal.ajax(selfSettings);
+                  });
+                }
               }
-              $('input[type=submit], button[type=submit], input[type=image]', $modal_exposed_form).not('[data-drupal-selector=edit-reset]').each(function (index) {
-                var selfSettings = $.extend({}, Drupal.views.instances[i].element_settings, {
-                  base: $(this).attr('id'),
-                  element: this
-                });
-                selfSettings.submit.exposed_form_display = $exposed_form;
-                $modal_exposed_form.exposedFormAjax[index] = Drupal.ajax(selfSettings);
-              });
-            }
-          });
+            });
+          }
         });
       }
 

--- a/modules/format_strawberryfield_views/src/Controller/FormatStrawberryfieldViewAjaxController.php
+++ b/modules/format_strawberryfield_views/src/Controller/FormatStrawberryfieldViewAjaxController.php
@@ -128,7 +128,7 @@ class FormatStrawberryfieldViewAjaxController extends ViewAjaxController {
       $dom_id = isset($dom_id) ? preg_replace('/[^a-zA-Z0-9_-]+/', '-', $dom_id) : NULL;
       $pager_element = $request->request->get('pager_element');
       $pager_element = isset($pager_element) ? intval($pager_element) : NULL;
-      $exposed_form_display = $request->request->get('exposed_form_display');
+      $exposed_form_display = (bool) $request->request->get('exposed_form_display', FALSE);
 
       $response = new ViewAjaxResponse();
 
@@ -206,15 +206,12 @@ class FormatStrawberryfieldViewAjaxController extends ViewAjaxController {
         // Views with ajax enabled aren't refreshing filters placed in blocks.
         // Only <div> containing view is refreshed. ReplaceCommand is fixing
         // that for view, if it uses ajax and exposed forms in block.
-        if ($view->display_handler->usesExposed() && $view->display_handler->getOption('exposed_block')) {
+        if ($exposed_form_display && $view->display_handler->usesExposed() && $view->display_handler->getOption('exposed_block')) {
           $view_id = preg_replace('/[^a-zA-Z0-9-]+/', '-', $name . '-' . $display_id);
           $context = new RenderContext();
           $exposed_form = $this->renderer->executeInRenderContext($context, function () use ($view) {
             return $view->display_handler->viewExposedFormBlocks();
           });
-          /*if (isset($exposed_form['#id'])) {
-           unset($exposed_form['#id']);
-          }*/
           if (!$context->isEmpty()) {
             $bubbleable_metadata = $context->pop();
             BubbleableMetadata::createFromRenderArray($exposed_form)

--- a/modules/format_strawberryfield_views/src/Controller/FormatStrawberryfieldViewAjaxController.php
+++ b/modules/format_strawberryfield_views/src/Controller/FormatStrawberryfieldViewAjaxController.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Drupal\format_strawberryfield_views\Controller;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Ajax\ReplaceCommand;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\EventSubscriber\AjaxResponseSubscriber;
+use Drupal\Core\EventSubscriber\MainContentViewSubscriber;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Path\CurrentPathStack;
+use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\Render\RenderContext;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Routing\RedirectDestinationInterface;
+use Drupal\views\Ajax\ScrollTopCommand;
+use Drupal\views\Ajax\ViewAjaxResponse;
+use Drupal\views\ViewExecutableFactory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Drupal\views\Controller\ViewAjaxController;
+
+/**
+ * Defines a controller to load a view via AJAX.
+ */
+class FormatStrawberryfieldViewAjaxController extends ViewAjaxController {
+
+  /**
+   * The entity storage for views.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $storage;
+
+  /**
+   * The factory to load a view executable with.
+   *
+   * @var \Drupal\views\ViewExecutableFactory
+   */
+  protected $executableFactory;
+
+  /**
+   * The renderer.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected $renderer;
+
+  /**
+   * The current path.
+   *
+   * @var \Drupal\Core\Path\CurrentPathStack
+   */
+  protected $currentPath;
+
+  /**
+   * The redirect destination.
+   *
+   * @var \Drupal\Core\Routing\RedirectDestinationInterface
+   */
+  protected $redirectDestination;
+
+  /**
+   * Constructs a ViewAjaxController object.
+   *
+   * @param \Drupal\Core\Entity\EntityStorageInterface $storage
+   *   The entity storage for views.
+   * @param \Drupal\views\ViewExecutableFactory $executable_factory
+   *   The factory to load a view executable with.
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The renderer.
+   * @param \Drupal\Core\Path\CurrentPathStack $current_path
+   *   The current path.
+   * @param \Drupal\Core\Routing\RedirectDestinationInterface $redirect_destination
+   *   The redirect destination.
+   */
+  public function __construct(EntityStorageInterface $storage, ViewExecutableFactory $executable_factory, RendererInterface $renderer, CurrentPathStack $current_path, RedirectDestinationInterface $redirect_destination) {
+    $this->storage = $storage;
+    $this->executableFactory = $executable_factory;
+    $this->renderer = $renderer;
+    $this->currentPath = $current_path;
+    $this->redirectDestination = $redirect_destination;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')->getStorage('view'),
+      $container->get('views.executable'),
+      $container->get('renderer'),
+      $container->get('path.current'),
+      $container->get('redirect.destination')
+    );
+  }
+
+  /**
+   * Loads and renders a view via AJAX.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The current request object.
+   *
+   * @return \Drupal\views\Ajax\ViewAjaxResponse
+   *   The view response as ajax response.
+   *
+   * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+   *   Thrown when the view was not found.
+   */
+  public function ajaxView(Request $request) {
+    $name = $request->request->get('view_name');
+    $display_id = $request->request->get('view_display_id');
+    if (isset($name) && isset($display_id)) {
+      $args = $request->request->get('view_args', '');
+      $args = $args !== '' ? explode('/', Html::decodeEntities($args)) : [];
+
+      // Arguments can be empty, make sure they are passed on as NULL so that
+      // argument validation is not triggered.
+      $args = array_map(function ($arg) {
+        return ($arg == '' ? NULL : $arg);
+      }, $args);
+
+      $path = $request->request->get('view_path');
+      $dom_id = $request->request->get('view_dom_id');
+      $dom_id = isset($dom_id) ? preg_replace('/[^a-zA-Z0-9_-]+/', '-', $dom_id) : NULL;
+      $pager_element = $request->request->get('pager_element');
+      $pager_element = isset($pager_element) ? intval($pager_element) : NULL;
+      $exposed_form_display = $request->request->get('exposed_form_display');
+
+      $response = new ViewAjaxResponse();
+
+      // Remove all of this stuff from the query of the request so it doesn't
+      // end up in pagers and tablesort URLs.
+      // @todo Remove this parsing once these are removed from the request in
+      //   https://www.drupal.org/node/2504709.
+      foreach ([
+        'view_name',
+        'view_display_id',
+        'view_args',
+        'view_path',
+        'view_dom_id',
+        'pager_element',
+        'view_base_path',
+        'exposed_form_display',
+        AjaxResponseSubscriber::AJAX_REQUEST_PARAMETER,
+        FormBuilderInterface::AJAX_FORM_REQUEST,
+        MainContentViewSubscriber::WRAPPER_FORMAT,
+      ] as $key) {
+        $request->query->remove($key);
+        $request->request->remove($key);
+      }
+
+      // Load the view.
+      if (!$entity = $this->storage->load($name)) {
+        throw new NotFoundHttpException();
+      }
+      $view = $this->executableFactory->get($entity);
+      if ($view && $view->access($display_id) && $view->setDisplay($display_id) && $view->display_handler->ajaxEnabled()) {
+        $response->setView($view);
+        // Fix the current path for paging.
+        if (!empty($path)) {
+          $this->currentPath->setPath('/' . ltrim($path, '/'), $request);
+        }
+
+        // Add all POST data, because AJAX is always a post and many things,
+        // such as tablesorts, exposed filters and paging assume GET.
+        $request_all = $request->request->all();
+        unset($request_all['ajax_page_state']);
+        $query_all = $request->query->all();
+        $request->query->replace($request_all + $query_all);
+
+        // Overwrite the destination.
+        // @see the redirect.destination service.
+        $origin_destination = $path;
+
+        $used_query_parameters = $request->query->all();
+        $query = UrlHelper::buildQuery($used_query_parameters);
+        if ($query != '') {
+          $origin_destination .= '?' . $query;
+        }
+        $this->redirectDestination->set($origin_destination);
+
+        // Override the display's pager_element with the one actually used.
+        if (isset($pager_element)) {
+          $response->addCommand(new ScrollTopCommand(".js-view-dom-id-$dom_id"));
+          $view->displayHandlers->get($display_id)->setOption('pager_element', $pager_element);
+        }
+        // Reuse the same DOM id so it matches that in drupalSettings.
+        $view->dom_id = $dom_id;
+
+        $context = new RenderContext();
+        $preview = $this->renderer->executeInRenderContext($context, function () use ($view, $display_id, $args) {
+          return $view->preview($display_id, $args);
+        });
+        if (!$context->isEmpty()) {
+          $bubbleable_metadata = $context->pop();
+          BubbleableMetadata::createFromRenderArray($preview)
+            ->merge($bubbleable_metadata)
+            ->applyTo($preview);
+        }
+        $response->addCommand(new ReplaceCommand(".js-view-dom-id-$dom_id", $preview));
+
+        // Views with ajax enabled aren't refreshing filters placed in blocks.
+        // Only <div> containing view is refreshed. ReplaceCommand is fixing
+        // that for view, if it uses ajax and exposed forms in block.
+        if ($view->display_handler->usesExposed() && $view->display_handler->getOption('exposed_block')) {
+          $view_id = preg_replace('/[^a-zA-Z0-9-]+/', '-', $name . '-' . $display_id);
+          $context = new RenderContext();
+          $exposed_form = $this->renderer->executeInRenderContext($context, function () use ($view) {
+            return $view->display_handler->viewExposedFormBlocks();
+          });
+          /*if (isset($exposed_form['#id'])) {
+           unset($exposed_form['#id']);
+          }*/
+          if (!$context->isEmpty()) {
+            $bubbleable_metadata = $context->pop();
+            BubbleableMetadata::createFromRenderArray($exposed_form)
+              ->merge($bubbleable_metadata)
+              ->applyTo($exposed_form);
+          }
+         $response->addCommand(new ReplaceCommand("#views-exposed-form-" . $view_id, $this->renderer->render($exposed_form)));
+        }
+
+        return $response;
+      }
+      else {
+        throw new AccessDeniedHttpException();
+      }
+    }
+    else {
+      throw new NotFoundHttpException();
+    }
+  }
+
+}

--- a/modules/format_strawberryfield_views/src/Controller/FormatStrawberryfieldViewAjaxController.php
+++ b/modules/format_strawberryfield_views/src/Controller/FormatStrawberryfieldViewAjaxController.php
@@ -128,7 +128,8 @@ class FormatStrawberryfieldViewAjaxController extends ViewAjaxController {
       $dom_id = isset($dom_id) ? preg_replace('/[^a-zA-Z0-9_-]+/', '-', $dom_id) : NULL;
       $pager_element = $request->request->get('pager_element');
       $pager_element = isset($pager_element) ? intval($pager_element) : NULL;
-      $exposed_form_display = (bool) $request->request->get('exposed_form_display', FALSE);
+      // Assume its there if not told otherwise
+      $exposed_form_display = (bool) $request->request->get('exposed_form_display', TRUE);
 
       $response = new ViewAjaxResponse();
 

--- a/modules/format_strawberryfield_views/src/Controller/ViewsExposedFormModalBlockAjaxController.php
+++ b/modules/format_strawberryfield_views/src/Controller/ViewsExposedFormModalBlockAjaxController.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Drupal\format_strawberryfield_views\Controller;
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\InvokeCommand;
+use Drupal\Core\Ajax\ReplaceCommand;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Http\RequestStack as DrupalRequestStack;
+use Drupal\Core\Path\CurrentPathStack;
+use Drupal\Core\PathProcessor\PathProcessorManager;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Routing\CurrentRouteMatch;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack as SymfonyRequestStack;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Defines a controller to load an Modal Exposed Views Form Block via AJAX.
+ */
+class ViewsExposedFormModalBlockAjaxController extends ControllerBase {
+
+  /**
+   * The entity storage for block.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $storage;
+
+  /**
+   * The renderer.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected $renderer;
+
+  /**
+   * The current path.
+   *
+   * @var \Drupal\Core\Path\CurrentPathStack
+   */
+  protected $currentPath;
+
+  /**
+   * The dynamic router service.
+   *
+   * @var \Symfony\Component\Routing\Matcher\RequestMatcherInterface
+   */
+  protected $router;
+
+  /**
+   * The path processor service.
+   *
+   * @var \Drupal\Core\PathProcessor\InboundPathProcessorInterface
+   */
+  protected $pathProcessor;
+
+  /**
+   * The current route match service.
+   *
+   * @var \Drupal\Core\Routing\CurrentRouteMatch
+   */
+  protected $currentRouteMatch;
+
+  /**
+   * Constructs a ViewsExposedFormModalBlockAjaxController object.
+   *
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The renderer service.
+   * @param \Drupal\Core\Path\CurrentPathStack $currentPath
+   *   The current path service.
+   * @param \Symfony\Component\Routing\RouterInterface $router
+   *   The router service.
+   * @param \Drupal\Core\PathProcessor\PathProcessorManager $pathProcessor
+   *   The path processor manager.
+   * @param \Drupal\Core\Routing\CurrentRouteMatch $currentRouteMatch
+   *   The current route match service.
+   */
+  public function __construct(RendererInterface $renderer, CurrentPathStack $currentPath, RouterInterface $router, PathProcessorManager $pathProcessor, CurrentRouteMatch $currentRouteMatch) {
+    $this->storage = $this->entityTypeManager()->getStorage('block');
+    $this->renderer = $renderer;
+    $this->currentPath = $currentPath;
+    $this->router = $router;
+    $this->pathProcessor = $pathProcessor;
+    $this->currentRouteMatch = $currentRouteMatch;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('renderer'),
+      $container->get('path.current'),
+      $container->get('router'),
+      $container->get('path_processor_manager'),
+      $container->get('current_route_match')
+    );
+  }
+
+  /**
+   * Loads and renders the facet blocks via AJAX.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The current request object.
+   *
+   * @return \Drupal\Core\Ajax\AjaxResponse
+   *   The ajax response.
+   *
+   * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+   *   Thrown when the view was not found.
+   */
+  public function ajaxExposedFormBlockView(Request $request) {
+    $response = new AjaxResponse();
+
+    // Rebuild the request and the current path, needed for facets.
+    $path = $request->request->get('exposedform_link');
+    $modalviews_blocks = $request->request->get('modalviews_blocks');
+
+    if (empty($path) || empty($modalviews_blocks)) {
+      throw new NotFoundHttpException('No Modal Exposed Views Form links or blocks found.');
+    }
+
+    // Make sure we are not updating blocks multiple times.
+    $modalviews_blocks = array_unique($modalviews_blocks);
+
+    $new_request = Request::create($path);
+    $request_stack = new DrupalRequestStack();
+
+    $processed = $this->pathProcessor->processInbound($path, $new_request);
+    $processed_request = Request::create($processed);
+
+    $this->currentPath->setPath($processed_request->getPathInfo());
+    $request->attributes->add($this->router->matchRequest($new_request));
+    $this->currentRouteMatch->resetRouteMatch();
+    $request_stack->push($new_request);
+
+    $container = \Drupal::getContainer();
+    $container->set('request_stack', $request_stack);
+
+    // Build the blocks found for the current request and update.
+    foreach ($modalviews_blocks as $block_inner_selector => $block_id) {
+      $block_entity = $this->storage->load($block_id);
+      // inner selector is not used but just as a way of having a consistent unique ID when posting the values
+      if ($block_entity) {
+        // Render a block, then add it to the response as a replace command.
+        $block_view = $this->entityTypeManager
+          ->getViewBuilder('block')
+          ->view($block_entity);
+
+        $block_view = (string) $this->renderer->renderPlain($block_view);
+        $response->addCommand(new ReplaceCommand('[data-drupal-modalblock-selector="js-modal-form-views-block-id-' .$block_id.'"]', $block_view));
+      }
+    }
+    return $response;
+  }
+
+}

--- a/modules/format_strawberryfield_views/src/Controller/ViewsExposedFormModalBlockAjaxController.php
+++ b/modules/format_strawberryfield_views/src/Controller/ViewsExposedFormModalBlockAjaxController.php
@@ -149,7 +149,6 @@ class ViewsExposedFormModalBlockAjaxController extends ControllerBase {
         $block_view = $this->entityTypeManager
           ->getViewBuilder('block')
           ->view($block_entity);
-
         $block_view = (string) $this->renderer->renderPlain($block_view);
         $response->addCommand(new ReplaceCommand('[data-drupal-modalblock-selector="js-modal-form-views-block-id-' .$block_id.'"]', $block_view));
       }

--- a/modules/format_strawberryfield_views/src/Plugin/Block/ViewsExposedFilterBlockModal.php
+++ b/modules/format_strawberryfield_views/src/Plugin/Block/ViewsExposedFilterBlockModal.php
@@ -1,0 +1,424 @@
+<?php
+
+namespace Drupal\format_strawberryfield_views\Plugin\Block;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Component\Utility\Xss;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+use Drupal\Core\Security\TrustedCallbackInterface;
+use Drupal\Core\Url;
+use Drupal\views\Plugin\Block\ViewsBlockBase;
+use Drupal\Component\Utility\Html;
+
+/**
+ * Provides a 'Views Exposed Filter with Modal display' block.
+ *
+ * @Block(
+ *   id = "views_exposed_filter_block_sbf",
+ *   admin_label = @Translation("Views Exposed Filter Block with Selectable type of Filter"),
+ *   deriver = "Drupal\views\Plugin\Derivative\ViewsExposedFilterBlock"
+ * )
+ */
+class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCallbackInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    $contexts = $this->view->display_handler->getCacheMetadata()->getCacheContexts();
+    return Cache::mergeContexts(parent::getCacheContexts(), $contexts);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @return array
+   *   A renderable array representing the content of the block with additional
+   *   context of current view and display ID.
+   */
+  public function build() {
+
+    $is_sort_exposed = FALSE;
+
+    /** @var \Drupal\views\Plugin\views\HandlerBase $sort */
+    $sort_ids = [];
+    foreach ($this->view->display_handler->getHandlers('sort') as $key => $sort) {
+      if ($sort->isExposed()) {
+        $sort_ids[$sort->options['expose']['field_identifier']] = $sort->options['expose']['field_identifier'];
+      }
+    }
+
+
+    $filter_ids = [];
+    foreach ($this->view->display_handler->getHandlers('filter') as $key => $filter) {
+      if ($filter->isExposed()) {
+        if ($filter->options['expose']['multiple'] ?? FALSE) {
+          $filter_ids[$filter->options['group_info']['identifier']] = $filter->options['group_info']['identifier'];
+        }
+        else {
+          $filter_ids[$filter->options['expose']['identifier']] = $filter->options['expose']['identifier'];
+        }
+      }
+    }
+    $output = $this->view->display_handler->viewExposedFormBlocks();
+    // Provide the context for block build and block view alter hooks.
+    // \Drupal\views\Plugin\Block\ViewsBlock::build() adds the same context in
+    // \Drupal\views\ViewExecutable::buildRenderable() using
+    // \Drupal\views\Plugin\views\display\DisplayPluginBase::buildRenderable().
+    $output['#attributes']['data-drupal-target-view'] = $this->view->storage->id() . '-' . $this->view->current_display;
+
+    $output['#id'] = Html::getUniqueId('views_exposed_form_modal-' .  $this->view->storage->id() . '-' . $this->view->current_display);
+    $exposed_elements = $output['#info'] ?? [];
+    foreach ($exposed_elements as $key => $exposed_values) {
+      if (strpos($key,'filter-') === 0) {
+        if (isset($exposed_values['value'])) {
+          $filter_ids[$exposed_values['value']] = $exposed_values['value'];
+        }
+      }
+      if (strpos($key,'sort-') === 0) {
+        if (isset($exposed_values['value'])) {
+          $sort_ids[$exposed_values['value']] = $exposed_values['value'];
+        }
+      }
+    }
+
+    // Hide Filters if needed
+    foreach ($filter_ids as $field_id) {
+      $real_id = NULL;
+      if (isset($output[$field_id]) && is_array($output[$field_id])) {
+        $real_id = $field_id;
+      }
+      elseif (isset($output[$field_id.'_wrapper']) && is_array($output[$field_id.'_wrapper'])) {
+        $real_id = $field_id.'_wrapper';
+      }
+      if ($real_id) {
+        $hide = $this->checkIfNeedsToHideFilter($output[$real_id] ?? []);
+        if ($hide) {
+          $output[$real_id]['#attributes']['class'][] = 'visually-hidden';
+          $output[$real_id]['#title_display'] = 'invisible';
+          $output[$real_id]['#description_display'] = 'invisible';
+          if (isset($output['#info']["filter-$field_id"]['label'])) {
+            $output['#info']["filter-$field_id"]['label'] = '';
+          }
+        }
+
+        foreach ($output[$real_id] as $possible_key => &$value) {
+          if (strpos($possible_key, '#') === FALSE && is_array($value)
+            && isset($value['#type'])
+          ) {
+            $hide = $this->checkIfNeedsToHideFilter($value ?? []);
+            if ($hide) {
+              $value['#type'] = 'hidden';
+              $value['#attributes']['class'][] = 'visually-hidden';
+              $output['#info']["filter-$field_id"]['label'] = '';
+            }
+          }
+        }
+      }
+    }
+
+    // Hide Sorts if needed
+    foreach ($sort_ids as $field_id) {
+      $real_id = NULL;
+      if (isset($output[$field_id]) && is_array($output[$field_id])) {
+        $real_id = $field_id;
+      }
+      elseif (isset($output[$field_id.'_wrapper']) && is_array($output[$field_id.'_wrapper'])) {
+        $real_id = $field_id.'_wrapper';
+      }
+      if ($real_id) {
+        $hide = $this->checkIfNeedsToHideSort($output[$real_id] ?? []);
+        if ($hide) {
+          $output[$real_id]['#attributes']['class'][] = 'visually-hidden';
+          $output[$real_id]['#title_display'] = 'invisible';
+          $output[$real_id]['#description_display'] = 'invisible';
+          if (isset($output['#info']["sort-$field_id"]['label'])) {
+            $output['#info']["sort-$field_id"]['label'] = '';
+          }
+        }
+
+        foreach ($output[$real_id] as $possible_key => &$value) {
+          if (strpos($possible_key, '#') === FALSE && is_array($value)
+            && isset($value['#type'])
+          ) {
+            $hide = $this->checkIfNeedsToHideSort($value ?? []);
+            if ($hide) {
+              $value['#type'] = 'hidden';
+              $value['#attributes']['class'][] = 'visually-hidden';
+              $output['#info']["sort-$field_id"]['label'] = '';
+            }
+          }
+        }
+      }
+    }
+    if ($this->configuration['views_exposed_sbf_show_submit']) {
+      if (trim($this->configuration['views_exposed_sbf_rename_submit_label'])
+        != ''
+        && isset($output['actions']['submit']['#value'])
+      ) {
+        $output['actions']['submit']['#value']
+          = $this->configuration['views_exposed_sbf_rename_submit_label'];
+      }
+    }
+    elseif (isset($output['actions']['submit'])) {
+      $output['actions']['submit']['#attributes']['class'][] = 'visually-hidden';
+    }
+
+    if (!$this->configuration['views_exposed_sbf_show_reset'] && isset($output['actions']['reset'])) {
+      $output['actions']['reset']['#attributes']['class'][] = 'visually-hidden';
+    }
+
+    if ($this->view->display_handler->ajaxEnabled()) {
+      $output['#attributes']['class'][] = 'block-modalformviews-ajax';
+      $output['#attributes']['class'][] = 'js-modal-form-views-block';
+
+      $js_settings = [
+        'view_id' => $this->view->id(),
+        'current_display_id' => $this->view->current_display,
+        'view_base_path' => ltrim($this->view->getPath() ?? '', '/'),
+        'ajax_path' => Url::fromRoute('views.ajax')->toString(),
+      ];
+      $output['#attached']['drupalSettings']['format_strawberryfield_views']['modal_exposed_form_block'][$output['#id']] = $js_settings;
+      $output['#attached']['library'][] = 'format_strawberryfield_views/modal-exposed-form-views-ajax';
+    }
+
+    if (is_array($output) && !empty($output)) {
+      $output += [
+        '#view' => $this->view,
+        '#display_id' => $this->displayID,
+      ];
+    }
+
+    // Before returning the block output, convert it to a renderable array with
+    // contextual links.
+    $this->addContextualLinks($output, 'views_exposed_filter_block_sbf');
+
+    // Set the blocks title.
+    if (!empty($this->configuration['label_display']) && ($this->view->getTitle() || !empty($this->configuration['views_label']))) {
+      $output['#title'] = [
+        '#markup' => empty($this->configuration['views_label']) ? $this->view->getTitle() : $this->configuration['views_label'],
+        '#allowed_tags' => Xss::getHtmlTagList(),
+      ];
+    }
+
+    return $output;
+  }
+
+  /**
+   * Checks if a Form elements for a filter needs to be hidden or not.
+   *
+   * @param array $element
+   *
+   * @return bool
+   */
+  protected function checkIfNeedsToHideFilter(array $element) {
+    $hide = FALSE;
+    if (!$this->configuration['views_exposed_sbf_show_text_filter']
+      && isset($element['#type'])
+      && in_array(
+        $element['#type'], ['textfield', 'search_api_autocomplete', 'textarea']
+      )
+    ) {
+      $hide = TRUE;
+    }
+    if (!$this->configuration['views_exposed_sbf_show_select_filter']
+      && isset($element['#type'])
+      && in_array(
+        $element['#type'], ['select']
+      )
+    ) {
+      $hide = TRUE;
+    }
+    if (!$this->configuration['views_exposed_sbf_show_checksandoptions_filter']
+      && isset($element['#type'])
+      && in_array(
+        $element['#type'], ['checkbox', 'radio', 'radios']
+      )
+    ) {
+      $hide = TRUE;
+    }
+    return $hide;
+  }
+
+  /**
+   * Checks if a Form elements for a filter needs to be hidden or not.
+   *
+   * @param array $element
+   *
+   * @return bool
+   */
+  protected function checkIfNeedsToHideSort(array $element) {
+    $hide = FALSE;
+    if (!$this->configuration['views_exposed_sbf_show_sort_filter']
+      && isset($element['#type'])
+      && in_array(
+        $element['#type'], ['select']
+      )
+    ) {
+      $hide = TRUE;
+    }
+    return $hide;
+  }
+
+  public function defaultConfiguration() {
+    $default_config = parent::defaultConfiguration(
+    ); // TODO: Change the autogenerated stub
+    $default_config['views_exposed_sbf_show_text_filter'] = 1;
+    $default_config['views_exposed_sbf_show_select_filter'] = 1;
+    $default_config['views_exposed_sbf_show_checksandoptions_filter'] = 1;
+    $default_config['views_exposed_sbf_show_sort_filter'] = 1;
+    $default_config['views_exposed_sbf_show_pager'] = 1;
+    $default_config['views_exposed_sbf_show_submit'] = 1;
+    $default_config['views_exposed_sbf_show_reset'] = 1;
+    $default_config['views_exposed_sbf_rename_submit_label'] = '';
+    return $default_config;
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    if (!$form_state->isValueEmpty('views_label_checkbox')) {
+      $this->configuration['views_label'] = $form_state->getValue('views_label');
+    }
+    else {
+      $this->configuration['views_label'] = '';
+    }
+
+    if (!$form_state->isValueEmpty('views_exposed_sbf_rename_submit')) {
+      $this->configuration['views_exposed_sbf_rename_submit_label'] = $form_state->getValue('views_exposed_sbf_rename_submit_label');
+    }
+    else {
+      $this->configuration['views_exposed_sbf_rename_submit_label'] = '';
+    }
+
+    $this->configuration['views_exposed_sbf_show_text_filter'] = $form_state->getValue('views_exposed_sbf_show_text_filter', 0) ;
+    $this->configuration['views_exposed_sbf_show_select_filter'] = $form_state->getValue('views_exposed_sbf_show_select_filter', 0) ;
+    $this->configuration['views_exposed_sbf_show_checksandoptions_filter'] = $form_state->getValue('views_exposed_sbf_show_checksandoptions_filter',0);
+    $this->configuration['views_exposed_sbf_show_sort_filter'] = $form_state->getValue('views_exposed_sbf_show_sort_filter',0);
+    $this->configuration['views_exposed_sbf_show_pager'] = $form_state->getValue('views_exposed_sbf_show_pager',0);
+    $this->configuration['views_exposed_sbf_show_submit'] = $form_state->getValue('views_exposed_sbf_show_submit',0);
+    $this->configuration['views_exposed_sbf_show_reset'] = $form_state->getValue('views_exposed_sbf_show_reset',0);
+
+    $form_state->unsetValue('views_label_checkbox');
+    $form_state->unsetValue('views_exposed_sbf_rename_submit');
+  }
+
+  public function buildConfigurationForm(array $form,
+    FormStateInterface $form_state
+  ) {
+    $form = parent::buildConfigurationForm(
+      $form, $form_state
+    );
+    $form['views_exposed_sbf_fieldset'] = [
+      '#type' => 'fieldset',
+      '#title' => 'Exposed Form element and component Visibility'
+    ];
+
+    $form['views_exposed_sbf_show_text_filter'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show filter components of type textfield if exposed'),
+      '#default_value' => !empty($this->configuration['views_exposed_sbf_show_text_filter']),
+      '#fieldset' => 'views_exposed_sbf_fieldset',
+    ];
+
+    $form['views_exposed_sbf_show_select_filter'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show filter components of type select if exposed'),
+      '#default_value' => !empty($this->configuration['views_exposed_sbf_show_select_filter']),
+      '#fieldset' => 'views_exposed_sbf_fieldset',
+    ];
+
+    $form['views_exposed_sbf_show_checksandoptions_filter'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show filter components of type checkbox/options if exposed'),
+      '#default_value' => !empty($this->configuration['views_exposed_sbf_show_checksandoptions_filter']),
+      '#fieldset' => 'views_exposed_sbf_fieldset',
+    ];
+
+    $form['views_exposed_sbf_show_sort_filter'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show sorting components if exposed'),
+      '#default_value' => !empty($this->configuration['views_exposed_sbf_show_sort_filter']),
+      '#fieldset' => 'views_exposed_sbf_fieldset',
+    ];
+
+    $form['views_exposed_sbf_show_pager'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show pager components if exposed'),
+      '#default_value' => !empty($this->configuration['views_exposed_sbf_show_pager']),
+      '#fieldset' => 'views_exposed_sbf_fieldset',
+    ];
+
+    $form['views_exposed_sbf_show_submit'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show Submit Button if exposed'),
+      '#description' => $this->t('Make sure you have autosubmit enabled if you decide to hide it'),
+      '#default_value' => !empty($this->configuration['views_exposed_sbf_show_submit']),
+      '#fieldset' => 'views_exposed_sbf_fieldset',
+    ];
+
+    $form['views_exposed_sbf_show_reset'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show Reset Button if exposed'),
+      '#default_value' => !empty($this->configuration['views_exposed_sbf_show_reset']),
+      '#fieldset' => 'views_exposed_sbf_fieldset',
+    ];
+
+    $form['views_exposed_sbf_rename_submit'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Override Submit button Label'),
+      '#default_value' => !empty($this->configuration['views_exposed_sbf_rename_submit_label']),
+      '#fieldset' => 'views_exposed_sbf_fieldset',
+      '#states' => [
+        'visible' => [
+          [
+            ':input[name="settings[views_exposed_sbf_show_submit]"]' => ['checked' => TRUE],
+          ],
+        ],
+      ],
+    ];
+
+
+    $form['views_exposed_sbf_rename_submit_label'] = [
+      '#title' => $this->t('Submit button label'),
+      '#type' => 'textfield',
+      '#default_value' => $this->configuration['views_exposed_sbf_rename_submit_label'] ?: 'Apply',
+      '#states' => [
+        'visible' => [
+          [
+            ':input[name="settings[views_exposed_sbf_rename_submit]"]' => ['checked' => TRUE],
+          ],
+        ],
+      ],
+      '#fieldset' => 'views_exposed_sbf_fieldset',
+    ];
+
+    return $form;
+  }
+
+
+  /**
+   * #pre_render callback for enriching this block.
+   */
+  public static function preRender($build) {
+    // The invoker/rendered moves #attributes from 'content' back into the top structure
+    if (isset($build['#attributes']['class']) && in_array('block-modalformviews-ajax', $build['#attributes']['class'])) {
+      $build['#attributes']['class'][] = 'js-modal-form-views-block-id-' . $build['#id'];
+      $build['#attributes']['data-drupal-modalblock-selector'] = 'js-modal-form-views-block-id-' . $build['#id'];
+      $build['content']['#attached']['drupalSettings']['format_strawberryfield_views']['modal_exposed_form_block'][$build['content']['#id']]['block_id'] = $build['#id'];
+    }
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function trustedCallbacks() {
+    return ['preRender'];
+  }
+
+}

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -1,0 +1,794 @@
+<?php
+
+namespace Drupal\format_strawberryfield_views\Plugin\views\filter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\StringTranslation\PluralTranslatableMarkup;
+use Drupal\search_api\Entity\Index;
+use Drupal\search_api\ParseMode\ParseModePluginManager;
+use Drupal\search_api_solr\Utility\Utility;
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\search_api\Plugin\views\filter\SearchApiFilterTrait;
+use Drupal\search_api\Plugin\views\filter\SearchApiFulltext;
+
+/**
+ * Defines a filter for adding a fulltext search to the view.
+ *
+ * @ingroup views_filter_handlers
+ *
+ * @ViewsFilter("sbf_advanced_search_api_fulltext")
+ */
+class AdvancedSearchApiFulltext extends SearchApiFulltext {
+
+  use SearchApiFilterTrait;
+
+  /**
+   * The current count of exposed Advanced Search Fields.
+   *
+   * @var array
+   */
+  public $searchedFieldsCount = 1;
+
+  /**
+   * The list of fields selected for the search.
+   *
+   * @var array
+   */
+  public $searchedFields = [];
+
+  /**
+   * The list of inter field operators for the searches.
+   *
+   * @var array
+   */
+  public $searchedFieldsOp = [];
+
+  /**
+   * The list of operators for the extra adv searches.
+   *
+   * @var array
+   */
+  public $operatorAdv = [];
+
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defineOptions() {
+    $options = parent::defineOptions();
+    $options['expose']['contains']['advanced_search_fields_multiple'] = ['default' => FALSE];
+    $options['expose']['contains']['advanced_search_fields_count'] = ['default' => 2];
+    $options['expose']['contains']['advanced_search_use_operator'] = ['default' => FALSE];
+    $options['expose']['contains']['advanced_search_operator_id'] = ['default' => ''];
+    $options['expose']['contains']['advanced_search_fields_add_one_label'] = ['default' => 'add one'];
+    $options['expose']['contains']['advanced_search_fields_remove_one_label'] = ['default' => 'remove one'];
+    return $options;
+  }
+
+
+  public function defaultExposeOptions() {
+    parent::defaultExposeOptions();
+    $this->options['expose']['advanced_search_fields_multiple'] = FALSE;
+    $this->options['expose']['advanced_search_fields_count'] = 2;
+    $this->options['expose']['advanced_search_use_operator'] = FALSE;
+    $this->options['expose']['advanced_search_operator_id'] = $this->options['id'] . '_group_operator';
+    $this->options['expose']['advanced_search_fields_add_one_label'] = 'add one';
+    $this->options['expose']['advanced_search_fields_remove_one_label'] = 'remove one';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildExposeForm(&$form, FormStateInterface $form_state) {
+    parent::buildExposeForm($form, $form_state);
+
+    $form['expose']['advanced_search_fields_multiple'] = [
+      '#type' => 'checkbox',
+      '#default_value' => $this->options['expose']['advanced_search_fields_multiple'],
+      '#title' => $this->t('Multiple/add more Search Fields'),
+      '#description' => $this->t('This allows users to add more Search Fields with the same general exposed settings. All identifiers passed by this filter in the URL after the ? will get an incremental suffix.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="options[expose][expose_fields]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+    $form['expose']['advanced_search_fields_count'] = [
+      '#type' => 'number',
+      '#default_value' => $this->options['expose']['advanced_search_fields_count'],
+      '#title' => $this->t('Max number of Multiple/add more Search Fields the user can expose.'),
+      '#size' => 5,
+      '#min' => 2,
+      '#max' => 10,
+      '#description' => $this->t('The number of additional search Fields with the same general exposed settings the user will be able to expose.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="options[expose][advanced_search_fields_multiple]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    $form['expose']['advanced_search_fields_add_one_label'] = [
+      '#type' => 'textfield',
+      '#default_value' => $this->options['expose']['advanced_search_fields_add_one_label'] ?? "add one",
+      '#title' => $this->t('Label to be used for the "add one" button'),
+      '#description' => $this->t('"Label to be used for the "add more" button. By default it is "add one" if left empty'),
+      '#states' => [
+        'visible' => [
+          ':input[name="options[expose][advanced_search_fields_multiple]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    $form['expose']['advanced_search_fields_remove_one_label'] = [
+      '#type' => 'textfield',
+      '#default_value' => $this->options['expose']['advanced_search_fields_remove_one_label'] ?? "remove one",
+      '#title' => $this->t('Label to be used for the "remove one" button'),
+      '#description' => $this->t('"Label to be used for the "add one" button. By default it is "remove one" if left empty'),
+      '#states' => [
+        'visible' => [
+          ':input[name="options[expose][advanced_search_fields_multiple]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    $form['expose']['advanced_search_use_operator'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Expose between search fields operator'),
+      '#description' => $this->t('Allow the user to choose the operator between Multiple Search Fields (AND/OR).'),
+      '#default_value' => !empty($this->options['expose']['advanced_search_use_operator']),
+      '#states' => [
+        'visible' => [
+          ':input[name="options[expose][advanced_search_fields_multiple]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    $form['expose']['advanced_search_operator_id'] = [
+      '#type' => 'textfield',
+      '#default_value' => $this->options['expose']['advanced_search_operator_id'],
+      '#title' => $this->t('Multiple/add more Search Fields operator (AND/OR) fields identifier'),
+      '#size' => 40,
+      '#description' => $this->t('This will appear in the URL after the ? to identify the operator used in the filter when multiple Search Fields and their extra options are exposed.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="options[expose][advanced_search_use_operator]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+
+    // The plan
+    // Get all the values - a.k.a exposed search fields
+    // Get all setup fields and also merge/unique them
+    // get all the conjunctions (per value/ exposed search fields)
+    // get all the between fields operators
+    // Create createConditionGroup(s) grouped by Operators
+    // Add the conditions per condition group (corresponding)
+    // Set the query
+    // Celebrate
+
+    /*while (is_array($this->value)) {
+      $this->value = $this->value ? reset($this->value) : '';
+    }*/
+    if (!is_array($this->value)) {
+      return;
+    }
+    $count = 0;
+
+    // Get all exposed ids or the defaults:
+    // Store searched fields.
+    $searched_fields_identifier = $this->options['id'] . '_searched_fields';
+
+    if (!empty($this->options['expose']['searched_fields_id'])) {
+      $searched_fields_identifier
+        = $this->options['expose']['searched_fields_id'];
+    }
+
+    $search_field_identifier = $this->options['id'];
+
+    if (!empty($this->options['expose']['identifier'])) {
+      $search_field_identifier = $this->options['expose']['identifier'];
+    }
+    $advanced_search_operator_id = $this->options['id'] . '_group_operator';
+    if (!empty($this->options['expose']['advanced_search_use_operator'])
+      && !empty($this->options['expose']['advanced_search_operator_id'])
+    ) {
+      $advanced_search_operator_id
+        = $this->options['expose']['advanced_search_operator_id'];
+    }
+
+    // Accumulator/grouper of all input/passed options
+    $query_able_data = [];
+
+    foreach ($this->value as $exposed_value_id => $exposed_value) {
+      // Catch empty strings entered by the user, but not "0".
+      if ($exposed_value === '') {
+        unset($this->value[$exposed_value_id]);
+        unset($this->searchedFields[$exposed_value_id]);
+      }
+      else {
+        // We will use this to track which fields need to be queried in case
+        // An empty value ended being discarded.
+        // Value rules over the others.
+        $valid_suffix = $count > 0 ? '_' . $count : '';
+        $chosen_fields = isset($this->searchedFields[$searched_fields_identifier
+          . $valid_suffix]) ? (array) $this->searchedFields[$searched_fields_identifier
+        . $valid_suffix] : [];
+        $query_able_data[] = [
+          'value'               => $this->value[$exposed_value_id],
+          'operator'            => ($valid_suffix == '') ? $this->operator
+            : ($this->operatorAdv[$exposed_value_id] ?? $this->operator),
+          'interfield_operator' => $this->searchedFieldsOp[$advanced_search_operator_id
+            . $valid_suffix] ?? 'or',
+          'fields'              => $chosen_fields,
+        ];
+      }
+      $count++;
+    }
+    if (!count($this->value)) {
+      return;
+    }
+
+    $fields = $this->options['fields'];
+    $fields = $fields ?: array_keys($this->getFulltextFields());
+
+    // Override the search fields, if exposed for each of the exposed searches.
+    foreach ($query_able_data as &$query_able_datum) {
+      if (!empty($query_able_datum['fields'])) {
+        $query_able_datum['fields'] = array_intersect(
+          $fields, $query_able_datum['fields']
+        );
+      }
+      else {
+        $query_able_datum['fields'] = $fields;
+      }
+    }
+    $query = $this->getQuery();
+
+    // Save any keywords that were already set.
+    $old = $query->getKeys();
+    $old_original = $query->getOriginalKeys();
+
+    if ($this->options['parse_mode']) {
+      /** @var \Drupal\search_api\ParseMode\ParseModeInterface $parse_mode */
+      $parse_mode = $this->getParseModeManager()
+        ->createInstance($this->options['parse_mode']);
+    }
+
+    // Humble attempt at doing this manually since we have multiple fields with varying operators.
+    // A direct query won't work until we have the actual Solr Field names via \Drupal\search_api_solr\Plugin\search_api\backend\SearchApiSolrBackend::getQueryFulltextFields
+    // See why https://www.drupal.org/project/search_api/issues/3049097
+    // If the backend is Solr we can do this, if not we default to either the basics (single query + filters) or just filtes
+    $backend = $query->getIndex()->getServerInstance()->getBackend();
+    $index_fields = $query->getIndex()->getFields();
+
+    if ($backend instanceof \Drupal\search_api_solr\SolrBackendInterface) {
+      $solr_field_names = $query->getIndex()
+        ->getServerInstance()
+        ->getBackend()
+        ->getSolrFieldNames($query->getIndex());
+      // Damn Solr Search API...
+      $settings = Utility::getIndexSolrSettings($query->getIndex());
+      $language_ids = $query->getLanguages();
+      // If there are no languages set, we need to set them. As an example, a
+      // language might be set by a filter in a search view.
+      if (empty($language_ids)) {
+        if (!$query->getSearchApiQuery()->hasTag('views') && $settings['multilingual']['limit_to_content_language']) {
+          // Limit the language to the current language being used.
+          $language_ids[] = \Drupal::languageManager()
+            ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+            ->getId();
+        }
+        else {
+          // If the query is generated by views and/or the query isn't limited
+          // by any languages we have to search for all languages using their
+          // specific fields.
+          $language_ids = array_keys(\Drupal::languageManager()->getLanguages());
+        }
+      }
+
+      if ($settings['multilingual']['include_language_independent']) {
+        $language_ids[] = LanguageInterface::LANGCODE_NOT_SPECIFIED;
+      }
+
+      $field_names = $backend->getSolrFieldNamesKeyedByLanguage($language_ids, $query->getIndex());
+
+      $query_fields_boosted = [];
+
+      foreach ($query_able_data as &$query_able_datum_fields) {
+        foreach ($query_able_datum['fields'] ?? [] as $field) {
+          if (isset($solr_field_names[$field])
+            && 'twm_suggest' !== $solr_field_names[$field] & strpos(
+              $solr_field_names[$field], 'spellcheck'
+            ) !== 0
+          ) {
+            $index_field = $index_fields[$field];
+            $boost = $index_field->getBoost() ? '^' . $index_field->getBoost()
+              : '';
+            $names = [];
+            $first_name = reset($field_names[$field]);
+            if (strpos($first_name, 't') === 0) {
+              // Add all language-specific field names. This should work for
+              // non Drupal Solr Documents as well which contain only a single
+              // name.
+              $names = array_values($field_names[$field]);
+            }
+            else {
+              $names[] = $first_name;
+            }
+
+            foreach (array_unique($names) as $name) {
+              $query_able_datum_fields['real_solr_fields'][] = $name . $boost;
+            }
+          }
+        }
+      }
+      $use_conditions = FALSE;
+    }
+    else {
+      // We need to use conditions/query filters if the Index is not Solr.
+      $use_conditions = TRUE;
+    }
+    $manual_keys = [];
+    $flat_keys = [];
+    $negation = FALSE;
+    // Now do the actual query creation/composite thing
+    foreach ($query_able_data as $query_able_datum_internal) {
+      if ($negation = $query_able_datum_internal['operator'] === 'not' ? TRUE
+        : FALSE
+      ) {
+        $parse_mode->setConjunction('OR');
+      }
+      else {
+        $parse_mode->setConjunction($query_able_datum_internal['operator']);
+      }
+
+      $parsed_value = $parse_mode->parseInput($query_able_datum_internal['value']);
+      $manual_keys = [
+        $parsed_value,
+      ];
+      if ($negation) {
+        $manual_keys[0]['#negation'] = $negation;
+      }
+
+      $flat_keys[] = \Drupal\search_api_solr\Utility\Utility::flattenKeys(
+        $manual_keys, $query_able_datum_internal['real_solr_fields'],
+        $parse_mode->getPluginId()
+      );
+    }
+    if (count($flat_keys)) {
+      /** @var \Drupal\search_api\ParseMode\ParseModeInterface $parse_mode */
+      $parse_mode_direct = $this->getParseModeManager()
+        ->createInstance('direct');
+      $this->getQuery()->setParseMode($parse_mode_direct);
+      $combined_keys = implode(" ", $flat_keys);
+      $this->getQuery()->keys("({$combined_keys})");
+      // This is just to avoid Search API rewriting the query
+      $this->getQuery()->setOption('solr_param_defType', 'edismax');
+      // This will allow us to remove the edismax processor on a hook/event subscriber.
+      $this->getQuery()->setOption('sbf_advanced_search_filter', TRUE);
+      //$parse_mode_direct->setConjunction('OR');
+      // This can't be null nor a field we need truly an empty array.
+      // Only that works.
+      $this->getQuery()->setFulltextFields([]);
+    }
+    else {
+      //@TODO get old fields, old keys, parse same as the rest, so we can
+      //Switch to a direct query
+      $old_fields = $query->getFulltextFields();
+      $use_conditions = $use_conditions
+        && ($old_fields
+          && (array_diff($old_fields, $fields)
+            || array_diff(
+              $fields, $old_fields
+            )));
+
+      if ($use_conditions) {
+        // In this case we set the original chosen parse mode directly back
+        // into the query.
+        $query->setParseMode($parse_mode);
+        //@TODO use the inbetweens to define condition groups
+        $conditions = $query->createConditionGroup('OR');
+        $op = $this->operator === 'not' ? '<>' : '=';
+        foreach ($fields as $field) {
+          $conditions->addCondition($field, $this->value, $op);
+        }
+        $query->addConditionGroup($conditions);
+        return;
+      }
+
+      // If the operator was set to OR or NOT, set OR as the conjunction. It is
+      // also set for NOT since otherwise it would be "not all of these words".
+      if ($this->operator != 'and') {
+        $query->getParseMode()->setConjunction('OR');
+      }
+
+      $query->setFulltextFields($fields);
+      $query->keys($this->value);
+      if ($this->operator == 'not') {
+        $keys = &$query->getKeys();
+        if (is_array($keys)) {
+          $keys['#negation'] = TRUE;
+        }
+        else {
+          // We can't know how negation is expressed in the server's syntax.
+        }
+        unset($keys);
+      }
+
+      // If there were fulltext keys set, we take care to combine them in a
+      // meaningful way (especially with negated keys).
+      if ($old) {
+
+        $keys = &$query->getKeys();
+        // Array-valued keys are combined.
+        if (is_array($keys)) {
+          // If the old keys weren't parsed into an array, we instead have to
+          // combine the original keys.
+          if (is_scalar($old)) {
+            $keys = "($old) ({$this->value})";
+          }
+          else {
+            // If the conjunction or negation settings aren't the same, we have to
+            // nest both old and new keys array.
+            if (empty($keys['#negation']) !== empty($old['#negation'])
+              || $keys['#conjunction'] !== $old['#conjunction']
+            ) {
+              $keys = [
+                '#conjunction' => 'AND',
+                $old,
+                $keys,
+              ];
+            }
+            // Otherwise, just add all individual words from the old keys to the
+            // new ones.
+            else {
+              foreach ($old as $key => $value) {
+                if (substr($key, 0, 1) === '#') {
+                  continue;
+                }
+                $keys[] = $value;
+              }
+            }
+          }
+        }
+        // If the parse mode was "direct" for both old and new keys, we
+        // concatenate them and set them both via method and reference (to also
+        // update the originalKeys property.
+        elseif (is_scalar($old_original)) {
+          $combined_keys = "($old_original) ($keys)";
+          $query->keys($combined_keys);
+          $keys = $combined_keys;
+        }
+        unset($keys);
+      }
+    }
+  }
+
+  public function submitExposed(&$form, FormStateInterface $form_state) {
+    if ($form_state->getTriggeringElement()['#op'] ?? NULL == $this->options['id'] . '_addone') {
+      $current_count = &$form_state->getValue($this->options['id'].'_advanced_search_fields_count',1);
+      $form_state->setRebuild(TRUE);
+    }
+    // OR HOW THE RESET BUTTON DOES IT
+    //if (!$form_state->isValueEmpty('op') && $form_state->getValue('op') == $this->options['reset_button_label'])
+    parent::submitExposed(
+      $form, $form_state
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function valueForm(&$form, FormStateInterface $form_state) {
+    parent::valueForm($form, $form_state);
+
+    $form['value'] = [
+      '#type' => 'textfield',
+      '#title' => !$form_state->get('exposed') ? $this->t('Value') : '',
+      '#size' => 30,
+      '#default_value' => $this->value[$this->options['expose']['identifier']] ?? '',
+    ];
+    if (!empty($this->options['expose']['placeholder'])) {
+      $form['value']['#attributes']['placeholder'] = $this->options['expose']['placeholder'];
+    }
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function acceptExposedInput($input) {
+    if (empty($this->options['exposed'])) {
+      return TRUE;
+    }
+    $return = parent::acceptExposedInput($input);
+    // Now do things a bit differently:
+    // Value in our case needs to be multiple values (bc of the multiple options)
+    if ($return && $realcount = $input[$this->options['expose']['identifier'].'_advanced_search_fields_count']) {
+      $this->value = [];
+      $this->value[$this->options['expose']['identifier']] = $input[$this->options['expose']['identifier']];
+      for($i=1;$i < $realcount && $realcount > 1; $i++) {
+        if (!empty($this->options['expose']['use_operator']) && !empty($this->options['expose']['operator_id']) && isset($input[$this->options['expose']['operator_id'].'_'.$i])) {
+          $this->operatorAdv[$this->options['expose']['identifier'] . '_' . $i] = $input[$this->options['expose']['operator_id'].'_'.$i];
+        }
+        $this->value[$this->options['expose']['identifier'] . '_' . $i] =  $input[$this->options['expose']['identifier'].'_'.$i] ?? '';
+      }
+    }
+
+    if (!$return) {
+      // Override for the "(not) empty" operators.
+      $operators = $this->operators();
+      if ($operators[$this->operator]['values'] == 0) {
+        return TRUE;
+      }
+    }
+
+    return $return;
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function buildExposedForm(&$form, FormStateInterface $form_state) {
+    parent::buildExposedForm($form, $form_state);
+
+    if (empty($this->options['exposed'])) {
+      return;
+    }
+    if ($this->options['expose']['expose_fields']) {
+      $fields = $this->getFulltextFields();
+      $configured_fields = $this->options['fields'];
+      // Only keep the configured fields.
+      if (!empty($configured_fields)) {
+        $configured_fields = array_flip($configured_fields);
+        $fields = array_intersect_key($fields, $configured_fields);
+      }
+      //Now the searched fields if exposed.
+      $searched_fields_identifier = $this->options['id'] . '_searched_fields';
+      if (!empty($this->options['expose']['searched_fields_id'])) {
+        $searched_fields_identifier
+          = $this->options['expose']['searched_fields_id'];
+      }
+
+      // Remove the group operator if found
+      unset($form[$searched_fields_identifier]);
+      $multiple_exposed_fields = $this->options['expose']['multiple'] ?? FALSE ? min(count($fields), 5) : 1;
+      $newelements[$searched_fields_identifier] = [
+        '#type'     => 'select',
+        '#title'    => new PluralTranslatableMarkup($multiple_exposed_fields, 'Search Field', 'Search Fields'),
+        '#options'  => $fields,
+        '#multiple' => $this->options['expose']['multiple'] ?? FALSE,
+        '#size'     => $multiple_exposed_fields,
+        '#default_value' => $form_state->getValue($searched_fields_identifier),
+      ];
+
+      if (isset($form[$this->options['id'] . '_wrapper'])) {
+        $form[$this->options['id'] . '_wrapper'][$searched_fields_identifier]
+          = $newelements[$searched_fields_identifier];
+
+      }
+      else {
+        $form[$searched_fields_identifier]
+          = $newelements[$searched_fields_identifier];
+      }
+    }
+
+    $advanced_search_operator_id = $this->options['id'] . '_group_operator';
+    // And our own settings.
+    if (!empty($this->options['expose']['advanced_search_use_operator']) && !empty($this->options['expose']['advanced_search_operator_id'])) {
+
+      if (!empty($this->options['expose']['advanced_search_operator_id'])) {
+        $advanced_search_operator_id = $this->options['expose']['advanced_search_operator_id'];
+      }
+      // Group operators are used to connected multiple exposed forms/groups
+      // for this Filters between each other at query time
+      $group_operator = [
+        'and' => $this->t('AND'),
+        'or'  => $this->t('OR'),
+      ];
+      $newelements[$advanced_search_operator_id] = [
+        '#type' => 'select',
+        '#title' => $this->t('Operator'),
+        '#options' => $group_operator,
+        '#multiple' => FALSE,
+        '#weight' => '-10',
+        '#access' => FALSE,
+        '#default_value' => $form_state->getValue($advanced_search_operator_id,'or'),
+      ];
+      if (isset($form[$this->options['id'].'_wrapper'])) {
+        $form[$this->options['id'] . '_wrapper'][$advanced_search_operator_id] = $newelements[$advanced_search_operator_id];
+      }
+      else {
+        $form[$advanced_search_operator_id] = $newelements[$advanced_search_operator_id];
+      }
+    }
+
+    // Yes over complicated but so far the only way i found to keep the state
+    // Of this value between calls/rebuilds and searches.
+    // @TODO move this into Accept input. That is easier?
+    $nextcount = (int) ($form_state->getUserInput()['sbf_advanced_search_api_fulltext_advanced_search_fields_count'] ?? 1);
+    $prevcount = $this->view->exposed_raw_input[$this->options['id'].'_advanced_search_fields_count'] ?? NULL;
+    $form_state_count = $form_state->getValue('sbf_advanced_search_api_fulltext_advanced_search_fields_count', NULL);
+    $realcount = $prevcount ?? ($form_state_count ?? $nextcount);
+    // Cap it to the max limit
+    $realcount = ($realcount <= $this->options['expose']['advanced_search_fields_count']) ? $realcount : $this->options['expose']['advanced_search_fields_count'];
+    // Only enable if setup and the realcount is less than the max.
+    $enable_more = $realcount < $this->options['expose']['advanced_search_fields_count'] && $this->options['expose']['advanced_search_fields_multiple'];
+    $enable_less = $realcount > 1;
+    // This fails on Preview (because of competing Ajax and replace calls)
+    // @TODO Re-test without the IF bc of Sunday refactor that should have fixed it?
+    if (empty($this->view->live_preview)) {
+      $form[$this->options['id'].'_addone'] = [
+        '#type' => 'submit',
+        '#op' => $this->options['id'] . '_addone',
+        '#value' => $this->t('@label', [
+          '@label' => $this->options['exposed']['advanced_search_fields_add_one_label'] ?? 'add one'
+        ]),
+        '#access' => $enable_more,
+        '#weight' => '100',
+      ];
+      $form[$this->options['id'].'_delone'] = [
+        '#type' => 'submit',
+        '#op' => $this->options['id'] . '_delone',
+        '#value' => $this->t('@label', [
+          '@label' => $this->options['exposed']['advanced_search_fields_remove_one_label'] ?? 'remove one'
+        ]),
+        '#access' => $enable_less,
+        '#weight' => '100',
+      ];
+    }
+
+    $form[$this->options['id'] . '_advanced_search_fields_count'] = [
+      '#type' => 'hidden',
+      '#value' => $realcount,
+    ];
+
+    for($i=1;$i < $realcount && $realcount > 1; $i++) {
+      if (isset($form[$this->options['id'].'_wrapper'])) {
+        foreach ($form[$this->options['id'].'_wrapper'] as $key => $value) {
+          $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i] = $value;
+          if ($key == $this->options['expose']['identifier']) {
+            $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#default_value'] = is_array($this->value) ? $this->value[$key.'_'.$i] ?? '' : '';
+          }
+          elseif (is_array($value) && strpos($key, '#') === FALSE) {
+            $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#default_value'] = $form_state->getValue($key.'_'.$i);
+            if ($key == $advanced_search_operator_id) {
+              $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#access'] = TRUE;
+            }
+          }
+          else {
+            error_log($key);
+          }
+        }
+      }
+    }
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateExposed(&$form, FormStateInterface $form_state) {
+    // Only validate exposed input.
+    if (empty($this->options['exposed'])
+      || empty($this->options['expose']['identifier'])
+    ) {
+      return;
+    }
+
+    // Store searched fields.
+    $searched_fields_identifier = $this->options['id'] . '_searched_fields';
+    if (!empty($this->options['expose']['searched_fields_id'])) {
+      $searched_fields_identifier
+        = $this->options['expose']['searched_fields_id'];
+    }
+
+    $advanced_search_operator_id = $this->options['id'] . '_group_operator';
+    if (!empty($this->options['expose']['advanced_search_operator_id'])) {
+      $advanced_search_operator_id
+        = $this->options['expose']['advanced_search_operator_id'];
+    }
+
+    $this->searchedFields[$searched_fields_identifier] = $form_state->getValue(
+      $searched_fields_identifier, []
+    );
+
+    // Store Exposed Advanced Search count
+    $current_count = &$form_state->getValue(
+      $this->options['id'] . '_advanced_search_fields_count', 1
+    );
+    if (($triggering_element = $form_state->getTriggeringElement()['#op'] ??
+        NULL == $this->options['id'] . '_addone')
+      && ($form_state->getUserInput()['op'] ?? NULL == "add one")
+      && $this->options['expose']['advanced_search_fields_multiple']
+    ) {
+      $this->searchedFieldsCount = $this->searchedFieldsCount
+      < ($this->options['expose']['advanced_search_fields_count'] ?? 1)
+        ? $this->searchedFieldsCount++
+        : ($this->options['expose']['advanced_search_fields_count'] ?? 1);
+      // Check if the state was set already
+      $current_count++;
+    }
+    if ($this->options['expose']['advanced_search_fields_multiple']) {
+      for ($i = 1; $i < $current_count; $i++) {
+        if (!empty($this->options['expose']['advanced_search_use_operator'])
+          && !empty($this->options['expose']['advanced_search_operator_id'])
+        ) {
+          $this->searchedFieldsOp[$advanced_search_operator_id . '_' . $i]
+            = $form_state->getValue(
+            $advanced_search_operator_id . '_' . $i, []
+          );
+        }
+        $this->searchedFields[$searched_fields_identifier . '_' . $i]
+          = $form_state->getValue($searched_fields_identifier . '_' . $i, []);
+      }
+    }
+
+
+    $identifiers[] = $this->options['expose']['identifier'];
+    for ($i = 1; $i < $current_count; $i++) {
+      $identifiers[] = $this->options['expose']['identifier'] . '_' . $i;
+    }
+    foreach ($identifiers as $identifier) {
+      $input = &$form_state->getValue($identifier, '');
+      /// @TODO Add all inputs here...
+      ///
+      if ($this->options['is_grouped']
+        && isset($this->options['group_info']['group_items'][$input])
+      ) {
+        $this->operator
+          = $this->options['group_info']['group_items'][$input]['operator'];
+        $input = &$this->options['group_info']['group_items'][$input]['value'];
+      }
+
+      // Under some circumstances, input will be an array containing the string
+      // value. Not sure why, but just deal with that.
+      while (is_array($input)) {
+        $input = $input ? reset($input) : '';
+      }
+      if (trim($input) === '') {
+        // No input was given by the user. If the filter was set to "required" and
+        // there is a query (not the case when an exposed filter block is
+        // displayed stand-alone), abort it.
+        if (!empty($this->options['expose']['required']) && $this->getQuery()) {
+          $this->getQuery()->abort();
+        }
+        // If the input is empty, there is nothing to validate: return early.
+        return;
+      }
+
+      // Only continue if there is a minimum word length set.
+      if ($this->options['min_length'] < 2) {
+        return;
+      }
+
+      $words = preg_split('/\s+/', $input);
+      foreach ($words as $i => $word) {
+        if (mb_strlen($word) < $this->options['min_length']) {
+          unset($words[$i]);
+        }
+      }
+      if (!$words) {
+        $vars['@count'] = $this->options['min_length'];
+        $msg = $this->t(
+          'You must include at least one positive keyword with @count characters or more.',
+          $vars
+        );
+        $form_state->setErrorByName($identifier, $msg);
+      }
+      $input = implode(' ', $words);
+    }
+  }
+
+  protected function canBuildGroup() {
+    // Building groups here makes no sense. We disable it.
+    return FALSE;
+  }
+}

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -342,7 +342,6 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     $flat_keys = [];
     $negation = FALSE;
     // Now do the actual query creation/composite thing
-    error_log(var_export($query_able_data, true));
     $j = 0;
     foreach ($query_able_data as $query_able_datum_internal) {
       $flat_key = '';
@@ -383,7 +382,6 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
 
       $combined_keys = implode(" ", $flat_keys);
       $this->getQuery()->keys("({$combined_keys})");
-      error_log($combined_keys);
       // This is just to avoid Search API rewriting the query
       $this->getQuery()->setOption('solr_param_defType', 'edismax');
       // This will allow us to remove the edismax processor on a hook/event subscriber.

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -653,7 +653,12 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     for($i=1;$i < $realcount && $realcount > 1; $i++) {
       if (isset($form[$this->options['id'].'_wrapper'])) {
         foreach ($form[$this->options['id'].'_wrapper'] as $key => $value) {
-          $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i] = $value;
+          if (strpos($key, '#') !== FALSE) {
+            $form[$this->options['id'].'_wrapper_'.$i][$key] = $value;
+          }
+          else {
+            $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i] = $value;
+          }
           if ($key == $this->options['expose']['identifier']) {
             $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#default_value'] = is_array($this->value) ? $this->value[$key.'_'.$i] ?? '' : '';
           }
@@ -663,12 +668,11 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
               $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#access'] = TRUE;
             }
           }
-          else {
-            error_log($key);
-          }
         }
+        $form[$this->options['id'].'_wrapper_'.$i]['#title_display'] = 'invisible';
       }
     }
+    $form = $form;
   }
 
 

--- a/modules/format_strawberryfield_views/src/Routing/RouteSubscriber.php
+++ b/modules/format_strawberryfield_views/src/Routing/RouteSubscriber.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\format_strawberryfield_views\Routing\RouteSubscriber.
+ */
+
+namespace Drupal\format_strawberryfield_views\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRoutes(RouteCollection $collection) {
+    if ($route = $collection->get('views.ajax')) {
+      $route->setDefaults(array(
+        '_controller' => '\Drupal\format_strawberryfield_views\Controller\FormatStrawberryfieldViewAjaxController:ajaxView',
+      ));
+    }
+  }
+}


### PR DESCRIPTION
See #260 

- Adds a special Filter named Advanced Search capable of handling multiple inputs with Boolean Operators
- Overrides the Default AJAX controller to NOT fail if the default Exposed Form is not present (Ajax ends clearing all Settings if that is the case, bad sloppy Drupal)
-  New Block Plugin (Modal Exposed Views Form) that allows selectively to hide/show Exposed Form elements providing a variety of cool options. Has a deriver
- Ajax to drive updates of Modal Exposed Views Forms (many on a single site) that is aware of Facet Summaries and Facets, overriding the default Facet JS which is (guess what) also sloppy
- New Facet Summary Processor that is able to show Active Selected Facets even if no results. Does some crazy pants stuff to reverse-engineer what normally the actual Search API field would do with Dates (means we convert granularity back into Timestamps.. I'm very good at this, surprised of myself)
- New Facet/Date Range (so far no slider) Widget/facet processor that actually WORKS (v/s the contributed module which, guess what? Does not)
- New Facet Summary Can ALSO (gosh, so much parsing) show full text user input allowing a Reset for those that works like a Facet. Super cool. (extra code + mega processing + scared of what I wrote)
- Extra! rename "Display settings" to "Active Display Settings" and make this and 'Metadata Display List' admin routes (so admin theme)

@TODO (different pull, this is just too big). Allow Exposed Views Form Blocks acting on Blocks also use Ajax (yep, that DOES NOT WORK) because of the way/order in which Ajax is loaded the block itself does not initialize views.ajax settings fast enough. 

