### PR TITLE
ISSUE-280b:Trimming was needed. But we want to preserve spaces at least

### DIFF
--- a/modules/format_strawberryfield_facets/src/Plugin/facets/processor/SbfExcludeSpecifiedItemsProcessor.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/processor/SbfExcludeSpecifiedItemsProcessor.php
@@ -41,20 +41,24 @@ class SbfExcludeSpecifiedItemsProcessor extends ProcessorPluginBase implements B
         }
       }
       else {
-        $exclude_items = explode("\n", $exclude_item);
-        foreach ($exclude_items as $item) {
+        $exclude_items = array_filter(explode(PHP_EOL, $exclude_item));
+        foreach ($exclude_items as $key => $item) {
+          // Why not an array_map? Bc we might want to preserve spaces.. facet values might have trailing spaces!
+          $item_trimmed = trim($item, "\n\r\t\v\x00");
           if ($config['exclude_case_insensitive']) {
-            if (strtolower($result->getRawValue()) == strtolower($item)
-              || strtolower($result->getDisplayValue()) == strtolower($item)
+            if (strtolower($result->getRawValue()) == strtolower($item_trimmed)
+              || strtolower($result->getDisplayValue()) == strtolower($item_trimmed)
             ) {
               $is_excluded = TRUE;
+              unset($exclude_items[$key]);
             }
           }
           else {
-            if ($result->getRawValue() == $item
-              || $result->getDisplayValue() == $item
+            if ($result->getRawValue() == $item_trimmed
+              || $result->getDisplayValue() == $item_trimmed
             ) {
               $is_excluded = TRUE;
+              unset($exclude_items[$key]);
             }
           }
         }


### PR DESCRIPTION
# What?

So, when you trim you also remove return carriages, tabs, etc. The explode on line break leaves \r which then won't match. This now trims modally only but also removes the already matched values from the list making this also, wait for it, FASTER! Means on each existing facet I only check for the excluded items that DID not match before. Good Diego

@alliomeria will update now. Sorry for the error/missunderstanding of the code 😵‍💫 
