### PR TITLE
ISSUE-334: Provide a manual Content-Type for the plain Binary Controller

### DIFF
--- a/modules/format_strawberryfield_facets/src/Plugin/facets_summary/processor/LastActiveFacetsProcessor.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets_summary/processor/LastActiveFacetsProcessor.php
@@ -17,8 +17,8 @@ use Drupal\facets_summary\Processor\ProcessorPluginBase;
  *
  * @SummaryProcessor(
  *   id = "sbf_last_active_facets",
- *   label = @Translation("Adds Option to remove selected facets when there are no results at all"),
- *   description = @Translation("When checked and no resilts, this facet will add a summary of previously selected facets."),
+ *   label = @Translation("Adds Option to remove selected facets when there are no results at all."),
+ *   description = @Translation("When checked and no results, a summary of previously selected facets will be calculated from the request."),
  *   stages = {
  *     "build" = 60
  *   }

--- a/src/Controller/IiifBinaryController.php
+++ b/src/Controller/IiifBinaryController.php
@@ -240,6 +240,7 @@ class IiifBinaryController extends ControllerBase {
         }
 
         $response->setETag($etag, TRUE);
+        $response->headers->set("Content-Type", $mime);
         $response->prepare($request);
         $response->setContentDisposition(
           ResponseHeaderBag::DISPOSITION_INLINE,


### PR DESCRIPTION
# What?

See #334. Symfony provides its own implementation inside the `::prepare` option but it is limited to a smaller/different/subset of mime types and will not work for model/obj etc leading to text. Better to use the already calculated one like we do in the ranged controller section/streamed controller section already. Tested and this does not affect any other implementation and plays well with AMI too


This also solves #333 (since I was here)