### PR TITLE
ISSUE-331: Removing autofocus on Views Exposed form Submit buttons

### DIFF
--- a/modules/format_strawberryfield_views/format_strawberryfield_views.module
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.module
@@ -143,7 +143,6 @@ function format_strawberryfield_views_form_alter(&$form, FormStateInterface $for
   if ($form_id == 'views_exposed_form') {
     if (isset($form['actions']['submit'])) {
       $form['actions']['#attached']['library'][] = 'format_strawberryfield_views/advanced-search-default-submit';
-      $form['actions']['submit']['#attributes']['autofocus'] = '';
       $form['actions']['submit']['#attributes']['tabindex'] = 1;
       $form['actions']['submit']['#attributes']['data-default-submit'] = '';
       // Needed when multiple buttons are on the same form, by default the name is empty


### PR DESCRIPTION
Gosh
See #331 

The autofocus on every page on the submit button is annoying. Functional OK. But theme wise something a theme can do outside of our code. Removing.