### PR TITLE
ISSUE-283:Facet Summary Processor misbehavior on Date Range when it is the only Facet selected

### DIFF
--- a/modules/format_strawberryfield_facets/config/schema/format_strawberryfield_facets.schema.yml
+++ b/modules/format_strawberryfield_facets/config/schema/format_strawberryfield_facets.schema.yml
@@ -84,7 +84,7 @@ plugin.plugin_configuration.facets_summary_processor.sbf_last_active_facets:
       label: 'Enable Full text search terms as Facet Summary Entry'
     quote_query:
       type: boolean
-      label: 'If Fulll Text search terms will be surrounded by Double Quotes or not'
+      label: 'If Full Text search terms will be surrounded by Double Quotes or not'
     text:
       type: mapping
       mapping:

--- a/modules/format_strawberryfield_facets/config/schema/format_strawberryfield_facets.schema.yml
+++ b/modules/format_strawberryfield_facets/config/schema/format_strawberryfield_facets.schema.yml
@@ -15,6 +15,17 @@ facet.widget.config.sbf_date_range:
       type: integer
       label: 'Hide Reset when no selection'
 
+plugin.plugin_configuration.facets_processor.sbf_date_range:
+  type: mapping
+  label: 'Format Strawberryfield Date Range Picker'
+  mapping:
+    enabled:
+      type: integer
+      label: 'If enabled'
+    variable_granularity:
+      type: integer
+      label: 'If Variable granularity is going to be used'
+
 facet.widget.config.sbf_range_date_slider:
   type: facet.widget.default_config
   label: 'List of range widget configuration'
@@ -64,13 +75,16 @@ plugin.plugin_configuration.facets_summary_processor.sbf_last_active_facets:
   mapping:
     enable:
       type: integer
-      label: Enabled
+      label: 'Enabled'
     enable_empty_message:
       type: integer
-      label: Enable Empty Message
+      label: 'Enable Empty Message'
     enable_query:
       type: integer
-      label: Enable Full text search terms as Facet Summary Entry
+      label: 'Enable Full text search terms as Facet Summary Entry'
+    quote_query:
+      type: boolean
+      label: 'If Fulll Text search terms will be surrounded by Double Quotes or not'
     text:
       type: mapping
       mapping:

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeWidget.php
@@ -227,7 +227,7 @@ class DateRangeWidget extends WidgetPluginBase {
     ];
     $form += parent::buildConfigurationForm($form, $form_state, $facet);
 
-    $message = $this->t('The Format Strawberryfield Date Range Picker Widget requires you to check the facet setting below <em>"Format Strawberryfield Date Range Picker" and inside it check "enabled" it.</em>.');
+    $message = $this->t('The Format Strawberryfield Date Range Picker Widget requires you to check the facet setting below <em>"Format Strawberryfield Date Range Picker" and check "enabled" inside it.</em>.');
     $form['warning'] = [
       '#markup' => '<div class="messages messages--warning">' . $message . '</div>',
     ];

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeWidget.php
@@ -227,7 +227,7 @@ class DateRangeWidget extends WidgetPluginBase {
     ];
     $form += parent::buildConfigurationForm($form, $form_state, $facet);
 
-    $message = $this->t('To achieve the standard behavior of a Format Strawberryfield Date Range Picker, you need to enable the facet setting below <em>"Format Strawberryfield Date Range Picker"</em>.');
+    $message = $this->t('The Format Strawberryfield Date Range Picker Widget requires you to check the facet setting below <em>"Format Strawberryfield Date Range Picker" and inside it check "enabled" it.</em>.');
     $form['warning'] = [
       '#markup' => '<div class="messages messages--warning">' . $message . '</div>',
     ];


### PR DESCRIPTION
See #283 

This one was tricky. Gist: To generate a "unselect the current facet" you have to build all active facets except the one you want to unselect. When there are no ones (means the current, in this case our custom range) Facet Module suggests (copied the code) to use a HTTP REQUEST based parser method that gets confused when a single View (Facet Source) has multiple Displays (specially if those display are not 1:1).

The solution was not terrible.

Now that this is working I also made "quoting" the Full Text Search Terms Facet Summary (part of this pull)