### PR TITLE
ISSUE-280:Exclude Facet Processor that allows multiline facet value settings

### DIFF
--- a/format_strawberryfield.routing.yml
+++ b/format_strawberryfield.routing.yml
@@ -262,7 +262,7 @@ format_strawberryfield.deletetmp_webannotations:
 
 # Display settings for each ADO
 format_strawberryfield.display_settings:
-  path: '/node/{node}/{bundle}/display-settings/{view_mode_name}'
+  path: '/node/{node}/display-settings/{bundle}/{view_mode_name}'
   defaults:
     _entity_form: 'entity_view_display.edit'
     _title: 'Active Display settings'

--- a/modules/format_strawberryfield_facets/config/schema/format_strawberryfield_facets.schema.yml
+++ b/modules/format_strawberryfield_facets/config/schema/format_strawberryfield_facets.schema.yml
@@ -1,6 +1,21 @@
-# Config schema for slider, you can find the implementation in
-# Drupal\facets_range\Plugin\facets\widget\SliderWidget.
-facet.widget.config.format_strawberryfield_dateslider:
+facet.widget.config.sbf_date_range:
+  type: facet.widget.default_config
+  label: 'List of range widget configuration'
+  mapping:
+    set_defaults_from_results:
+      type: integer
+      label: 'Use default max/min from reslts'
+    show_reset_link:
+      type: integer
+      label: 'Show Reset Link'
+    reset_text:
+      type: string
+      label: 'Text to be used in the reset button'
+    hide_reset_when_no_selection:
+      type: integer
+      label: 'Hide Reset when no selection'
+
+facet.widget.config.sbf_range_date_slider:
   type: facet.widget.default_config
   label: 'List of range widget configuration'
   mapping:
@@ -26,28 +41,42 @@ facet.widget.config.format_strawberryfield_dateslider:
       type: float
       label: 'Step'
 
-facet.widget.config.format_strawberryfield_daterange_slider:
-  type: facet.widget.default_config
-  label: 'List of range widget configuration'
+plugin.plugin_configuration.facets_processor.sbf_exclude_specified_items:
+  type: mapping
+  label: 'Format Strawberryfield Exclude specified items'
   mapping:
-    prefix:
-      type: label
-      label: 'Prefix'
-    suffix:
-      type: label
-      label: 'Suffix'
-    min_type:
+    exclude:
       type: string
-      label: 'Minimum type'
-    min_value:
-      type: float
-      label: 'Minimum value'
-    max_type:
-      type: string
-      label: 'Maximum type'
-    max_value:
-      type: float
-      label: 'Maximum value'
-    step:
-      type: float
-      label: 'Step'
+      label: Exclude
+    regex:
+      type: boolean
+      label: Regex
+    invert:
+      type: boolean
+      label: Invert
+    exclude_case_insensitive:
+      type: boolean
+      label: Use Case insensitive comparison
+# inherited from the facet_summary module
+plugin.plugin_configuration.facets_summary_processor.sbf_last_active_facets:
+  type: mapping
+  label: 'Last Active Processor Facet Summary'
+  mapping:
+    enable:
+      type: integer
+      label: Enabled
+    enable_empty_message:
+      type: integer
+      label: Enable Empty Message
+    enable_query:
+      type: integer
+      label: Enable Full text search terms as Facet Summary Entry
+    text:
+      type: mapping
+      mapping:
+        format:
+          type: string
+          label: Text format
+        value:
+          type: string
+          label: The Text used for Empty

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/processor/SbfExcludeSpecifiedItemsProcessor.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/processor/SbfExcludeSpecifiedItemsProcessor.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Drupal\format_strawberryfield_facets\Plugin\facets\processor;
+
+use Drupal\Core\Cache\UnchangingCacheableDependencyTrait;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\facets\FacetInterface;
+use Drupal\facets\Processor\BuildProcessorInterface;
+use Drupal\facets\Processor\ProcessorPluginBase;
+
+/**
+ * Provides a processor that excludes specified items.
+ *
+ * @FacetsProcessor(
+ *   id = "sbf_exclude_specified_items",
+ *   label = @Translation("Format Strawberry Field Exclude specified items"),
+ *   description = @Translation("Exclude items depending on their raw or display value (such as node IDs or titles) using multi line input."),
+ *   stages = {
+ *     "build" = 50
+ *   }
+ * )
+ */
+class SbfExcludeSpecifiedItemsProcessor extends ProcessorPluginBase implements BuildProcessorInterface {
+
+  use UnchangingCacheableDependencyTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(FacetInterface $facet, array $results) {
+    $config = $this->getConfiguration();
+
+    /** @var \Drupal\facets\Result\ResultInterface $result */
+    $exclude_item = $config['exclude'];
+    foreach ($results as $id => $result) {
+      $is_excluded = FALSE;
+      if ($config['regex']) {
+        $matcher = '/' . trim(str_replace('/', '\\/', $exclude_item)) . '/';
+        if (preg_match($matcher, $result->getRawValue()) || preg_match($matcher, $result->getDisplayValue())) {
+          $is_excluded = TRUE;
+        }
+      }
+      else {
+        $exclude_items = explode("\n", $exclude_item);
+        foreach ($exclude_items as $item) {
+          if ($config['exclude_case_insensitive']) {
+            if (strtolower($result->getRawValue()) == strtolower($item)
+              || strtolower($result->getDisplayValue()) == strtolower($item)
+            ) {
+              $is_excluded = TRUE;
+            }
+          }
+          else {
+            if ($result->getRawValue() == $item
+              || $result->getDisplayValue() == $item
+            ) {
+              $is_excluded = TRUE;
+            }
+          }
+        }
+      }
+
+      // Invert the is_excluded result when the invert setting is active.
+      if ($config['invert']) {
+        $is_excluded = !$is_excluded;
+      }
+
+      // Filter by the excluded results.
+      if ($is_excluded) {
+        unset($results[$id]);
+      }
+    }
+
+    return $results;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state, FacetInterface $facet) {
+    $config = $this->getConfiguration();
+
+    $build['exclude'] = [
+      '#title' => $this->t('Exclude items'),
+      '#type' => 'textarea',
+      '#default_value' => $config['exclude'],
+      '#description' => $this->t("List of titles or values that should be excluded, matching either an item's title or value. Enter one by line. Starting and trailing spaces won't be trimmed to allow facets that contain spaces to be matched exactly"),
+    ];
+    $build['exclude_case_insensitive'] = [
+      '#title' => $this->t('Exclude Items in an case insensitive way'),
+      '#type' => 'checkbox',
+      '#default_value' => $config['exclude_case_insensitive'],
+      '#description' => $this->t('Makes the comparison for the Excluded items list case insensitive'),
+    ];
+    $build['regex'] = [
+      '#title' => $this->t('Regular expressions used'),
+      '#type' => 'checkbox',
+      '#default_value' => $config['regex'],
+      '#description' => $this->t('Interpret each exclude list item as a regular expression pattern.<br /><small>(Slashes are escaped automatically, patterns using a comma can be wrapped in "double quotes", and if such a pattern uses double quotes itself, just make them double-double-quotes (""))</small>.'),
+    ];
+    $build['invert'] = [
+      '#title' => $this->t('Invert - only list matched items'),
+      '#type' => 'checkbox',
+      '#default_value' => $config['invert'],
+      '#description' => $this->t('Instead of excluding items based on the pattern specified above, only matching items will be displayed.'),
+    ];
+
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'exclude' => '',
+      'exclude_case_insensitive' => 0,
+      'regex' => 0,
+      'invert' => 0,
+    ];
+  }
+
+}

