### PR TITLE
ISSUE-271: Deal with Empty Queries on Advanced and Facet Summary for Queries

### DIFF
--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -211,7 +211,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
 
     foreach ($this->value as $exposed_value_id => $exposed_value) {
       // Catch empty strings entered by the user, but not "0".
-      if ($exposed_value === '') {
+      if (trim($exposed_value) === '') {
         unset($this->value[$exposed_value_id]);
         unset($this->searchedFields[$exposed_value_id]);
       }


### PR DESCRIPTION
See #271. Includes some fixes for Advanced searches (Direct Parser) where we know (now) that Drupal's Parse Mode Parser DOES NOT know how to deal with an empty and we end with just the `#conjunction` which means a wrong Parsed Solr query. This filters out anything that after trimming == '' but preserves spaces on the query term if that is not the case.

There might be other "Edge" cases but we can start with what we know right?
