### PR TITLE
ISSUE-343: Metadata Preview error display

### DIFF
--- a/src/Form/MetadataDisplayForm.php
+++ b/src/Form/MetadataDisplayForm.php
@@ -234,26 +234,24 @@ class MetadataDisplayForm extends ContentEntityForm {
   }
 
   /**
-   * Takes an output array and an error message and returns
-   * the output with a status message container at the top.
+   * Takes an error message and returns
+   * the status message container.
    */
-  public static function buildAjaxPreviewError(array $output, string $message) {
-    if(!empty($message)) {
-      $output['preview_error'] = [
-        '#type' => 'container',
-        '#weight' => -1000,
-        '#theme' => 'status_messages',
-        '#message_list' => [
-          'error' => [
-            t($message),
-          ],
+  public static function buildAjaxPreviewError(string $message) {
+    $preview_error = [
+      '#type' => 'container',
+      '#weight' => -1000,
+      '#theme' => 'status_messages',
+      '#message_list' => [
+        'error' => [
+          t($message),
         ],
-        '#status_headings' => [
-          'error' => t('Error message'),
-        ],
-      ];
-    }
-    return $output;
+      ],
+      '#status_headings' => [
+        'error' => t('Error message'),
+      ],
+    ];
+    return $preview_error;
   }
 
   /**
@@ -417,7 +415,11 @@ class MetadataDisplayForm extends ContentEntityForm {
             ],
           ];
         }
-	$output = static::buildAjaxPreviewError($output, $message);
+        if(!empty($message)) {
+	  $preview_error = static::buildAjaxPreviewError($message);
+	  $output['preview_error'] = $preview_error;
+
+	}
       } catch (\Exception $exception) {
         // Make the Message easier to read for the end user
         if ($exception instanceof TwigError) {
@@ -426,7 +428,11 @@ class MetadataDisplayForm extends ContentEntityForm {
         else {
           $message = $exception->getMessage();
         }
-	$output = static::buildAjaxPreviewError($output, $message);
+        if(!empty($message)) {
+	  $preview_error = static::buildAjaxPreviewError($message);
+	  $output['preview_error'] = $preview_error;
+
+	}
       }
       $response->addCommand(new OpenOffCanvasDialogCommand(t('Preview'), $output, ['width' => '50%']));
     }

--- a/src/Form/MetadataDisplayForm.php
+++ b/src/Form/MetadataDisplayForm.php
@@ -234,6 +234,29 @@ class MetadataDisplayForm extends ContentEntityForm {
   }
 
   /**
+   * Takes an output array and an error message and returns
+   * the output with a status message container at the top.
+   */
+  public static function buildAjaxPreviewError(array $output, string $message) {
+    if(!empty($message)) {
+      $output['preview_error'] = [
+        '#type' => 'container',
+        '#weight' => -1000,
+        '#theme' => 'status_messages',
+        '#message_list' => [
+          'error' => [
+            t($message),
+          ],
+        ],
+        '#status_headings' => [
+          'error' => t('Error message'),
+        ],
+      ];
+    }
+    return $output;
+  }
+
+  /**
    * AJAX callback.
    */
   public static function ajaxPreview($form, FormStateInterface $form_state) {
@@ -389,17 +412,12 @@ class MetadataDisplayForm extends ContentEntityForm {
             '#type' => 'details',
             '#open' => TRUE,
             '#title' => 'HTML Output',
-            'messages' => [
-              '#markup' => $message,
-              '#attributes' => [
-                'class' => ['error'],
-              ],
-            ],
             'render' => [
                 '#markup' => $render,
             ],
           ];
         }
+	$output = static::buildAjaxPreviewError($output, $message);
       } catch (\Exception $exception) {
         // Make the Message easier to read for the end user
         if ($exception instanceof TwigError) {
@@ -408,15 +426,7 @@ class MetadataDisplayForm extends ContentEntityForm {
         else {
           $message = $exception->getMessage();
         }
-
-        $output['preview'] = [
-          '#type' => 'details',
-          '#open' => TRUE,
-          '#title' => t('Syntax error'),
-          'error' => [
-            '#markup' => $message,
-          ]
-        ];
+	$output = static::buildAjaxPreviewError($output, $message);
       }
       $response->addCommand(new OpenOffCanvasDialogCommand(t('Preview'), $output, ['width' => '50%']));
     }

--- a/src/Form/MetadataDisplayForm.php
+++ b/src/Form/MetadataDisplayForm.php
@@ -236,6 +236,9 @@ class MetadataDisplayForm extends ContentEntityForm {
   /**
    * Takes an error message and returns
    * the status message container.
+   *
+   * @param string $message
+   *   The error message to display to the user.
    */
   public static function buildAjaxPreviewError(string $message) {
     $preview_error = [


### PR DESCRIPTION
Resolves #343. Adds a static function that inserts a container with an error status at the top of the Metadata Preview modal if there is an error message and replaces the error messages that were being displayed in the details tabs.