### PR TITLE
ISSUE-334b: Add exceptions for past wrongly provided mime types by remote sources

### DIFF
--- a/src/Controller/IiifBinaryController.php
+++ b/src/Controller/IiifBinaryController.php
@@ -137,7 +137,19 @@ class IiifBinaryController extends ControllerBase {
       $uri = $found->getFileUri(); // The source URL
       $filename = $found->getFilename(); // The filename...
 
-      $mime = $found->getMimeType(); // We may want the actual mime from metadata?
+      $mime = $found->getMimeType(); // We may want the actual mime from metadata? Not really.
+
+      // For weirdly migrated/pre 1.1.1 mimetypes we remap a few here
+      if ($mime == 'image/jpg') {
+        $mime = 'image/jpeg';
+      }
+      if ($mime == 'image/tif') {
+        $mime = 'image/tiff';
+      }
+      if ($mime == "audio/vnd.wave") {
+        $mime = "audio/x-wave";
+      }
+
       // Let's check!
       // Note: we are not touching the metadata here.
       $etag = md5($found->uuid());


### PR DESCRIPTION
See #334 and https://github.com/esmero/ami/issues/173

What? Work around. If we ended migrating Files from badly setup Fedoras/Islandora we can at least at the last minute provide canonical Mime Types. I can not update Files here. We can build then an update hook for files in 1.2.0, if needed, that does this.