### PR TITLE
ISSUE-313: Save button on Metadata Display Preview on default theme is under Code Mirror

### DIFF
--- a/css/metadatapreview.css
+++ b/css/metadatapreview.css
@@ -1,0 +1,14 @@
+/* using row here allows us to not interfer with non Bootstrap themes */
+.path-metadatadisplay .row #metadata-preview-container {
+  position: sticky;
+  bottom: 0;
+  background: white;
+  z-index:200;
+}
+
+.path-metadatadisplay .row .form-actions {
+  position: sticky;
+  bottom: 0;
+  background: white;
+  z-index:200;
+}

--- a/css/metadatapreview.css
+++ b/css/metadatapreview.css
@@ -11,4 +11,6 @@
   bottom: 0;
   background: white;
   z-index:200;
+  padding-top: 1rem;
+  padding-top: 0.5rem;
 }

--- a/css/metadatapreview.css
+++ b/css/metadatapreview.css
@@ -3,7 +3,7 @@
   position: sticky;
   top: 0;
   background: white;
-  z-index:200;
+  z-index:100;
 }
 
 .path-metadatadisplay .row .form-actions {

--- a/css/metadatapreview.css
+++ b/css/metadatapreview.css
@@ -1,7 +1,7 @@
 /* using row here allows us to not interfer with non Bootstrap themes */
 .path-metadatadisplay .row #metadata-preview-container {
   position: sticky;
-  bottom: 0;
+  top: 0;
   background: white;
   z-index:200;
 }

--- a/css/metadatapreview.css
+++ b/css/metadatapreview.css
@@ -6,7 +6,7 @@
   z-index:100;
 }
 
-.path-metadatadisplay .row .form-actions {
+.path-metadatadisplay .row #edit-actions.form-actions {
   position: sticky;
   bottom: 0;
   background: white;

--- a/format_strawberryfield.libraries.yml
+++ b/format_strawberryfield.libraries.yml
@@ -390,6 +390,9 @@ code_mirror_autosave:
   version: 1.0
   js:
     js/code_mirror_autosave.js: { minified: false }
+  css:
+    component:
+      css/metadatapreview.css: { }
   dependencies:
     - core/jquery
     - core/drupal


### PR DESCRIPTION
See #313 
This also now makes the Preview button sticky/solves the overlay. Much easier for editing/previewing while you work @alliomeria @karomabiles !