### PR TITLE
ISSUE-265: Allow multiple CSS classes for clipboard copy functionality

### DIFF
--- a/js/clipboard_copy_strawberry.js
+++ b/js/clipboard_copy_strawberry.js
@@ -26,20 +26,27 @@
           if(copyButtonContainers !== undefined) {
             for(var i = 0; i < copyButtonContainers.length; i++) {
               var copyButtonContainer = copyButtonContainers[i];
-              var copyContentContainer = copyContentContainers[i];
-              if(!copyContentContainer.hasAttribute('id')) {
-                copyContentContainer.id = 'clipboard-copy-content-' + i;
+              var userCopyButton = copyButtonContainer.querySelector('clipboard-copy');
+              if (userCopyButton) {
+                copyButtonContainer.addEventListener('click', function () {
+                  userCopyButton.click();
+                });
+              } else {
+                var copyContentContainer = copyContentContainers[i];
+                if(!copyContentContainer.hasAttribute('id')) {
+                  copyContentContainer.id = 'clipboard-copy-content-' + i;
+                }
+                var copyButtonWrapper = document.createElement('button');
+                var copyButton = document.createElement('clipboard-copy');
+                copyButton.setAttribute('for', copyContentContainer.id);
+                copyButton.innerHTML = copyButtonText;
+                copyButtonWrapper.appendChild(copyButton);
+                for (var i = 0; i < copyButtonClasses.length; i++) {
+                  var copyButtonClassAppend = copyButtonClasses[i];
+                  copyButtonWrapper.classList.add(copyButtonClassAppend);
+                }
+                copyButtonContainer.parentElement.insertBefore(copyButtonWrapper, copyButtonContainer.nextSibling);
               }
-              var copyButtonWrapper = document.createElement('button');
-              var copyButton = document.createElement('clipboard-copy');
-              copyButton.setAttribute('for', copyContentContainer.id);
-              copyButton.innerHTML = copyButtonText;
-              copyButtonWrapper.appendChild(copyButton);
-              for (var i = 0; i < copyButtonClasses.length; i++) {
-                var copyButtonClassAppend = copyButtonClasses[i];
-                copyButtonWrapper.classList.add(copyButtonClassAppend);
-              }
-              copyButtonContainer.parentElement.insertBefore(copyButtonWrapper, copyButtonContainer.nextSibling);
             }
           }
         });

--- a/js/clipboard_copy_strawberry.js
+++ b/js/clipboard_copy_strawberry.js
@@ -4,9 +4,11 @@
     attach: function (context, settings) {
       $('.clipboard-copy-data').once('attach_clipboard')
         .each(function (index, value) {
-          var theid = '#' + $(this).attr("id");
+          var theid = '#' + $(this).attr('id');
           var copyContainer = document.querySelector(theid);
-          var copyButtonClass = copyContainer.dataset.clipboardCopyButton;
+          var copyButtonClassData = copyContainer.dataset.clipboardCopyButton;
+          var copyButtonClasses = copyButtonClassData.split(' ');
+          var copyButtonClass = copyButtonClasses[0];
           var copyContentClass = copyContainer.dataset.clipboardCopyContent;
           var copyButtonText = copyContainer.dataset.clipboardCopyButtonText;
           var copyButtonContainers;
@@ -33,7 +35,10 @@
               copyButton.setAttribute('for', copyContentContainer.id);
               copyButton.innerHTML = copyButtonText;
               copyButtonWrapper.appendChild(copyButton);
-              copyButtonWrapper.classList.add(copyButtonClass);
+              for (var i = 0; i < copyButtonClasses.length; i++) {
+                var copyButtonClassAppend = copyButtonClasses[i];
+                copyButtonWrapper.classList.add(copyButtonClassAppend);
+              }
               copyButtonContainer.parentElement.insertBefore(copyButtonWrapper, copyButtonContainer.nextSibling);
             }
           }

--- a/js/clipboard_copy_strawberry.js
+++ b/js/clipboard_copy_strawberry.js
@@ -4,15 +4,15 @@
     attach: function (context, settings) {
       $('.clipboard-copy-data').once('attach_clipboard')
         .each(function (index, value) {
-          var theid = '#' + $(this).attr('id');
-          var copyContainer = document.querySelector(theid);
-          var copyButtonClassData = copyContainer.dataset.clipboardCopyButton;
-          var copyButtonClasses = copyButtonClassData.split(' ');
-          var copyButtonClass = copyButtonClasses[0];
-          var copyContentClass = copyContainer.dataset.clipboardCopyContent;
-          var copyButtonText = copyContainer.dataset.clipboardCopyButtonText;
-          var copyButtonContainers;
-          var copyContentContainers = document.querySelectorAll('.' + copyContentClass);
+          const theid = '#' + this.id;
+          const copyContainer = document.querySelector(theid);
+          const copyButtonClassData = copyContainer.dataset.clipboardCopyButton;
+          const copyButtonClasses = copyButtonClassData.split(' ');
+          const copyButtonClass = copyButtonClasses[0];
+          const copyContentClass = copyContainer.dataset.clipboardCopyContent;
+          const copyButtonText = copyContainer.dataset.clipboardCopyButtonText;
+          let copyButtonContainers;
+          const copyContentContainers = document.querySelectorAll('.' + copyContentClass);
           if(copyContentContainers.length == 0) {
             console.log('Class provided by Twig function is not available. Clipboard Copy was not initiated.');
           } else if(copyButtonClass == 'clipboard-copy-button') {
@@ -24,25 +24,25 @@
             }
           }
           if(copyButtonContainers !== undefined) {
-            for(var i = 0; i < copyButtonContainers.length; i++) {
-              var copyButtonContainer = copyButtonContainers[i];
-              var userCopyButton = copyButtonContainer.querySelector('clipboard-copy');
+            for(let i = 0; i < copyButtonContainers.length; i++) {
+              let copyButtonContainer = copyButtonContainers[i];
+              let userCopyButton = copyButtonContainer.querySelector('clipboard-copy');
               if (userCopyButton) {
                 copyButtonContainer.addEventListener('click', function () {
                   userCopyButton.click();
                 });
               } else {
-                var copyContentContainer = copyContentContainers[i];
+                let copyContentContainer = copyContentContainers[i];
                 if(!copyContentContainer.hasAttribute('id')) {
                   copyContentContainer.id = 'clipboard-copy-content-' + i;
                 }
-                var copyButtonWrapper = document.createElement('button');
-                var copyButton = document.createElement('clipboard-copy');
+                const copyButtonWrapper = document.createElement('button');
+                const copyButton = document.createElement('clipboard-copy');
                 copyButton.setAttribute('for', copyContentContainer.id);
                 copyButton.innerHTML = copyButtonText;
                 copyButtonWrapper.appendChild(copyButton);
-                for (var i = 0; i < copyButtonClasses.length; i++) {
-                  var copyButtonClassAppend = copyButtonClasses[i];
+                for (let j = 0; j < copyButtonClasses.length; j++) {
+                  let copyButtonClassAppend = copyButtonClasses[j];
                   copyButtonWrapper.classList.add(copyButtonClassAppend);
                 }
                 copyButtonContainer.parentElement.insertBefore(copyButtonWrapper, copyButtonContainer.nextSibling);


### PR DESCRIPTION
Resolves #265. The data attribute used for the copy button's CSS classes can contain a space-separated list. Once this is merged 2 small updates can follow:

1. Open PR for documentation around this copy/paste functionality should be updated.
2. Javascript for the IA Bookreader share functionality can be slightly refactored to be cleaner.