### PR TITLE
ISSUE-326: Advanced search community needs

### DIFF
--- a/modules/format_strawberryfield_facets/src/Plugin/facets_summary/processor/LastActiveFacetsProcessor.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets_summary/processor/LastActiveFacetsProcessor.php
@@ -133,7 +133,7 @@ class LastActiveFacetsProcessor extends ProcessorPluginBase implements BuildProc
         $exposed_input = $view->getExposedInput();
         $view->getRequest()->getRequestUri();
         $keys_to_filter = [];
-        $key_with_search_value = [] ;
+        $key_with_search_value = [];
         // Oh gosh, blocks...
         if (!$view->getDisplay()->isDefaultDisplay() && empty($view->getDisplay()->options['filters'] ?? [] )) {
           $filters = $view->getDisplay()->handlers['filter'];
@@ -147,9 +147,17 @@ class LastActiveFacetsProcessor extends ProcessorPluginBase implements BuildProc
             elseif ($filter->getPluginId() == 'sbf_advanced_search_api_fulltext'
               && $filter->isExposed()
             ) {
+              $current_count = 1;
+              if ($filter->options['expose']['identifier'] ?? NULL ) {
+                $field_count_field = $filter->options['expose']['identifier'] . '_advanced_search_fields_count';
+                $current_count = $exposed_input[$field_count_field] ?? ($filter->options['expose']['advanced_search_fields_count'] ?? 1);
+              }
               $extra_keys_to_filter = [];
-              $keys_to_filter[] =$filter->options['expose']['operator_id'] ?? NULL;
+              $keys_to_filter[] = $filter->options['expose']['operator_id'] ?? NULL;
               $keys_to_filter[] = $filter->options['expose']['identifier'] ?? NULL;
+              if ($filter->options['expose']['identifier'] ?? NULL ) {
+                $keys_to_filter[] = $filter->options['expose']['identifier'] . '_advanced_search_fields_count';
+              }
               $key_with_search_value[] = $filter->options['expose']['identifier'] ?? NULL;
               $keys_to_filter[] = $filter->options['expose']['searched_fields_id'] ?? NULL;
               $keys_to_filter[] = $filter->options['expose']['advanced_search_operator_id']
@@ -160,17 +168,20 @@ class LastActiveFacetsProcessor extends ProcessorPluginBase implements BuildProc
                   $i < $filter->options['expose']['advanced_search_fields_count'] ?? 1;
                   $i++
                 ) {
-
                   $extra_keys_to_filter[] = $key_to_filter . '_' . $i;
                   if (in_array($key_to_filter, $key_with_search_value)){
-                    $key_with_search_value[] = $key_to_filter . '_' . $i;
+                    if ($i < $current_count) {
+                      $key_with_search_value[] = $key_to_filter . '_' . $i;
+                    }
                   }
                 }
               }
-              $keys_to_filter = array_filter($keys_to_filter);
+
               $keys_to_filter = array_merge(
                 $keys_to_filter, $extra_keys_to_filter
               );
+              $keys_to_filter = array_unique($keys_to_filter);
+              $keys_to_filter = array_filter($keys_to_filter);
             }
           }
         }
@@ -187,9 +198,20 @@ class LastActiveFacetsProcessor extends ProcessorPluginBase implements BuildProc
             elseif ($filter['plugin_id'] == 'sbf_advanced_search_api_fulltext'
               && $filter['exposed']
             ) {
+              $current_count = 1;
+              if ($filter['expose']['identifier'] ?? NULL ) {
+                $field_count_field = $filter['expose']['identifier'] . '_advanced_search_fields_count';
+                $current_count = $exposed_input[$field_count_field] ?? ($filter['expose']['advanced_search_fields_count'] ?? 1);
+              }
+
               $extra_keys_to_filter = [];
               $keys_to_filter[] = $filter['expose']['operator_id'] ?? NULL;
               $keys_to_filter[] = $filter['expose']['identifier'] ?? NULL;
+              // fields count = $filter['expose']['identifier']
+              if ($filter['expose']['identifier'] ?? NULL ) {
+                $keys_to_filter[]
+                  = $filter['expose']['identifier'] . '_advanced_search_fields_count';
+              }
               $key_with_search_value[] = $filter['expose']['identifier'] ??
                 NULL;
               $keys_to_filter[] = $filter['expose']['searched_fields_id'] ??
@@ -203,17 +225,19 @@ class LastActiveFacetsProcessor extends ProcessorPluginBase implements BuildProc
                   $i < $filter['expose']['advanced_search_fields_count'] ?? 1;
                   $i++
                 ) {
-
                   $extra_keys_to_filter[] = $key_to_filter . '_' . $i;
                   if (in_array($key_to_filter, $key_with_search_value)) {
-                    $key_with_search_value[] = $key_to_filter . '_' . $i;
+                    if ($i < $current_count) {
+                      $key_with_search_value[] = $key_to_filter . '_' . $i;
+                    }
                   }
                 }
               }
