### PR TITLE
ISSUE-348: Adds a pseudo Node "Upcaster" for Routed Views in the presence of "Active Display Settings" tab

### DIFF
--- a/src/Plugin/Menu/LocalTask/ViewModeLocalTask.php
+++ b/src/Plugin/Menu/LocalTask/ViewModeLocalTask.php
@@ -8,7 +8,6 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\format_strawberryfield\ViewModeResolverInterface;
 use Drupal\node\NodeInterface;
-use Drupal\node\Entity\Node;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/src/Plugin/Menu/LocalTask/ViewModeLocalTask.php
+++ b/src/Plugin/Menu/LocalTask/ViewModeLocalTask.php
@@ -78,7 +78,7 @@ class ViewModeLocalTask extends LocalTaskDefault implements ContainerFactoryPlug
     }
     elseif ($route_match->getParameter('view_id') && is_numeric($node)) {
       /* Upcasting %node route argument to NodeInterface will not happen for
-      Rputed Views (Page/Rest), when under access control because of
+      Routed Views (Page/Rest), when under access control because of
       https://www.drupal.org/project/drupal/issues/2528166
       @TODO Revisit this work-around on Drupal 11.x
       */

--- a/src/Plugin/Menu/LocalTask/ViewModeLocalTask.php
+++ b/src/Plugin/Menu/LocalTask/ViewModeLocalTask.php
@@ -2,11 +2,13 @@
 
 namespace Drupal\format_strawberryfield\Plugin\Menu\LocalTask;
 
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Menu\LocalTaskDefault;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\format_strawberryfield\ViewModeResolverInterface;
 use Drupal\node\NodeInterface;
+use Drupal\node\Entity\Node;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -22,20 +24,28 @@ class ViewModeLocalTask extends LocalTaskDefault implements ContainerFactoryPlug
   protected $viewModeResolver;
 
   /**
+   * The Entity Type Manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
    * Construct the ViewModeLocalTask object.
    *
-   * @param array $configuration
+   * @param array                                                    $configuration
    *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
+   * @param string                                                   $plugin_id
    *   The plugin_id for the plugin instance.
-   * @param array $plugin_definition
+   * @param array                                                    $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\format_strawberryfield\ViewModeResolverInterface
-   *   The SBF View Mode resolver.
+   * @param \Drupal\format_strawberryfield\ViewModeResolverInterface $view_mode_resolver
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface           $entitytype_manager
    */
-  public function __construct(array $configuration, $plugin_id, array $plugin_definition, ViewModeResolverInterface $view_mode_resolver) {
+  public function __construct(array $configuration, $plugin_id, array $plugin_definition, ViewModeResolverInterface $view_mode_resolver, EntityTypeManagerInterface $entitytype_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->viewModeResolver = $view_mode_resolver;
+    $this->entityTypeManager = $entitytype_manager;
   }
 
   /**
@@ -46,7 +56,8 @@ class ViewModeLocalTask extends LocalTaskDefault implements ContainerFactoryPlug
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('format_strawberryfield.view_mode_resolver')
+      $container->get('format_strawberryfield.view_mode_resolver'),
+      $container->get('entity_type.manager')
     );
   }
 
@@ -66,6 +77,30 @@ class ViewModeLocalTask extends LocalTaskDefault implements ContainerFactoryPlug
       }
       $params += ['bundle' =>  $node->bundle(), 'node' => $node->id(), 'view_mode_name' => $viewmode];
     }
+    elseif ($route_match->getParameter('view_id') && is_numeric($node)) {
+      /* Upcasting %node route argument to NodeInterface will not happen for
+      Rputed Views (Page/Rest), when under access control because of
+      https://www.drupal.org/project/drupal/issues/2528166
+      @TODO Revisit this work-around on Drupal 11.x
+      */
+      $node = $this->entityTypeManager->getStorage('node')->load($node);
+      if ($node) {
+        if ($node->hasField('ds_switch')
+          && !empty($node->ds_switch->value)
+        ) {
+          $viewmode = $node->ds_switch->value;
+        }
+        else {
+          $viewmode = $this->viewModeResolver->get($node);
+        }
+        $params += [
+          'bundle' => $node->bundle(),
+          'node' => $node->id(),
+          'view_mode_name' => $viewmode
+        ];
+      }
+    }
+
     return $params;
   }
 


### PR DESCRIPTION
See #348 

This tries to get around the exception that happens when a View uses %node as a parameter, but does not upcast it the value to NodeInterface. It (of course) does this without too much overhead, which means it does not processes the View  Entity Itself and we simply assume a `view_id` + `node `argument are reasons enough to enrich the Route. It is important to node that really only place where this can happen (so pretty edge case) is when a View's path is node/%node given that (fixed in code) that is where our Route (Active Display settings) will call this class. Basically when Node level Tabs (actions) and View level Actions depend on each other/live side by side.