--- a/modules/format_strawberryfield_facets/src/Plugin/facets_summary/processor/LastActiveFacetsProcessor.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets_summary/processor/LastActiveFacetsProcessor.php
@@ -13,7 +13,7 @@ use Drupal\facets_summary\Processor\BuildProcessorInterface;
 use Drupal\facets_summary\Processor\ProcessorPluginBase;
 
 /**
- * Provides a processor that adds Date ranges as a facet summary.
+ * Empty Results and Search Query Facet Summary Processor.
  *
  * @SummaryProcessor(
  *   id = "sbf_last_active_facets",

--- a/modules/format_strawberryfield_facets/src/Plugin/facets_summary/processor/LastActiveFacetsProcessor.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets_summary/processor/LastActiveFacetsProcessor.php
@@ -125,7 +125,7 @@ class LastActiveFacetsProcessor extends ProcessorPluginBase implements BuildProc
       }
     }
 
-    if ($config['settings']['enable_query'] ?? FALSE && $results_query) {
+    if (($config['settings']['enable_query'] ?? FALSE) && $results_query) {
       // The original View
       /** @var \Drupal\views\ViewExecutable $view */
       $view = $results_query->getQuery()->getOptions()['search_api_view'];

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.module
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.module
@@ -240,7 +240,7 @@ function format_strawberryfield_views_search_api_solr_converted_query_alter(Sola
 /**
  * Implements hook_library_info_alter().
  */
-function  format_strawberryfield_views_library_info_alter(&$libraries, $extension) {
+function format_strawberryfield_views_library_info_alter(&$libraries, $extension) {
   if ($extension === 'facets' && isset($libraries['drupal.facets.views-ajax'])) {
 
       $libraries['drupal.facets.views-ajax']['version'] = '1.x';

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -566,6 +566,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
           = $this->options['expose']['searched_fields_id'];
       }
 
+
       // Remove the group operator if found
       unset($form[$searched_fields_identifier]);
       $multiple_exposed_fields = $this->options['expose']['multiple'] ?? FALSE ? min(count($fields), 5) : 1;


### PR DESCRIPTION
See #280 

This also includes

- Small update to the `format_strawberryfield.display_settings:` route to allow a pattern that is not based only on dynamic pieces and thus not interferes when trying to add Views as tabs
- Small fix for our Empty results facet summary processor (in case there is no query at all) + start of better config schemas