-              $keys_to_filter = array_filter($keys_to_filter);
               $keys_to_filter = array_merge(
                 $keys_to_filter, $extra_keys_to_filter
               );
+              $keys_to_filter = array_unique($keys_to_filter);
+              $keys_to_filter = array_filter($keys_to_filter);
             }
           }
         }

--- a/modules/format_strawberryfield_views/css/advanced_search.css
+++ b/modules/format_strawberryfield_views/css/advanced_search.css
@@ -1,0 +1,7 @@
+.adv-search-delone {
+  margin-right: 0.275rem;
+}
+
+.adv-search-addone {
+  margin-right: 0.275rem;
+}

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.libraries.yml
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.libraries.yml
@@ -46,6 +46,9 @@ view-ajax-interactions:
 advanced-search-default-submit:
   js:
     js/sbf-advanced-search-default-submit.js: {minified: false}
+  css:
+    component:
+      css/advanced_search.css: { }
   dependencies:
     - core/drupal
     - core/jquery

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.libraries.yml
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.libraries.yml
@@ -42,3 +42,10 @@ view-ajax-interactions:
     - core/views
     - core/views.ajax
     - format_strawberryfield/iiif_formatstrawberryfield_utils
+
+advanced-search-default-submit:
+  js:
+    js/sbf-advanced-search-default-submit.js: {minified: false}
+  dependencies:
+    - core/drupal
+    - core/jquery

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.module
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.module
@@ -151,7 +151,7 @@ function format_strawberryfield_views_form_alter(&$form, FormStateInterface $for
       $form['actions']['submit']['#name'] = 'op';
     }
     foreach ($form as $key => $value) {
-      if (is_array($value) && isset ($value['#group']) && isset($value['#type']) && $value['#group'] == 'actions' && ($value['#type'] == 'submit' || $value['#type'] == 'button')) {
+      if (is_array($value) && isset ($value['#group']) && isset($value['#type']) && $value['#group'] == 'actions' && ($value['#type'] == 'submit' || $value['#type'] == 'button' || $value['#type'] == 'link')) {
         $form['actions'][$key] = $value;
         unset($form[$key]);
       }

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.module
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.module
@@ -146,6 +146,9 @@ function format_strawberryfield_views_form_alter(&$form, FormStateInterface $for
       $form['actions']['submit']['#attributes']['autofocus'] = '';
       $form['actions']['submit']['#attributes']['tabindex'] = 1;
       $form['actions']['submit']['#attributes']['data-default-submit'] = '';
+      // Needed when multiple buttons are on the same form, by default the name is empty
+      // making \Drupal\Core\Form\FormBuilder::buttonWasClicked fail!
+      $form['actions']['submit']['#name'] = 'op';
     }
     foreach ($form as $key => $value) {
       if (is_array($value) && isset ($value['#group']) && isset($value['#type']) && $value['#group'] == 'actions' && ($value['#type'] == 'submit' || $value['#type'] == 'button')) {

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.module
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.module
@@ -141,8 +141,14 @@ function format_strawberryfield_views_block_view_views_exposed_filter_block_sbf_
  */
 function format_strawberryfield_views_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if ($form_id == 'views_exposed_form') {
+    if (isset($form['actions']['submit'])) {
+      $form['actions']['#attached']['library'][] = 'format_strawberryfield_views/advanced-search-default-submit';
+      $form['actions']['submit']['#attributes']['autofocus'] = '';
+      $form['actions']['submit']['#attributes']['tabindex'] = 1;
+      $form['actions']['submit']['#attributes']['data-default-submit'] = '';
+    }
     foreach ($form as $key => $value) {
-      if (is_array($value) && isset ($value['#group']) && isset($value['#type']) && $value['#group'] == 'actions' && $value['#type'] == 'submit') {
+      if (is_array($value) && isset ($value['#group']) && isset($value['#type']) && $value['#group'] == 'actions' && ($value['#type'] == 'submit' || $value['#type'] == 'button')) {
         $form['actions'][$key] = $value;
         unset($form[$key]);
       }

--- a/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
+++ b/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
@@ -190,7 +190,6 @@
           }
         });
         if (reloadfacets) {
-          console.log('reloading!');
           Drupal.AjaxFacetsView.updateFacetsBlocks(href, options.extraData.view_name, options.extraData.view_display_id);
         }
       }
@@ -215,8 +214,6 @@
     if (ajax_views_call && view_name && view_display_id) {
       var exposed_form_selector = '#views-exposed-form-' + view_name.replace(/_/g, '-') + '-' + view_display_id.replace(/_/g, '-');
       var $exposed_form = $(exposed_form_selector).length;
-      console.log($exposed_form);
-      console.log(exposed_form_selector);
       if ($exposed_form > 0) {
         $exposed_form = 1;
       }
@@ -258,10 +255,7 @@
   };
 
   Drupal.AjaxCommands.prototype.SbfSetBrowserUrl = function (ajax, response) {
-    console.log(response.url);
     window.history.replaceState(null, '', response.url);
   }
-
-
 })(jQuery, Drupal, once, drupalSettings);
 

--- a/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
+++ b/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
@@ -1,0 +1,18 @@
+(function ($, Drupal) {
+  Drupal.behaviors.sbfAdvancedSearchViewsForm = {
+    attach(context) {
+      var formInterception = function(defaultSubmitInput, ev) {
+        if (ev.keyCode == 13) {
+          ev.preventDefault();
+          ev.stopPropagation();
+          defaultSubmitInput.click();
+        }
+      };
+      for (const defaultSubmitInput of document.querySelectorAll('.views-exposed-form [data-default-submit]')) {
+        for (const formInput of defaultSubmitInput.form.querySelectorAll('input')) {
+          formInput.addEventListener('keypress', formInterception.bind(null, defaultSubmitInput));
+        }
+      }
+    }
+  }
+})(jQuery, Drupal);

--- a/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
+++ b/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
@@ -8,9 +8,44 @@
           defaultSubmitInput.click();
         }
       };
