### PR TITLE
ISSUE-304 --- Use the correct variable name for the aggregated fields

### DIFF
--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -413,12 +413,12 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
         $parse_mode->getPluginId()
       );
 
-      // Generate the special Highlight query for the Advanced Highligther
-      if ($query_able_datum_internal['aggregated'] ?? FALSE) {
+      // Generate the special Highlight query for the Advanced Highlighter
+      if (!empty($query_able_datum_internal['aggregated']) && is_array($query_able_datum_internal['aggregated'])) {
         // These little babies are always OR bc it is a highlight.. no need to go
         // Boolean here folks.
         $flat_key_sbf_highlight[] = \Drupal\search_api_solr\Utility\Utility::flattenKeys(
-          $manual_keys, $query_able_datum_fields['aggregated'],
+          $manual_keys, $query_able_datum_internal['aggregated'],
           $parse_mode->getPluginId()
         );
       }


### PR DESCRIPTION
$query_able_data gets iterated twice, the first time with its members called $query_able_datum_fields, and the second time as $query_able_datum_internal. During the second round of iterations ($query_able_datum_internal), the $query_able_datum_fields variable was referenced, which may or may not be the same as the current $query_able_datum_internal variable. When it is the same, no problem. But when it's not, the $query_able_datum_fields['aggregated'] may not be an array.  This causes \Drupal\search_api_solr\Utility\Utility::flattenKeys to fatal error.

The fix is to change out $query_able_datum_fields['aggregated'] for $query_able_datum_internal['aggregated']. 

For good measure, I added in extra validity checking for $query_able_datum_internal['aggregated'], though I don't think it's strictly necessary.

To test, create advanced searches using multiple filters, sbf aggregated fulltext and content fulltext, with at least one content fulltext filter following an sbf aggregated fulltext filter. 