### PR TITLE
ISSUE-287: Adds a new JOIN filter to allow Flavors to matching ADO unified search

### DIFF
--- a/modules/format_strawberryfield_views/format_strawberryfield_views.module
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.module
@@ -174,6 +174,18 @@ function format_strawberryfield_views_views_data_alter(array &$data) {
       if ($advanced_fulltext_field != 'sbf_advanced_search_api_fulltext') {
         $table[$advanced_fulltext_field]['real field'] = 'sbf_advanced_search_api_fulltext';
       }
+
+      $sbf_join_field = _search_api_views_find_field_alias('sbf_flavors_join', $table);
+      $table[$sbf_join_field] = [
+        'title'  => t('Strawberry Flavor to Node Join.'),
+        'group' => t('Search'),
+        'help' => t('Joins Strawberry Flavor Search API datasources (e.g OCR) to Nodes (ADO) when doing a Full Text Search.'),
+        'filter' => [
+          'title' => t('Strawberry Flavor to Node Join.'),
+          'field' => 'id',
+          'id'    => 'sbf_flavors_join',
+        ],
+      ];
       // @TODO add also an argument ID if relationships are enabled to
       // $table[$advanced_fulltext_field]['argument']['id'] = 'sbf_advanced_search_api_fulltext';
       // Requires a special Argument Plugin. Not needed right now.
@@ -187,28 +199,6 @@ function format_strawberryfield_views_views_data_alter(array &$data) {
   }
   return $data;
 }