+
+      var addMoreInterception = function(defaultSubmitInput, ev) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        const $form = defaultSubmitInput.closest('.views-exposed-form');
+        let $count =  $form.querySelector('input[name="sbf_advanced_search_api_fulltext_advanced_search_fields_count"]');
+        $count.value = Number($count.value) + 1;
+        defaultSubmitInput.click();
+      };
+
+      var delOneInterception = function(defaultSubmitInput, ev) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        if (typeof ev.target.dataset.advancedSearchPrefix !== 'undefined') {
+          const $name = ev.target.dataset.advancedSearchPrefix + '_advanced_search_fields_count';
+          const $form = defaultSubmitInput.closest('.views-exposed-form');
+          let $count = $form.querySelector('input[name="'+$name+'"]');
+          if ($count) {
+            $count.value = Number($count.value) - 1;
+            const $tounsetSelector = ev.target.dataset.advancedSearchPrefix + '_' + $count.value;
+            let $tounset = $form.querySelector('input[name="' + $tounsetSelector + '"]');
+            if ($tounset) {
+              $tounset.value = '';
+            }
+          }
+        }
+        defaultSubmitInput.click();
+      };
+
       for (const defaultSubmitInput of document.querySelectorAll('.views-exposed-form [data-default-submit]')) {
         for (const formInput of defaultSubmitInput.form.querySelectorAll('input')) {
           formInput.addEventListener('keypress', formInterception.bind(null, defaultSubmitInput));
+        }
+        for (const addMore of document.querySelectorAll('.views-exposed-form [data-advanced-search-addone]')) {
+          addMore.addEventListener('click', addMoreInterception.bind(null, defaultSubmitInput));
+        }
+        for (const delOne of document.querySelectorAll('.views-exposed-form [data-advanced-search-delone]')) {
+          delOne.addEventListener('click', delOneInterception.bind(null, defaultSubmitInput));
         }
       }
     }

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -544,8 +544,16 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
   }
 
   public function submitExposed(&$form, FormStateInterface $form_state) {
+    /*
     if ($form_state->getTriggeringElement()['#op'] ?? NULL == $this->options['id'] . '_addone') {
       $current_count = &$form_state->getValue($this->options['id'].'_advanced_search_fields_count',1);
+      $form_state->setRebuild(TRUE);
+    }
+    */
+    if (!$form_state->isValueEmpty('op') &&
+      ((($form_state->getTriggeringElement()['#op'] ?? NULL) == $this->options['id'] . '_addone') ||
+      (($form_state->getTriggeringElement()['#op'] ?? NULL) == $this->options['id'] . '_delone'))
+    ){
       $form_state->setRebuild(TRUE);
     }
     // OR HOW THE RESET BUTTON DOES IT
@@ -695,7 +703,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
         '#value' => $this->t('@label', [
           '@label' => $this->options['exposed']['advanced_search_fields_add_one_label'] ?? 'add one'
         ]),
-        '#name' => 'addone',
+        '#name' => 'op',
         '#access' => $enable_more,
         '#attributes' => ['data-disable-refocus' => "true", 'tabindex' => 2],
         '#executes_submit_callback' => TRUE,
@@ -706,7 +714,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
       'actions' key in a form alter */
       $form[$this->options['id'].'_delone'] = [
         '#type' => 'button',
-        '#name' => 'delone',
+        '#name' => 'op',
         '#op' => $this->options['id'] . '_delone',
         '#value' => $this->t('@label', [
           '@label' => $this->options['exposed']['advanced_search_fields_remove_one_label'] ?? 'remove one'
@@ -780,9 +788,10 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     $current_count = &$form_state->getValue(
       $this->options['id'] . '_advanced_search_fields_count', 1
     );
+    error_log(var_export($form_state->getUserInput(),true));
     if ((($triggering_element = $form_state->getTriggeringElement()['#op'] ??
           NULL) == $this->options['id'] . '_addone')
-      && ($form_state->getUserInput()['op'] ?? NULL == $this->options['expose']['advanced_search_fields_add_one_label'])
+      && (isset($form_state->getUserInput()['op']) && $form_state->getUserInput()['op'] == $form_state->getTriggeringElement()['#value'])
       && $this->options['expose']['advanced_search_fields_multiple']
     ) {
       $this->searchedFieldsCount = $this->searchedFieldsCount
@@ -794,7 +803,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     }
     elseif ((($triggering_element = $form_state->getTriggeringElement()['#op'] ??
           NULL) == $this->options['id'] . '_delone')
-      && ($form_state->getUserInput()['op'] ?? NULL == $this->options['expose']['advanced_search_fields_remove_one_label'])
+      && (isset($form_state->getUserInput()['op']) && $form_state->getUserInput()['op'] == $form_state->getTriggeringElement()['#value'])
       && $this->options['expose']['advanced_search_fields_multiple']
     ) {
       $this->searchedFieldsCount = $this->searchedFieldsCount

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -745,6 +745,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
             'adv-search-addone',
             'button',
             'btn',
+            'btn-secondary'
           ],
         ],
         '#access' => $enable_more,
@@ -765,6 +766,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
             'adv-search-delone',
             'button',
             'btn',
+            'btn-secondary'
           ],
         ],
         '#access' => $enable_less,

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -5,6 +5,7 @@ namespace Drupal\format_strawberryfield_views\Plugin\views\filter;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\StringTranslation\PluralTranslatableMarkup;
+use Drupal\Core\Url;
 use Drupal\search_api\Entity\Index;
 use Drupal\search_api\ParseMode\ParseModePluginManager;
 use Drupal\search_api_solr\Utility\Utility;
@@ -65,6 +66,8 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     $options['expose']['contains']['advanced_search_operator_id'] = ['default' => ''];
     $options['expose']['contains']['advanced_search_fields_add_one_label'] = ['default' => 'add one'];
     $options['expose']['contains']['advanced_search_fields_remove_one_label'] = ['default' => 'remove one'];
+    $options['advanced_search_fields_add_one_label'] = ['default' => ['add one']];
+    $options['advanced_search_fields_remove_one_label'] = ['default' => ['remove one']];
     return $options;
   }
 
