### PR TITLE
ISSUE-345: left over SBF Ajax interactions when enabling Ajax, then enabling interactions, then disabling Ajax again

### DIFF
--- a/modules/format_strawberryfield_views/src/Controller/FormatStrawberryfieldViewAjaxController.php
+++ b/modules/format_strawberryfield_views/src/Controller/FormatStrawberryfieldViewAjaxController.php
@@ -135,6 +135,7 @@ class FormatStrawberryfieldViewAjaxController extends ViewAjaxController {
       }, $args);
 
       $path = $request->request->get('view_path');
+      // If a view has an invalid Path (e.g you added some % somewhere) this will be null.
       $target_url = $this->pathValidator->getUrlIfValid($path);
       $dom_id = $request->request->get('view_dom_id');
       $dom_id = isset($dom_id) ? preg_replace('/[^a-zA-Z0-9_-]+/', '-', $dom_id) : NULL;
@@ -229,7 +230,9 @@ class FormatStrawberryfieldViewAjaxController extends ViewAjaxController {
         if ($query != '') {
           $origin_destination .= '?' . $query;
           unset($used_query_parameters['op']);
-          $target_url->setOption('query', $used_query_parameters);
+          if ($target_url) {
+            $target_url->setOption('query', $used_query_parameters);
+          }
         }
         $this->redirectDestination->set($origin_destination);
 
@@ -254,7 +257,9 @@ class FormatStrawberryfieldViewAjaxController extends ViewAjaxController {
         $response->addCommand(new ReplaceCommand(".js-view-dom-id-$dom_id", $preview));
         //@TODO revisit in Drupal 10
         //@See https://www.drupal.org/project/drupal/issues/343535
-        $response->addCommand(new SbfSetBrowserUrl($target_url->toString()));
+        if ($target_url) {
+          $response->addCommand(new SbfSetBrowserUrl($target_url->toString()));
+        }
 
         // Views with ajax enabled aren't refreshing filters placed in blocks.
         // Only <div> containing view is refreshed. ReplaceCommand is fixing

--- a/modules/format_strawberryfield_views/src/Plugin/views/display_extender/StrawberryAjaxInteractions.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/display_extender/StrawberryAjaxInteractions.php
@@ -27,29 +27,33 @@ class StrawberryAjaxInteractions extends DisplayExtenderPluginBase {
       $form['sbf_ajax_interactions'] = [
         '#title'         => $this->t('Strawberryfield ADO to ADO Interactions'),
         '#type'          => 'checkbox',
-        '#description'   => $this->t('Allow this View to get Exposed and Contextual filter values from other Strawberryfield formatters'),
+        '#description'   => $this->t('Allow this view to get Contextual filter values from other Strawberryfield formatters'),
         '#default_value' => isset($this->options['sbf_ajax_interactions'])
           ? $this->options['sbf_ajax_interactions'] : 0,
         '#states'        => [
-          'visible' => [
+          'enabled' => [
             ':input[name="use_ajax"]' => ['checked' => TRUE],
           ],
         ],
       ];
-      $arguments = $this->displayHandler->getOption('arguments');
-      $all_exposed_arguments = array_combine(array_keys($arguments),array_keys($arguments));
-      $form['sbf_ajax_interactions_arguments'] = [
-        '#type' => 'checkboxes',
-        '#title' => $this->t('Which exposed filters should allow input from other ADOs'),
-        '#options' => $all_exposed_arguments,
-        '#default_value' => $this->options['sbf_ajax_interactions_arguments'],
-        '#states'        => [
-          'visible' => [
-            ':input[name="sbf_ajax_interactions"]' => ['checked' => TRUE],
-            ':input[name="use_ajax"]' => ['checked' => TRUE],
+      $arguments = $this->displayHandler->getOption('arguments') ?? [];
+      $all_exposed_arguments = array_combine(array_keys($arguments), array_keys($arguments));
+      if (count($all_exposed_arguments)) {
+        $form['sbf_ajax_interactions_arguments'] = [
+          '#type'          => 'checkboxes',
+          '#title'         => $this->t(
+            'Which Contextual filters (if any) should allow input from other ADOs'
+          ),
+          '#options'       => $all_exposed_arguments,
+          '#default_value' => $this->options['sbf_ajax_interactions_arguments'],
+          '#states'        => [
+            'enabled' => [
+              ':input[name="sbf_ajax_interactions"]' => ['checked' => TRUE],
+              ':input[name="use_ajax"]'              => ['checked' => TRUE],
+            ],
           ],
-        ],
-      ];
+        ];
+      }
     }
   }
 
@@ -67,6 +71,7 @@ class StrawberryAjaxInteractions extends DisplayExtenderPluginBase {
       }
       else {
         unset($this->options['sbf_ajax_interactions_arguments']);
+        unset($this->options['sbf_ajax_interactions']);
       }
     }
   }
@@ -93,6 +98,7 @@ class StrawberryAjaxInteractions extends DisplayExtenderPluginBase {
     if ($form_state->hasValue('use_ajax') && $form_state->getValue('use_ajax') != TRUE) {
       // Prevent use ajax history when ajax for view are disabled.
       $form_state->setValue('sbf_ajax_interactions', FALSE);
+      $form_state->setValue('sbf_ajax_interactions_arguments', NULL);
     }
   }
   /**


### PR DESCRIPTION
See #345 

Also did a small work-around a bug in Drupal: A non valid (bc I messed it up) Views Page Path will still render a page but basically not work. In that case I can not generate a browser history. I mean nothing will work, but at least it won't be because of our code.

Also the wording of our display extender was "improved". We only allow relationships and Contextual filters to be "fed" by a viewer/ado. Not pure exposed filters that could be modified by the user via a form (that would be a great/extra mess if we did).I mean, an exposed filter "could" be used, but only if also used as contextual. You all know what I mean (or not!)

@alliomeria this solves the array error we saw today.