### PR TITLE
ISSUE-323: Layout Builder uses a totally different Field UI render array

### DIFF
--- a/src/Plugin/Field/FieldFormatter/StrawberryDirectJsonFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryDirectJsonFormatter.php
@@ -62,16 +62,42 @@ abstract class StrawberryDirectJsonFormatter extends StrawberryBaseFormatter {
   public function settingsForm(array $form, FormStateInterface $form_state) {
 
     $form = parent::settingsForm($form, $form_state);
-    $current_field = array_keys($form_state->getValue('fields'));
-    $field_name = reset($current_field);
-    $realparents = [
-      'fields',
-      $field_name,
-      'settings_edit_form',
-      'settings',
-      'formatter',
-      'jmespath',
-    ];
+    $provider_settings = $form_state->getValue('settings', []);
+    // Deal with Layout Builder's structure/config form render array parents
+    if (isset($provider_settings['provider']) && $provider_settings['provider'] == 'layout_builder') {
+      $realparents = [
+        'settings',
+        'formatter',
+        'settings',
+        'jmespath',
+      ];
+    }
+    else {
+      // Deal with DS/Normal Display Mode Structure
+      $current_field = array_keys($form_state->getValue('fields', []));
+      $field_name = reset($current_field);
+      if ($field_name) {
+        $realparents = [
+          'fields',
+          $field_name,
+          'settings_edit_form',
+          'settings',
+          'formatter',
+          'jmespath',
+        ];
+      }
+      else {
+        // If for some never seen before reason we have no fields in form state
+        // default to same layour builder option just so we don't fail badly
+        // But ajax might not work. Also, this should never happen.
+        $realparents = [
+          'settings',
+          'formatter',
+          'settings',
+          'jmespath',
+        ];
+      }
+    }
     $jmespath_settings = $this->getSetting('jmespath');
     $form['jmespath']['use_jmespath'] = [
       '#type' => 'checkbox',


### PR DESCRIPTION
See #323

Basically the issue is when using formatters we have a form inside a form (multiple fields, each one with a formatter via fields_ui but layout builder moves this out to its own structure) breaking our expected #parents key needed for JMESPATH validation.

Also note: when upgrading to DS 3.15, disabling and re-enabling core Layout Builder, Layout Builder or DS can be used without having to disable DS totally. It requires some "playing around" but it actually works. Maybe something we want to offer for the release?