### PR TITLE
ISSUE-290b: Remove op query parameter from the Browser state 

### DIFF
--- a/modules/format_strawberryfield_views/src/Controller/FormatStrawberryfieldViewAjaxController.php
+++ b/modules/format_strawberryfield_views/src/Controller/FormatStrawberryfieldViewAjaxController.php
@@ -189,10 +189,11 @@ class FormatStrawberryfieldViewAjaxController extends ViewAjaxController {
         // @see the redirect.destination service.
         $origin_destination = $path;
 
-        $used_query_parameters = $request->query->all();
+        $used_query_parameters = $request_all;
         $query = UrlHelper::buildQuery($used_query_parameters);
         if ($query != '') {
           $origin_destination .= '?' . $query;
+          unset($used_query_parameters['op']);
           $target_url->setOption('query', $used_query_parameters);
         }
         $this->redirectDestination->set($origin_destination);


### PR DESCRIPTION
Still part of #290 (sorry @alliomeria )

`op` is being kept in the Ajax/browser state (thing I used for having bookmarks) and bc ops is used to add fields/remove files and submitting, we are having conflicts when doing advanced search + this.

@alliomeria reason is "op" is basically a submit. You don't want to have a submit on the browser history bc it will clash with the actual submit and drupal is not smart enough to discern "data is coming from Ajax or GET", get will win