-
-
-/**
- * Finds an unused field alias for a field in a Views table definition.
- *
- * @param string $field_id
- *   The original ID of the Search API field.
- * @param array $table
- *   The Views table definition.
- *
- * @return string
- *   The field alias to use.
- */
-function _format_strawberryfield_views_find_field_alias($field_id, array &$table) {
-  $base = $field_alias = preg_replace('/[^a-zA-Z0-9]+/S', '_', $field_id);
-  $i = 0;
-  while (isset($table[$field_alias])) {
-    $field_alias = $base . '_' . ++$i;
-  }
-  return $field_alias;
-}
-
 
 /**
  * Implements hook_search_api_solr_query_alter().
@@ -231,8 +221,33 @@ function format_strawberryfield_views_search_api_solr_converted_query_alter(Sola
   if ($query->getOption('sbf_advanced_search_filter')) {
     $components = $solarium_query->getComponents();
     if (isset($components['edismax'])) {
-      $solarium_query->removeComponent(ComponentAwareQueryInterface::COMPONENT_EDISMAX);
-      $solarium_query->addParam('defType','lucene');
+      $solarium_query->removeComponent(
+        ComponentAwareQueryInterface::COMPONENT_EDISMAX
+      );
+      $solarium_query->addParam('defType', 'lucene');
+    }
+  }
+  if ($query->getOption('sbf_join_flavor')) {
+    $options = $query->getOption('sbf_join_flavor');
+    if (is_array($options) &&
+      !empty($options['from']) &&
+      !empty($options['to']) &&
+      !empty($options['v'])) {
+      $subquery = $options['v'];
+      $options['v'] = '$subquery';
+      // $options['method'] = 'topLevelDV' or 'dvWithScore' This requires docvalues to be set on the joined fields
+      // This is desired because it will be faster
+      // Also adding $options['score'] = 'none' even faster.
+      // @TODO enable extra UUID type Solr field to be used as joined ones
+      $join = $solarium_query->getHelper()->qparser(
+        'join',
+        $options
+      );
+      $new_query_string = $solarium_query->getQuery() . ' OR ' . $join;
+      $solarium_query->setQuery($new_query_string);
+      $solarium_query->addParam(
+        'subquery', $subquery
+      );
     }
   }
 }

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -5,11 +5,7 @@ namespace Drupal\format_strawberryfield_views\Plugin\views\filter;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\StringTranslation\PluralTranslatableMarkup;
-use Drupal\search_api\Entity\Index;
-use Drupal\search_api\ParseMode\ParseModePluginManager;
 use Drupal\search_api_solr\Utility\Utility;
-use Drupal\views\Plugin\views\filter\FilterPluginBase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\search_api\Plugin\views\filter\SearchApiFilterTrait;
 use Drupal\search_api\Plugin\views\filter\SearchApiFulltext;
 
@@ -270,7 +266,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     // Humble attempt at doing this manually since we have multiple fields with varying operators.
     // A direct query won't work until we have the actual Solr Field names via \Drupal\search_api_solr\Plugin\search_api\backend\SearchApiSolrBackend::getQueryFulltextFields
     // See why https://www.drupal.org/project/search_api/issues/3049097
-    // If the backend is Solr we can do this, if not we default to either the basics (single query + filters) or just filtes
+    // If the backend is Solr we can do this, if not we default to either the basics (single query + filters) or just filters
     $backend = $query->getIndex()->getServerInstance()->getBackend();
     $index_fields = $query->getIndex()->getFields();
 

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/StrawberryFlavorsJoin.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/StrawberryFlavorsJoin.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace Drupal\format_strawberryfield_views\Plugin\views\filter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\search_api\Entity\Index;
+use Drupal\search_api\ParseMode\ParseModePluginManager;
+use Drupal\search_api\Plugin\views\filter\SearchApiFulltext;
+use Drupal\search_api\Plugin\views\query\SearchApiQuery;
+use Drupal\search_api_solr\Utility\Utility;
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+use \Drupal\search_api\Plugin\views\filter\SearchApiFilterTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Defines a filter for Joining Full Text searches to Strawberry Flavor Data Sources.
+ *
+ * @ingroup views_filter_handlers
+ *
+ * @ViewsFilter("sbf_flavors_join")
+ */
+class StrawberryFlavorsJoin extends FilterPluginBase {
+
+  use SearchApiFilterTrait;
+
+  /**
+   * The parse mode manager.
+   *
+   * @var \Drupal\search_api\ParseMode\ParseModePluginManager|null
+   */
+  protected $parseModeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    /** @var static $plugin */
+    $plugin = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+
+    $plugin->setParseModeManager($container->get('plugin.manager.search_api.parse_mode'));
+    return $plugin;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defineOptions() {
+    $options = parent::defineOptions();
+
+    $options['operator']['default'] = 'or';
+    $options['join_fields'] = ['default' => []];
+    $options['sbf_fields'] = ['default' => []];
+    $options['expose']['sbf_type'] = ['default' => []];
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultExposeOptions() {
+    parent::defaultExposeOptions();
+    $this->options['expose']['sbf_type'] = ['default' => []];
+  }
+
+  /**
+   * Retrieves the parse mode manager.
+   *
+   * @return \Drupal\search_api\ParseMode\ParseModePluginManager
+   *   The parse mode manager.
+   */
+  public function getParseModeManager() {
+    return $this->parseModeManager ?: \Drupal::service('plugin.manager.search_api.parse_mode');
+  }
+
+  /**
+   * Sets the parse mode manager.
+   *
+   * @param \Drupal\search_api\ParseMode\ParseModePluginManager $parse_mode_manager
+   *   The new parse mode manager.
+   *
+   * @return $this
+   */
+  public function setParseModeManager(ParseModePluginManager $parse_mode_manager) {
+    $this->parseModeManager = $parse_mode_manager;
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::buildOptionsForm($form, $form_state);
+    $fields = $this->getSbfFulltextFields() ?? [];
+    $join_fields = $this->getSbfNidFields() ?? [];
+    $form['sbf_fields'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Strawberry Flavor fields that need to match.'),
+      '#description' => $this->t('Select the fields that will be searched inside a Strawberry Flavor Document before Joining.'),
+      '#options' => $fields,
+      '#size' => min(4, count($fields)),
+      '#multiple' => TRUE,
+      '#default_value' => $this->options['sbf_fields'],
+      '#required' => TRUE,
+    ];
+    $form['join_fields'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Strawberry Flavor fields referencing a parent Node ID to be used for Joining.'),
+      '#description' => $this->t('Select the fields that reference Parent Nodes or ADOs to be used to Join the results.'),
+      '#options' => $join_fields,
+      '#size' => min(4, count($join_fields)),
+      '#multiple' => TRUE,
+      '#default_value' => $this->options['join_fields'],
+      '#required' => TRUE,
+    ];
+
+  }
+
+
+  public function query() {
+    $query = $this->getQuery();
+    $backend = $query->getIndex()->getServerInstance()->getBackend();
+    $full_text = NULL;
+    // We only know how to join on Solr. All rest is bad poetry
+    if ($backend instanceof \Drupal\search_api_solr\SolrBackendInterface) {
+      $index_fields = $query->getIndex()->getFields(TRUE);
+      /* @var \Drupal\views\Plugin\views\display\DisplayPluginBase[] $filters */
+      $filters = $this->view->getHandlers('filter', NULL);
+      $value = "";
+      foreach ($filters as $filter_name => $filter) {
+        if ($filter['plugin_id'] == 'search_api_fulltext') {
+          // Reuse the Full Text Field's parse mode
+          $parsemode = $filter['parse_mode'] ?? 'terms' ;
+          /** @var \Drupal\search_api\ParseMode\ParseModeInterface $parse_mode */
+          $parse_mode = $this->getParseModeManager()
+            ->createInstance($parsemode);
+
+          if (!$filter['exposed']) {
+            $op = $filter['operator'];
+          }
+          $full_text = $query->getKeys();
+        }
+        if ($this->options['id'] == $filter_name) {
+          // This is myself, break out.
+          break;
+        }
+      }
+      // If value == "" do nothing, no need to JOIN SBF for that.
+      if ($full_text && ((is_scalar($full_text) && strlen($full_text) > 0) || (is_array($full_text) && count($full_text) > 0 ))) {
+        $subquery = $this->buildFlavorSubQuery($query, $parse_mode, $this->options['sbf_fields'],$full_text);
+        if (strlen($subquery) > 0 ) {
+          $join_structure = [
+            'from' => 'its_parent_id',
+            'to'   => 'its_nid',
+            'v'    => $subquery
+          ];
+          $this->getQuery()->setOption('sbf_join_flavor', $join_structure);
+        }
+      }
+    }
+  }
+
+  /**
+   * @param \Drupal\search_api\Plugin\views\query\SearchApiQuery $query
+   *
+   * @throws \Drupal\search_api\SearchApiException
+   */
+  protected function buildFlavorSubQuery(SearchApiQuery $query, $parse_mode, array $queryable_fields, array|string $keys) {
+    $solr_field_names = $query->getIndex()
+      ->getServerInstance()
+      ->getBackend()
+      ->getSolrFieldNames($query->getIndex());
+    // Damn Solr Search API...
+
+    $index_fields = $query->getIndex()->getFields(TRUE);
+
+    $settings = Utility::getIndexSolrSettings($query->getIndex());
+    $language_ids = $query->getLanguages();
+    $flat_keys = [];
+    // If there are no languages set, we need to set them. As an example, a
+    // language might be set by a filter in a search view.
+    if (empty($language_ids)) {
+      if (!$query->getSearchApiQuery()->hasTag('views') && $settings['multilingual']['limit_to_content_language']) {
+        // Limit the language to the current language being used.
+        $language_ids[] = \Drupal::languageManager()
+          ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+          ->getId();
+      }
+      else {
+        // If the query is generated by views and/or the query isn't limited
+        // by any languages we have to search for all languages using their
+        // specific fields.
+        $language_ids = array_keys(\Drupal::languageManager()->getLanguages());
+      }
+    }
+
+    if ($settings['multilingual']['include_language_independent']) {
+      $language_ids[] = LanguageInterface::LANGCODE_NOT_SPECIFIED;
+    }
+
+    $field_names = $query->getIndex()
+      ->getServerInstance()
+      ->getBackend()->getSolrFieldNamesKeyedByLanguage($language_ids, $query->getIndex());
+
+    foreach (($queryable_fields ?? []) as $field) {
+      if (isset($solr_field_names[$field])
+        && 'twm_suggest' !== $solr_field_names[$field] & strpos(
+          $solr_field_names[$field], 'spellcheck'
+        ) !== 0
+      ) {
+        $index_field = $index_fields[$field];
+        $boost = $index_field->getBoost() ? '^' . $index_field->getBoost()
+          : '';
+        $names = [];
+        $first_name = reset($field_names[$field]);
+        if (strpos($first_name, 't') === 0) {
+          // Add all language-specific field names. This should work for
+          // non Drupal Solr Documents as well which contain only a single
+          // name.
+          $names = array_values($field_names[$field]);
+        }
+        else {
+          $names[] = $first_name;
+        }
+        $names = array_unique($names);
+        foreach ($names as &$name) {
+          $name = $name . $boost;
+        }
+      }
+    }
+
+    if (count($names)) {
+      $flat_keys[] = \Drupal\search_api_solr\Utility\Utility::flattenKeys(
+        $keys, $names,
+        $parse_mode->getPluginId()
+      );
+    }
+    return implode(" ", $flat_keys);
+  }
+  /**
+   * Retrieves a list of all available fulltext fields.
+   *
+   * @return string[]
+   *   An options list of fulltext field identifiers mapped to their prefixed
+   *   labels.
+   */
+  protected function getSbfFulltextFields() {
+    $fields = [];
+    /** @var \Drupal\search_api\IndexInterface $index */
+    $index = Index::load(substr($this->table, 17));
+
+    $fields_info = $index->getFields();
+    foreach ($index->getFulltextFields() as $field_id) {
+      if ($fields_info[$field_id]->getDatasourceId() == 'strawberryfield_flavor_datasource') {
+        $fields[$field_id] = $fields_info[$field_id]->getPrefixedLabel() . '('.  $fields_info[$field_id]->getFieldIdentifier() .')';
+      }
+    }
+
+    return $fields;
+  }
+
+
+  /**
+   * Retrieves a list of all available fulltext fields.
+   *
+   * @return string[]
+   *   An options list of fulltext field identifiers mapped to their prefixed
+   *   labels.
+   */
+  protected function getSbfNidFields() {
+    $fields = [];
+    /** @var \Drupal\search_api\IndexInterface $index */
+    $index = Index::load(substr($this->table, 17));
+
+    $fields_info = $index->getFields();
+    foreach ($fields_info as $field_id => $field) {
+      if (($field->getDatasourceId() == 'strawberryfield_flavor_datasource') && ($field->getType() == "integer")) {
+        $property_path = $field->getPropertyPath();
+        $property_path_parts = explode(":", $property_path);
+        if (end($property_path_parts) == "nid" || $property_path == 'parent_id') {
+          $fields[$field_id] = $field->getPrefixedLabel() . '('
+            . $field->getFieldIdentifier() . ')';
+        }
+      }
+    }
+    return $fields;
+  }
+
+}


### PR DESCRIPTION
This is WIP but works. Why WIP? The settings are not all the ones i need And also i want to expose (checkboxes) if this is enabled or not. It connects with/ Requires https://github.com/esmero/strawberryfield/pull/258 to enabled Highlight after the match was made

I could also work on improving this by 
- Exposing/Setting which Flavors to filter against (ONLY OCR?). For now we go for all which makes sense given that for one or another reason we are already indexing those right? (VTTs, XMLs, JSONs, HTML from webpages, you name it)
- Expose an ON/OFF switch/exposed filter on a view
- Making the Joined Solr fields able to `dvWithScore` or `topLevelDV` (last one allows millions to one) using `score=none` option to make joins even faster. This requires enabling other fields to be used to join ADOs and Flavors together (e.g the UUID instead of the ID which is `Int` using  `string`