@@ -75,8 +78,8 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     $this->options['expose']['advanced_search_fields_count'] = 2;
     $this->options['expose']['advanced_search_use_operator'] = FALSE;
     $this->options['expose']['advanced_search_operator_id'] = $this->options['id'] . '_group_operator';
-    $this->options['expose']['advanced_search_fields_add_one_label'] = 'add one';
-    $this->options['expose']['advanced_search_fields_remove_one_label'] = 'remove one';
+    $this->options['expose']['advanced_search_fields_add_one_label'] = $this->options['advanced_search_fields_add_one_label'];
+    $this->options['expose']['advanced_search_fields_remove_one_label'] = $this->options['advanced_search_fields_remove_one_label'];
   }
 
   /**
@@ -426,12 +429,13 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
 
       if ($j > 0) {
         if ($query_able_datum_internal['interfield_operator'] == 'and') {
-          $flat_key = ' && '.$flat_key;
+          $flat_key = ' && '. $flat_key;
         }
       }
       $flat_keys[] = $flat_key;
       $j++;
     }
+
     if (count($flat_keys)) {
       /** @var \Drupal\search_api\ParseMode\ParseModeInterface $parse_mode */
       $parse_mode_direct = $this->getParseModeManager()
@@ -545,22 +549,9 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
   }
 
   public function submitExposed(&$form, FormStateInterface $form_state) {
-
-    if (!$form_state->isValueEmpty('op') &&
-      ((($form_state->getTriggeringElement()['#op'] ?? NULL) == $this->options['id'] . '_addone') ||
-      (($form_state->getTriggeringElement()['#op'] ?? NULL) == $this->options['id'] . '_delone'))
-    ){
-      $form_state->setRebuild(TRUE);
-    }
-    elseif (!$form_state->isValueEmpty('op') && !empty($this->options['exposed'])) {
-      if ($form_state->getTriggeringElement()['#parents'] ?? NULL &&
-        isset($form_state->getTriggeringElement()['#parents'][0]) == 'reset') {
-          error_log('reset pressed');
-      }
-    }
-
     // OR HOW THE RESET BUTTON DOES IT
     //if (!$form_state->isValueEmpty('op') && $form_state->getValue('op') == $this->options['reset_button_label'])
+    $form_state->setRebuild();
     parent::submitExposed(
       $form, $form_state
     );
@@ -594,27 +585,8 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     // Value in our case needs to be multiple values (bc of the multiple options)
     if ($return && $realcount = $input[$this->options['expose']['identifier'].'_advanced_search_fields_count']) {
       $this->value = [];
-      // On add one/delete one (means not submit.. check if this will affect other exposed input? )
-      if (isset($input['op']) &&
-        isset($input['submit']) &&
-        $input['op'] != $input['submit'] &&
-        \Drupal::request()->hasSession() &&
-        $this->getQuery() &&
-        !$this->getQuery()->shouldAbort()) {
-        $session = \Drupal::request()->getSession();
-        $display_id = ($this->view->display_handler->isDefaulted('filters'))
-          ? 'default' : $this->view->current_display;
-        $adv_search_session = $session->get('sbf_advanced_search_views', []);
-        if (isset($adv_search_session[$this->view->storage->id()][$display_id])) {
-          $input = $adv_search_session[$this->view->storage->id()][$display_id];
-          // $realcount needs to be the last one submitted/stored in the session.
-          $realcount = $input[$this->options['expose']['identifier']
-          . '_advanced_search_fields_count'];
-        }
-      }
-
       $this->value[$this->options['expose']['identifier']] = $input[$this->options['expose']['identifier']];
-      for($i=1;$i < $realcount && $realcount > 1; $i++) {
+      for($i=1; $i < $realcount && $realcount > 1; $i++) {
         if (!empty($this->options['expose']['use_operator']) && !empty($this->options['expose']['operator_id']) && isset($input[$this->options['expose']['operator_id'].'_'.$i])) {
           $this->operatorAdv[$this->options['expose']['identifier'] . '_' . $i] = $input[$this->options['expose']['operator_id'].'_'.$i];
         }
@@ -655,7 +627,6 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
           = $this->options['expose']['searched_fields_id'];
       }
 
-
       // Remove the group operator if found
       unset($form[$searched_fields_identifier]);
       $multiple_exposed_fields = $this->options['expose']['multiple'] ?? FALSE ? min(count($fields), 5) : 1;
@@ -680,7 +651,6 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     $advanced_search_operator_id = $this->options['id'] . '_group_operator';
     // And our own settings.
     if (!empty($this->options['expose']['advanced_search_use_operator']) && !empty($this->options['expose']['advanced_search_operator_id'])) {
-
       if (!empty($this->options['expose']['advanced_search_operator_id'])) {
         $advanced_search_operator_id = $this->options['expose']['advanced_search_operator_id'];
       }
@@ -705,44 +675,53 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     // Yes over complicated but so far the only way i found to keep the state
     // Of this value between calls/rebuilds and searches.
     // @TODO move this into Accept input. That is easier?
-    $nextcount = (int) ($form_state->getUserInput()['sbf_advanced_search_api_fulltext_advanced_search_fields_count'] ?? 1);
-    $prevcount = $this->view->exposed_raw_input[$this->options['id'].'_advanced_search_fields_count'] ?? NULL;
-    $form_state_count = $form_state->getValue('sbf_advanced_search_api_fulltext_advanced_search_fields_count', NULL);
+    $nextcount = (int) ($form_state->getUserInput()[$this->options['id'] . '_advanced_search_fields_count'] ?? 1);
+    //$prevcount = $this->view->exposed_raw_input[$this->options['id'].'_advanced_search_fields_count'] ?? NULL;
+    $form_state_count = $form_state->getValue($this->options['id'] . '_advanced_search_fields_count', NULL);
 
-    $realcount = $prevcount ?? ($form_state_count ?? $nextcount);
+    // $realcount = $prevcount ?? ($form_state_count ?? $nextcount);
+    $realcount = $form_state_count ?? $nextcount;
     // Cap it to the max limit
     $realcount = ($realcount <= $this->options['expose']['advanced_search_fields_count']) ? $realcount : $this->options['expose']['advanced_search_fields_count'];
     // Only enable if setup and the realcount is less than the max.
     $enable_more = $realcount < $this->options['expose']['advanced_search_fields_count'] && $this->options['expose']['advanced_search_fields_multiple'];
     $enable_less = $realcount > 1;
-    // This fails on Preview (because of competing Ajax and replace calls)
-    // @TODO Re-test without the IF bc of Sunday refactor that should have fixed it?
 
     if (empty($this->view->live_preview)) {
       $form[$this->options['id'].'_addone'] = [
-        '#type' => 'button',
-        '#op' => $this->options['id'] . '_addone',
-        '#value' => $this->t('@label', [
-          '@label' => $this->options['exposed']['advanced_search_fields_add_one_label'] ?? 'add one'
-        ]),
-        '#name' => 'op',
+        '#type' => 'link',
+        '#title' => t($this->options['expose']['advanced_search_fields_add_one_label'] ?? 'add one'),
+        '#url' => Url::fromRoute('<current>'),
+        '#attributes' => [
+          'data-disable-refocus' => "true",
+          'data-advanced-search-addone' => "true",
+          'data-advanced-search-prefix' => $this->options['id'],
+          'tabindex' => 2,
+          'class' => [
+            'adv-search-addone',
+            'button',
+            'btn',
+          ],
+        ],
         '#access' => $enable_more,
-        '#attributes' => ['data-disable-refocus' => "true", 'tabindex' => 2],
-        '#executes_submit_callback' => TRUE,
         '#weight' => '-100',
         '#group' => 'actions',
       ];
-      /* Note: #group does not work for buttons but we use this to bring them into
-      'actions' key in a form alter */
       $form[$this->options['id'].'_delone'] = [
-        '#type' => 'button',
-        '#name' => 'op',
-        '#op' => $this->options['id'] . '_delone',
-        '#value' => $this->t('@label', [
-          '@label' => $this->options['exposed']['advanced_search_fields_remove_one_label'] ?? 'remove one'
-        ]),
-        '#executes_submit_callback' => TRUE,
-        '#attributes' => ['data-disable-refocus' => "true", 'tabindex' => 3],
+        '#type' => 'link',
+        '#title' => t($this->options['expose']['advanced_search_fields_remove_one_label'] ?? 'delete one'),
+        '#url' => Url::fromRoute('<current>'),
+        '#attributes' => [
+          'data-disable-refocus' => "true",
+          'data-advanced-search-delone' => "true",
+          'data-advanced-search-prefix' => $this->options['id'],
+          'tabindex' => 3,
+          'class' => [
+            'adv-search-delone',
+            'button',
+            'btn',
+          ],
+        ],
         '#access' => $enable_less,
         '#weight' => '-101',
         '#group' => 'actions',
@@ -810,36 +789,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     $current_count = &$form_state->getValue(
       $this->options['id'] . '_advanced_search_fields_count', 1
     );
-    if ((($triggering_element = $form_state->getTriggeringElement()['#op'] ??
-          NULL) == $this->options['id'] . '_addone')
-      && (isset($form_state->getUserInput()['op']) && $form_state->getUserInput()['op'] == $form_state->getTriggeringElement()['#value'])
-      && $this->options['expose']['advanced_search_fields_multiple']
-    ) {
-      $this->searchedFieldsCount = $this->searchedFieldsCount
-      < ($this->options['expose']['advanced_search_fields_count'] ?? 1)
-        ? $this->searchedFieldsCount++
-        : ($this->options['expose']['advanced_search_fields_count'] ?? 1);
-      // Check if the state was set already
-      $current_count++;
-      if (!empty($this->options['expose']['required']) && $this->getQuery()) {
-
-      }
-    }
-    elseif ((($triggering_element = $form_state->getTriggeringElement()['#op'] ??
-          NULL) == $this->options['id'] . '_delone')
-      && (isset($form_state->getUserInput()['op']) && $form_state->getUserInput()['op'] == $form_state->getTriggeringElement()['#value'])
-      && $this->options['expose']['advanced_search_fields_multiple']
-    ) {
-      $this->searchedFieldsCount = $this->searchedFieldsCount
-      > ($this->options['expose']['advanced_search_fields_count'] ?? 1)
-        ? $this->searchedFieldsCount--
-        : ($this->options['expose']['advanced_search_fields_count'] ?? 1);
-      // Check if the state was set already
-      $current_count--;
-      if (!empty($this->options['expose']['required']) && $this->getQuery()) {
-
-      }
-    }
+    $this->searchedFieldsCount = $current_count;
 
     if ($this->options['expose']['advanced_search_fields_multiple']) {
       for ($i = 1; $i < $current_count; $i++) {
@@ -856,11 +806,31 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
       }
     }
 
-    $identifiers[] = $this->options['expose']['identifier'];
-    for ($i = 1; $i < $current_count; $i++) {
-      $identifiers[] = $this->options['expose']['identifier'] . '_' . $i;
+    $identifiers[] = $identifiers_to_keep[] = $this->options['expose']['identifier'];
+
+    for ($i = 1; $i < $this->options['expose']['advanced_search_fields_count']; $i++) {
+      if ($i < $current_count) {
+        $identifiers_to_keep[] = $this->options['expose']['identifier'] . '_'
+          . $i;
+      }
+      $identifiers[] = $this->options['expose']['identifier'] . '_'
+        . $i;
     }
-    foreach ($identifiers as $identifier) {
+
+    foreach ($identifiers as $index => $identifier) {
+      if (!in_array($identifier, $identifiers_to_keep)) {
+        $form_state->unsetValue($identifier);
+        $form_state->unsetValue($index > 0 ? $searched_fields_identifier . '_' . $index : $searched_fields_identifier);
+        $form_state->unsetValue($index > 0 ? $advanced_search_operator_id . '_' . $index : $advanced_search_operator_id);
+        $userInput = $form_state->getUserInput();
+        unset($userInput[$identifier]);
+        unset($userInput[$index > 0 ? $searched_fields_identifier . '_' . $index : $searched_fields_identifier]);
+        unset($userInput[$index > 0 ? $advanced_search_operator_id . '_' . $index : $advanced_search_operator_id]);
+        $form_state->setUserInput($userInput);
+      }
+    }
+
+    foreach ($identifiers_to_keep as $index => $identifier) {
       $input = &$form_state->getValue($identifier, '');
       /// @TODO Add all inputs here...
       ///
@@ -869,7 +839,8 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
       ) {
         $this->operator
           = $this->options['group_info']['group_items'][$input]['operator'];
-        $input = &$this->options['group_info']['group_items'][$input]['value'];
+        $input
+          = &$this->options['group_info']['group_items'][$input]['value'];
       }
 
       // Under some circumstances, input will be an array containing the string
@@ -881,7 +852,9 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
         // No input was given by the user. If the filter was set to "required" and
         // there is a query (not the case when an exposed filter block is
         // displayed stand-alone), abort it.
-        if (!empty($this->options['expose']['required']) && $this->getQuery()) {
+        if (!empty($this->options['expose']['required'])
+          && $this->getQuery()
+        ) {
           $this->getQuery()->abort();
         }
         // If the input is empty, there is nothing to validate: return early.
@@ -920,33 +893,6 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     parent::prepareFilterSelectOptions(
       $options
     ); // TODO: Change the autogenerated stub
-  }
-
-  public function storeExposedInput($input, $status) {
-    $return = parent::storeExposedInput(
-      $input, $status
-    );
-    // In case of a proper submit (not addone/delone) we store all input in the session.
-    // This will be retrieved instead of the actual "form state/input submit on addone/delone
-    // So a previous search can be "replicated" and allowing added new fields to not be submited
-    // to the Views until the user decides so.
-    // @TODO make this an option, not the default (i like autosubmit).
-    if (!empty($this->options['exposed']) && isset($input['op']) && isset($input['submit']) && $input['op'] == $input['submit']) {
-      if (\Drupal::request()->hasSession() && $this->getQuery() && !$this->getQuery()->shouldAbort()) {
-        $session = \Drupal::request()->getSession();
-        $display_id = ($this->view->display_handler->isDefaulted('filters'))
-          ? 'default' : $this->view->current_display;
-        $adv_search_session = $session->get('sbf_advanced_search_views', []);
-        $exclude = ['submit', 'form_build_id', 'form_id', 'form_token', 'exposed_form_plugin', 'reset'];
-        foreach( $exclude as $key) {
-          unset($input[$key]);
-        }
-        $adv_search_session[$this->view->storage->id()][$display_id] = $input;
-        $session->set('sbf_advanced_search_views', $adv_search_session);
-      }
-    }
-
-    return $return;
   }
 
 

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -588,9 +588,16 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
   }
 
   public function submitExposed(&$form, FormStateInterface $form_state) {
-    // OR HOW THE RESET BUTTON DOES IT
-    //if (!$form_state->isValueEmpty('op') && $form_state->getValue('op') == $this->options['reset_button_label'])
-    $form_state->setRebuild();
+    if (!$form_state->isValueEmpty('op') &&
+      !empty($this->options['exposed']) &&
+      $form_state->getTriggeringElement()['#parents'] ?? NULL &&
+      ($form_state->getTriggeringElement()['#parents'][0] ?? NULL) == 'reset') {
+      $form_state->setRebuild(FALSE);
+    }
+    elseif (!$form_state->isValueEmpty('op') &&
+      !empty($this->options['exposed'])) {
+      $form_state->setRebuild(TRUE);
+    }
     parent::submitExposed(
       $form, $form_state
     );
@@ -954,7 +961,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
         }
       }
     }
-  return $options;
+    return $options;
   }
 
 

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -690,23 +690,29 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
 
     if (empty($this->view->live_preview)) {
       $form[$this->options['id'].'_addone'] = [
-        '#type' => 'submit',
+        '#type' => 'button',
         '#op' => $this->options['id'] . '_addone',
         '#value' => $this->t('@label', [
           '@label' => $this->options['exposed']['advanced_search_fields_add_one_label'] ?? 'add one'
         ]),
+        '#name' => 'addone',
         '#access' => $enable_more,
+        '#attributes' => ['data-disable-refocus' => "true", 'tabindex' => 2],
+        '#executes_submit_callback' => TRUE,
         '#weight' => '-100',
         '#group' => 'actions',
       ];
       /* Note: #group does not work for buttons but we use this to bring them into
       'actions' key in a form alter */
       $form[$this->options['id'].'_delone'] = [
-        '#type' => 'submit',
+        '#type' => 'button',
+        '#name' => 'delone',
         '#op' => $this->options['id'] . '_delone',
         '#value' => $this->t('@label', [
           '@label' => $this->options['exposed']['advanced_search_fields_remove_one_label'] ?? 'remove one'
         ]),
+        '#executes_submit_callback' => TRUE,
+        '#attributes' => ['data-disable-refocus' => "true", 'tabindex' => 3],
         '#access' => $enable_less,
         '#weight' => '-101',
         '#group' => 'actions',

--- a/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
@@ -388,7 +388,6 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
     array $form,
     FormStateInterface $form_state
   ) {
-    error_log('changeSceneCallBack called');
     $button = $form_state->getTriggeringElement();
     $element = NestedArray::getValue(
       $form,


### PR DESCRIPTION
See #326 

First one:
Submit on enter (not add one/remove one on Enter)

So much code for such a simple thing @alliomeria . Stuff is: Browsers will always pick the first submit found, so rendering order leads. If i put search first then other stuff like adding a + button by each one will still fail (future needs). Also Drupal will make all  buttons input type=submit (if we want to pass stuff via form state) so i have to alter the form, intercept the Enter and trigger the only and only one (staring at the moon) button i care for (i care of other things, like plants and some people and trees and moonshine)

Second: no more stuck keywords on remove one, add one. I changed the whole logic, drupal is so buggy. Now Add more/remove one act on pure JS, change values and then autosubmit (via drupal). Which in theory means in the near future I can have add more/remove without any submits at all.. (not today). Also no more ghost "previous" values appearing

Third: Fields to be searched can have their Labels rewritten (don't like Rendered HTML? you can name them `Pikachu field` and done

Fourth: You can define a min of initial fields. Don't like a single one? Start with 2!

Need to show you this so you can find more bugs tomorrow, but I feel release is ready to roll if all goes well/passes your checks