### PR TITLE
ISSUE-269: Lower the strict conditions for a single Media (audio and video) with VTT(s)

### DIFF
--- a/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
@@ -52,41 +52,41 @@ class StrawberryAudioFormatter extends StrawberryDirectJsonFormatter {
    */
   public function settingsForm(array $form, FormStateInterface $form_state) {
     return [
-      'json_key_source' => [
-        '#type' => 'textfield',
-        '#title' => t('JSON Key from where to fetch Media URLs'),
-        '#default_value' => $this->getSetting('json_key_source'),
-        '#required' => TRUE
-      ],
-      'number_media' => [
-        '#type' => 'number',
-        '#title' => $this->t('Number of Audio files'),
-        '#default_value' => $this->getSetting('number_media'),
-        '#size' => 2,
-        '#maxlength' => 2,
-        '#min' => 0,
-      ],
-      'max_width' => [
-        '#type' => 'number',
-        '#title' => $this->t('Maximum width'),
-        '#default_value' => $this->getSetting('max_width'),
-        '#size' => 5,
-        '#maxlength' => 5,
-        '#field_suffix' => $this->t('pixels'),
-        '#min' => 0,
-        '#required' => TRUE
-      ],
-      'max_height' => [
-        '#type' => 'number',
-        '#title' => $this->t('Maximum height'),
-        '#default_value' => $this->getSetting('max_height'),
-        '#size' => 5,
-        '#maxlength' => 5,
-        '#field_suffix' => $this->t('pixels'),
-        '#min' => 0,
-        '#required' => TRUE
-      ],
-    ] + parent::settingsForm($form, $form_state);
+        'json_key_source' => [
+          '#type' => 'textfield',
+          '#title' => t('JSON Key from where to fetch Media URLs'),
+          '#default_value' => $this->getSetting('json_key_source'),
+          '#required' => TRUE
+        ],
+        'number_media' => [
+          '#type' => 'number',
+          '#title' => $this->t('Number of Audio files'),
+          '#default_value' => $this->getSetting('number_media'),
+          '#size' => 2,
+          '#maxlength' => 2,
+          '#min' => 0,
+        ],
+        'max_width' => [
+          '#type' => 'number',
+          '#title' => $this->t('Maximum width'),
+          '#default_value' => $this->getSetting('max_width'),
+          '#size' => 5,
+          '#maxlength' => 5,
+          '#field_suffix' => $this->t('pixels'),
+          '#min' => 0,
+          '#required' => TRUE
+        ],
+        'max_height' => [
+          '#type' => 'number',
+          '#title' => $this->t('Maximum height'),
+          '#default_value' => $this->getSetting('max_height'),
+          '#size' => 5,
+          '#maxlength' => 5,
+          '#field_suffix' => $this->t('pixels'),
+          '#min' => 0,
+          '#required' => TRUE
+        ],
+      ] + parent::settingsForm($form, $form_state);
   }
 
   /**
@@ -213,57 +213,74 @@ class StrawberryAudioFormatter extends StrawberryDirectJsonFormatter {
           $upload_keys, []);
         if (count($media)) {
           $conditions[] = [
-            'source' => ['dr:mimetype'],
+            'source'    => ['dr:mimetype'],
             'condition' => 'text/vtt',
           ];
-          $vtt = $this->fetchMediaFromJsonWithFilter($delta, $items,
+          $vtt = $this->fetchMediaFromJsonWithFilter(
+            $delta, $items,
             $elements,
             FALSE, $jsondata, 'Text', 'as:text', $ordersubkey, $number_media,
-            $upload_keys, $conditions);
-          /* This may be a bit more complex, possible situations
+            $upload_keys, $conditions
+          );
+          /* This may be a bit more complex, possible situations we cover
             1.- NO vtt, all good
             2.- One Media, multiple vtt, all good
-            3.- Multiple media, single vtt (all good?)
-            4.- Multiple media, multiple vtt. But there is a single media per upload_key and vtt share the upload key
-            5.- Multiple media, multiple vtt, all in different upload keys. We can match by filename prefix?
+            3.- Multiple media, multiple vtt. need to grouped by sourcekey
             */
           if (count($vtt)) {
             // Yep, redundant but we have no longer these settings here
             // and i need to add 30px (uff) to the top.
 
-            if  ($max_height = $this->getSetting('max_height') <= 90) {
+            if ($max_height = $this->getSetting('max_height') <= 90) {
               $max_width = $this->getSetting('max_width');
               $max_height = 90;
-              $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width . 'px';
+              $max_width_css = empty($max_width) || $max_width == 0 ? '100%'
+                : $max_width . 'px';
             }
+            // If $media is a single one, we will assume all VTTS belong to it, bypassing the dr:for grouping
 
             foreach ($media as $drforkey => $media_item) {
-              if (isset($vtt[$drforkey])) {
+              if (isset($vtt[$drforkey]) || count($media) == 1) {
                 foreach ($media_item as $key => $media_entry) {
-                  $elements[$delta]['audio_hmtl5_' . $key]['audio']['#attributes']['style'] = "width:{$max_width_css}; height:{$max_height}px";
-                  foreach ($vtt[$drforkey] as $vtt_key => &$vtt_item) {
-                    $route_parameters = [
-                      'node' => $nodeid,
-                      'uuid' => $vtt_item['file']->uuid(),
-                      'format' => 'default.' . pathinfo($vtt_item['file']->getFilename(),
-                          PATHINFO_EXTENSION)
-                    ];
-                    $publicurl = Url::fromRoute('format_strawberryfield.iiifbinary',
-                      $route_parameters);
-                    //<track label="English" kind="subtitles" srclang="en" src="captions/vtt/sintel-en.vtt" default>//
-                    // tracks need at least 30px more up. Wonder if we should add those here
-                    // Or document it as min: 90px height?
-                    $elements[$delta]['audio_hmtl5_' . $key]['audio']['track' . $vtt_key] = [
-                      '#type' => 'html_tag',
-                      '#tag' => 'track',
-                      '#attributes' => [
-                        'label' => $this->t('Transcript ' . $current_language),
-                        'kind' => 'subtitles',
-                        'srclang' => $current_language,
-                        'src' => $publicurl->toString(),
-                        'default' => TRUE
-                      ]
-                    ];
+                  $elements[$delta]['audio_hmtl5_'
+                  . $key]['audio']['#attributes']['style']
+                    = "width:{$max_width_css}; height:{$max_height}px";
+                  foreach ($vtt as $vtt_drforkey => $vtt_entries) {
+                    if (count($media) == 1 || $drforkey == $vtt_drforkey) {
+                      foreach ($vtt_entries as $vtt_key => &$vtt_item) {
+                        $route_parameters = [
+                          'node'   => $nodeid,
+                          'uuid'   => $vtt_item['file']->uuid(),
+                          'format' => 'default.' . pathinfo(
+                              $vtt_item['file']->getFilename(),
+                              PATHINFO_EXTENSION
+                            )
+                        ];
+                        $publicurl = Url::fromRoute(
+                          'format_strawberryfield.iiifbinary',
+                          $route_parameters
+                        );
+                        //<track label="English" kind="subtitles" srclang="en" src="captions/vtt/sintel-en.vtt" default>//
+                        // tracks need at least 30px more up. Wonder if we should add those here
+                        // Or document it as min: 90px height?
+                        $elements[$delta]['audio_hmtl5_'
+                        . $key]['audio']['track'
+                        . $vtt_key]
+                          = [
+                          '#type'       => 'html_tag',
+                          '#tag'        => 'track',
+                          '#attributes' => [
+                            'label'   => $this->t(
+                              'Transcript ' . $current_language ." ({$vtt_item['file_name']})"
+                            ),
+                            'kind'    => 'subtitles',
+                            'srclang' => $current_language,
+                            'src'     => $publicurl->toString(),
+                            'default' => TRUE
+                          ]
+                        ];
+                      }
+                    }
                   }
                 }
               }

--- a/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
@@ -167,7 +167,7 @@ class StrawberryVideoFormatter extends StrawberryDirectJsonFormatter {
     $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
     $max_height = $this->getSetting('max_height');
     $max_height_css = empty($max_height) || $max_height == 0 ? 'auto' : $max_height .'px';
-    // Basically min 90px height if using VTT	  
+    // Basically min 90px height if using VTT
     $max_height_vtt_css = empty($max_height) || $max_height == 0 ? 'auto' : ($max_height <= 90 ? 90 : $max_height) .'px';
 
     $current_language = $items->getEntity()->get('langcode')->value;
@@ -248,7 +248,7 @@ class StrawberryVideoFormatter extends StrawberryDirectJsonFormatter {
           $upload_keys, []);
         if (count($media)) {
           $conditions[] = [
-            'source' => ['dr:mimetype'],
+            'source'    => ['dr:mimetype'],
             'condition' => 'text/vtt',
           ];
           // WE call the parent here since we do not want/nor have a JMESPATH
@@ -257,43 +257,53 @@ class StrawberryVideoFormatter extends StrawberryDirectJsonFormatter {
             $elements,
             FALSE, $jsondata, 'Text', 'as:text', $ordersubkey, $number_media,
             $upload_keys, $conditions);
-          /* This may be a bit more complex, possible situations
+          /* This may be a bit more complex, possible situations we cover
             1.- NO vtt, all good
             2.- One Media, multiple vtt, all good
-            3.- Multiple media, single vtt (all good?)
-            4.- Multiple media, multiple vtt. But there is a single media per upload_key and vtt share the upload key
-            5.- Multiple media, multiple vtt, all in different upload keys. We can match by filename prefix?
+            3.- Multiple media, multiple vtt. need to grouped by sourcekey
             */
           if (count($vtt)) {
-            // Yep, redundant but we have no longer these settings here
-
+            // If $media is a single one, we will assume all VTTS belong to it, bypassing the dr:for grouping
             foreach ($media as $drforkey => $media_item) {
-              if (isset($vtt[$drforkey])) {
+              if (isset($vtt[$drforkey]) || count($media) == 1) {
                 foreach ($media_item as $key => $media_entry) {
                   $elements[$delta]['video_hmtl5_' . $key]['video']['#attributes']['style'] = "width:{$max_width_css}; height:{$max_height_vtt_css}";
-                  foreach ($vtt[$drforkey] as $vtt_key => &$vtt_item) {
-                    $route_parameters = [
-                      'node' => $nodeid,
-                      'uuid' => $vtt_item['file']->uuid(),
-                      'format' => 'default.' . pathinfo($vtt_item['file']->getFilename(),
-                          PATHINFO_EXTENSION)
-                    ];
-                    $publicurl = Url::fromRoute('format_strawberryfield.iiifbinary',
-                      $route_parameters);
-                    //<track label="English" kind="subtitles" srclang="en" src="captions/vtt/sintel-en.vtt" default>//
-                    // tracks need at least 30px more up. Wonder if we should add those here
-                    // Or document it as min: 90px height?
-                    $elements[$delta]['video_hmtl5_' . $key]['video']['track' . $vtt_key] = [
-                      '#type' => 'html_tag',
-                      '#tag' => 'track',
-                      '#attributes' => [
-                        'label' => $this->t('Transcript ' . $current_language),
-                        'kind' => 'subtitles',
-                        'srclang' => $current_language,
-                        'src' => $publicurl->toString(),
-                        'default' => TRUE
-                      ]
-                    ];
+                  foreach ($vtt as $vtt_drforkey => $vtt_entries) {
+                    if (count($media) == 1 || $drforkey == $vtt_drforkey) {
+                      foreach ($vtt_entries as $vtt_key => &$vtt_item) {
+                        $route_parameters = [
+                          'node'   => $nodeid,
+                          'uuid'   => $vtt_item['file']->uuid(),
+                          'format' => 'default.' . pathinfo(
+                              $vtt_item['file']->getFilename(),
+                              PATHINFO_EXTENSION
+                            )
+                        ];
+                        $publicurl = Url::fromRoute(
+                          'format_strawberryfield.iiifbinary',
+                          $route_parameters
+                        );
+                        //<track label="English" kind="subtitles" srclang="en" src="captions/vtt/sintel-en.vtt" default>//
+                        // tracks need at least 30px more up. Wonder if we should add those here
+                        // Or document it as min: 90px height?
+                        $elements[$delta]['video_hmtl5_'
+                        . $key]['video']['track'
+                        . $vtt_key]
+                          = [
+                          '#type'       => 'html_tag',
+                          '#tag'        => 'track',
+                          '#attributes' => [
+                            'label'   => $this->t(
+                              'Transcript ' . $current_language ." ({$vtt_item['file_name']})"
+                            ),
+                            'kind'    => 'subtitles',
+                            'srclang' => $current_language,
+                            'src'     => $publicurl->toString(),
+                            'default' => TRUE
+                          ]
+                        ];
+                      }
+                    }
                   }
                 }
               }


### PR DESCRIPTION
See #269 

When using a single Media Source all present VTTs (independently where) are going to be used. Also adds the Filename as part of the VTT label on the player. The old behavior still works, grouped VTTs/Media will be treated as such.

![image](https://user-images.githubusercontent.com/6946023/218568664-54092255-a912-4c8b-b32e-fbf49773ea2a.png)

