### PR TITLE
ISSUE-353: Hide viewer if embargo is present + enforce embargo on Exposed Metadata Endpoints via 401

### DIFF
--- a/config/schema/format_strawberryfield.entity.metadataexpose_entity.schema.yml
+++ b/config/schema/format_strawberryfield.entity.metadataexpose_entity.schema.yml
@@ -25,3 +25,6 @@
     active:
       type: boolean
       label: 'Whether this endpoint is active'
+    hide_on_embargo:
+      type: boolean
+      label: 'If a 401 should be returned on a resolved Embargo'

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -100,9 +100,6 @@ field.formatter.settings.strawberry_image_formatter:
     embargo_json_key_source:
       type: string
       label: 'When embargoed, comma separated list of Image Upload JSON keys to filter against'
-    viewer_overrides:
-      type: string
-      label: 'OSD JSON based Viewer Overrides'
 field.formatter.settings.strawberry_media_formatter:
   type: mapping
   label: 'Specific Config for strawberry_media_formatter'
@@ -155,6 +152,9 @@ field.formatter.settings.strawberry_media_formatter:
     embargo_json_key_source:
       type: string
       label: 'When embargoed, comma separated list of Image Upload JSON keys to filter against'
+    viewer_overrides:
+      type: string
+      label: 'OSD JSON based Viewer Overrides'
     hide_on_embargo:
       type: boolean
       label: 'Hide Viewer if embargo is resolved as embargoed.'

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -100,6 +100,9 @@ field.formatter.settings.strawberry_image_formatter:
     embargo_json_key_source:
       type: string
       label: 'When embargoed, comma separated list of Image Upload JSON keys to filter against'
+    viewer_overrides:
+      type: string
+      label: 'OSD JSON based Viewer Overrides'
 field.formatter.settings.strawberry_media_formatter:
   type: mapping
   label: 'Specific Config for strawberry_media_formatter'
@@ -152,6 +155,9 @@ field.formatter.settings.strawberry_media_formatter:
     embargo_json_key_source:
       type: string
       label: 'When embargoed, comma separated list of Image Upload JSON keys to filter against'
+    hide_on_embargo:
+      type: boolean
+      label: 'Hide Viewer if embargo is resolved as embargoed.'
 
 field.formatter.settings.strawberry_3d_formatter:
   type: mapping
@@ -253,7 +259,10 @@ field.formatter.settings.strawberry_paged_formatter:
       label: 'Comma separated list of Image upload JSON keys to filter against'
     embargo_json_key_source:
       type: string
-      label: 'When embargoed, comma separated list of Image upload JSON keys to filter against'
+      label: 'When embargoed, comma separated list of Image upload JSON keys to filter against.'
+    hide_on_embargo:
+      type: boolean
+      label: 'Hide Viewer if embargo is resolved as embargoed.'
 
 field.formatter.settings.strawberry_pannellum_formatter:
   type: mapping
@@ -404,6 +413,9 @@ field.formatter.strawberry_uv_formatter:
     use_iiif_globals:
       type: string
       label: 'Whether to use global IIIF settings or not.'
+    hide_on_embargo:
+      type: boolean
+      label: 'Hide Viewer if embargo is resolved as embargoed.'
 field.formatter.settings.strawberry_mirador_formatter:
   type: mapping
   label: 'Specific Config for strawberry_mirador_formatter'
@@ -450,7 +462,9 @@ field.formatter.settings.strawberry_mirador_formatter:
     use_iiif_globals:
       type: string
       label: 'Whether to use global IIIF settings or not.'
-
+    hide_on_embargo:
+      type: boolean
+      label: 'Hide Viewer if embargo is resolved as embargoed.'
 field.formatter.settings.strawberry_warc_formatter:
   type: mapping
   label: 'Specific Config for strawberry_warc_formatter'

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -132,6 +132,9 @@ field.formatter.settings.strawberry_media_formatter:
     webannotations_betterpolygon:
       type: boolean
       label: 'If Better Polygon plugin is enabled. Only if tool is polygon or both'
+    webannotations_georeferencewidget:
+      type: boolean
+      label: 'If Georeference Annotation Plugin is enabled.'
     use_iiif_globals:
       type: string
       label: 'Whether to use global IIIF settings or not.'
@@ -152,11 +155,27 @@ field.formatter.settings.strawberry_media_formatter:
     embargo_json_key_source:
       type: string
       label: 'When embargoed, comma separated list of Image Upload JSON keys to filter against'
+    mediasource:
+      type: mapping
+      label: 'Sources for IIIF URL'
+      mapping:
+        manifestnodelist:
+          type: string
+          label: 'If manifestnodelist is being used'
+        metadataexposeentity:
+          type: string
+          label: 'If metadataexposeentity is being used'
+        manifesturl:
+          type: string
+          label: 'If manifesturl is being used'
+    main_mediasource:
+      type: string
+      label: 'Primary IIIF URL Source used'
     viewer_overrides:
       type: string
       label: 'OSD JSON based Viewer Overrides'
     hide_on_embargo:
-      type: boolean
+      type: string
       label: 'Hide Viewer if embargo is resolved as embargoed.'
 
 field.formatter.settings.strawberry_3d_formatter:
@@ -222,6 +241,15 @@ field.formatter.settings.strawberry_metadata_formatter:
       type: string
     metadatadisplayentity_uselabel:
       type: string
+    upload_json_key_source:
+      type: string
+      label: 'Not used. Comma separated list of Image upload JSON keys to filter against'
+    embargo_json_key_source:
+      type: string
+      label: 'Not used. Inherited. When embargoed, comma separated list of Image Upload JSON keys to filter against'
+    hide_on_embargo:
+      type: string
+      label: 'Hide Viewer if embargo is resolved as embargoed.'
 field.formatter.settings.strawberry_paged_formatter:
   type: mapping
   label: 'Specific Config for strawberry_paged_formatter'
@@ -261,7 +289,7 @@ field.formatter.settings.strawberry_paged_formatter:
       type: string
       label: 'When embargoed, comma separated list of Image upload JSON keys to filter against.'
     hide_on_embargo:
-      type: boolean
+      type: string
       label: 'Hide Viewer if embargo is resolved as embargoed.'
 
 field.formatter.settings.strawberry_pannellum_formatter:
@@ -392,7 +420,7 @@ field.formatter.settings.strawberry_pdf_formatter:
     embargo_json_key_source:
       type: string
       label: 'When embargoed, comma separated list of PDF Upload JSON keys to filter against'
-field.formatter.strawberry_uv_formatter:
+field.formatter.settings.strawberry_uv_formatter:
   type: mapping
   label: 'Specific Config for strawberry_uv_formatter'
   mapping:
@@ -414,8 +442,14 @@ field.formatter.strawberry_uv_formatter:
       type: string
       label: 'Whether to use global IIIF settings or not.'
     hide_on_embargo:
-      type: boolean
+      type: string
       label: 'Hide Viewer if embargo is resolved as embargoed.'
+    upload_json_key_source:
+      type: string
+      label: 'Not used. Inherited. Comma separated list of Image Upload JSON keys to filter against'
+    embargo_json_key_source:
+      type: string
+      label: 'Not used. Inherited. When embargoed, comma separated list of Image Upload JSON keys to filter against'
 field.formatter.settings.strawberry_mirador_formatter:
   type: mapping
   label: 'Specific Config for strawberry_mirador_formatter'
@@ -462,8 +496,14 @@ field.formatter.settings.strawberry_mirador_formatter:
     use_iiif_globals:
       type: string
       label: 'Whether to use global IIIF settings or not.'
+    upload_json_key_source:
+      type: string
+      label: 'Not used. Inherited. Comma separated list of Image Upload JSON keys to filter against'
+    embargo_json_key_source:
+      type: string
+      label: 'Not used. Inherited. When embargoed, comma separated list of Image Upload JSON keys to filter against'
     hide_on_embargo:
-      type: boolean
+      type: string
       label: 'Hide Viewer if embargo is resolved as embargoed.'
 field.formatter.settings.strawberry_warc_formatter:
   type: mapping
@@ -595,6 +635,12 @@ field.formatter.settings.strawberry_map_formatter:
     use_iiif_globals:
       type: string
       label: 'Whether to use global IIIF settings or not.'
+    upload_json_key_source:
+      type: string
+      label: 'Not used. Comma separated list of Image upload JSON keys to filter against'
+    embargo_json_key_source:
+      type: string
+      label: 'Not used. Inherited. When embargoed, comma separated list of Image Upload JSON keys to filter against'
 # Given any DS field plugin formatter key a type
 ds.field_plugin.*:
   type: mapping
@@ -666,4 +712,12 @@ condition.plugin.ado_type_condition:
     recurse_ado_types:
       type: boolean
       label: 'Recurse metadata'
-
+condition.plugin.ado_jmespath_condition:
+  type: condition.plugin
+  label: 'ADO JMESPATH Condition'
+  mapping:
+    ado_jmespaths:
+      type: sequence
+      label: 'ADO JMESPATHS'
+      sequence:
+        type: string

--- a/format_strawberryfield.install
+++ b/format_strawberryfield.install
@@ -214,3 +214,21 @@ function format_strawberryfield_update_8702() {
   $message = "All Metadata Display Entities in Configurations updated to use UUIDs";
   return $message;
 }
+/**
+ * Implements hook_update_N().
+ *
+ * Updates metadataexpose_entity config adding hide_on_embargo config option.
+ *
+ */
+function format_strawberryfield_update_8703() {
+  $message = "Nothing to update. metadataexpose_entity entity is not installed.";
+  $entity_type = \Drupal::entityDefinitionUpdateManager()->getEntityType('metadataexpose_entity');
+  if ($entity_type) {
+      $entity_config_export = $entity_type->get('config_export');
+      $entity_config_export[] = 'hide_on_embargo';
+      $entity_type->set('config_export', $entity_config_export);
+      \Drupal::entityDefinitionUpdateManager()->updateEntityType($entity_type);
+      $message = "Metadata Exposed Display Entity's (metadataexpose_entity) Schema updated with hide_on_embargo setting";
+  }
+  return $message;
+}

--- a/src/Entity/MetadataExposeConfigEntity.php
+++ b/src/Entity/MetadataExposeConfigEntity.php
@@ -46,6 +46,7 @@ use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
  *     "metadatadisplayentity_uuid",
  *     "cache",
  *     "active",
+ *     "hide_on_embargo",
  *   },
  *   links = {
  *     "edit-form" = "/admin/config/archipelago/metadataexpose/{metadataexpose_entity}/edit",
@@ -123,6 +124,36 @@ class MetadataExposeConfigEntity extends ConfigEntityBase implements MetadataCon
    * @var bool
    */
   protected $active = TRUE;
+
+
+  /**
+   * If a 401 should be returned on a resolved embargo.
+   *
+   * @var bool
+   */
+  protected $hide_on_embargo = FALSE;
+
+
+  /**
+   * The $hide_on_embargo getter.
+   *
+   * @return bool
+   *   The label.
+   */
+  public function getHideOnEmbargo(): bool {
+    return $this->hide_on_embargo ?? FALSE;
+  }
+
+  /**
+   * $hide_on_embargo setter.
+   *
+   * @param bool $flag
+   *   If it should hide or not.
+   */
+  public function setHideOnEmbargo(bool $flag): void {
+    $this->hide_on_embargo = $flag;
+  }
+
 
   /**
    * The Label for this config entity.
@@ -400,7 +431,5 @@ class MetadataExposeConfigEntity extends ConfigEntityBase implements MetadataCon
       );
     return $url;
   }
-
-
 
 }

--- a/src/Form/MetadataExposeConfigEntityForm.php
+++ b/src/Form/MetadataExposeConfigEntityForm.php
@@ -89,14 +89,21 @@ class MetadataExposeConfigEntityForm extends EntityForm {
         '#title' => $this->t('Which Content types will this metadata be allowed to be exposed?'),
         '#required'=> TRUE,
         '#default_value' => (!$metadataconfig->isNew()) ? $metadataconfig->getTargetEntityTypes(): [],
-        ],
+      ],
       'active' => [
         '#type' => 'checkbox',
         '#title' => $this->t('Is this exposed Metadata Endpoint active?'),
         '#return_value' => TRUE,
         '#default_value' => ($metadataconfig->isNew()) ? TRUE : $metadataconfig->isActive()
+      ],
+      'hide_on_embargo' => [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Return a 401 (Not authorized) in case of an embargo.'),
+        '#Description' => $this->t('If checked and in the presence of an Embargo, this endpoint will return a 401 instead of delegating the embargo processing to the metadata display entity'),
+        '#return_value' => TRUE,
+        '#default_value' => ($metadataconfig->isNew()) ? FALSE : $metadataconfig->getHideOnEmbargo()
       ]
-     ];
+    ];
 
     return $form;
   }

--- a/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
@@ -8,6 +8,7 @@
 
 namespace Drupal\format_strawberryfield\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FieldItemInterface;
 use Drupal\format_strawberryfield\EmbargoResolverInterface;
@@ -131,6 +132,7 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
         'custom_js' => FALSE,
         'max_width' => 720,
         'max_height' => 480,
+        'hide_on_embargo' => FALSE,
       ];
   }
 
@@ -297,6 +299,16 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
           '#min' => 0,
           '#required' => TRUE
         ],
+        'hide_on_embargo' => [
+          '#type' => 'checkbox',
+          '#title' => $this->t('Hide the Viewer in the presence of an Embargo.'),
+          '#description' => t('If unchecked, acting on an embargo will be delegated to the IIIF Manifest driving the viewer.'),
+          '#default_value' => $this->getSetting('hide_on_embargo') ?? FALSE,
+          '#required' => FALSE,
+          '#attributes' => [
+            'data-formatter-selector' => 'hide_on_embargo',
+          ],
+        ],
       ] + parent::settingsForm($form, $form_state);
     if (empty($options_for_mainsource)) {
       // let's give people a hint of what they are doing wrong
@@ -420,9 +432,14 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
         '%max_height' => $this->getSetting('max_height') . ' pixels',
       ]
     );
-   if ($this->getSetting('custom_js')) {
-     $summary[] = $this->t('Using Custom Mirador with Plugins');
-   }
+    if ($this->getSetting('custom_js')) {
+      $summary[] = $this->t('Using Custom Mirador with Plugins');
+    }
+    $summary[] = $this->t('Viewer for embargoed Objects is %hide',
+      [
+        '%hide' => $this->getSetting('hide_on_embargo') ? 'hidden' : 'visible'
+      ]
+    );
 
     return array_merge($summary, parent::settingsSummary());
   }
@@ -438,6 +455,14 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
     $max_height = $this->getSetting('max_height');
     $mediasource = is_array($this->getSetting('mediasource')) ? $this->getSetting('mediasource') : [];
     $main_mediasource = $this->getSetting('main_mediasource');
+    $hide_on_embargo =  $this->getSetting('hide_on_embargo');
+    // This won't be evaluated and will stay false even if embargoed
+    // if hide_on_embargo is not enabled
+    // bc all embargo decision will anyways be delegated to the
+    // Exposed Metadata endpoints.
+    $embargo_context = [];
+    $embargo_tags = [];
+    $embargoed = FALSE;
 
     /* @var \Drupal\file\FileInterface[] $files */
     // Fixing the key to extract while coding to 'Media'
@@ -472,95 +497,138 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
         return $elements[$delta] = ['#markup' => $this->t('ERROR')];
       }
       // A rendered Manifest
-
-      foreach ($mediasource as $iiifsource) {
-        $pagestrategy = (string)$iiifsource;
-        switch ($pagestrategy) {
-          case 'metadataexposeentity':
-            $manifests['metadataexposeentity'] = $this->processManifestforMetadataExposeEntity(
-              $jsondata,
-              $item
-            );
-            continue 2;
-          case 'manifesturl':
-            $manifests['manifesturl'] = $this->processManifestforURL(
-              $jsondata,
-              $item
-            );
-            continue 2;
-          case 'manifestnodelist':
-            $manifests['manifestnodelist'] = $this->processManifestforNodeList(
-              $jsondata,
-              $item
-            );
-            continue 2;
-        }
-      }
-
-      // Check which one is our main source and if it really exists
-      if (isset($manifests[$main_mediasource]) && !empty($manifests[$main_mediasource])) {
-        // Take only the first since we could have more
-        $main_manifesturl = array_shift($manifests[$main_mediasource]);
-        $all_manifesturl =  array_reduce($manifests,'array_merge',[]);
-      } else {
-        // reduce flattens and applies a merge. Basically we get a simple list.
-        $all_manifesturl = array_reduce($manifests,'array_merge',[]);
-        $main_manifesturl = array_shift($all_manifesturl);
-      }
-
-      // Only process is we got at least one manifest
-      if (!empty($main_manifesturl)) {
-
-        $groupid = 'iiif-' . $item->getName(
-          ) . '-' . $nodeuuid . '-' . $delta . '-mirador';
-        $htmlid = $groupid;
-
-        $elements[$delta]['media'] = [
-          '#type' => 'container',
-          '#default_value' => $htmlid,
-          '#attributes' => [
-            'id' => $htmlid,
-            'class' => [
-              'strawberry-mirador-item',
-              'MiradorViewer',
-              'field-iiif',
-            ],
-            'style' => "width:{$max_width_css}; height:{$max_height}px",
-            'height' => $max_height,
-          ],
-        ];
-
-        // get the URL to our Metadata Expose Endpoint, we will get a string here.
-
-        $elements[$delta]['media']['#attributes']['data-iiif-infojson'] = '';
-        $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['mirador'][$htmlid]['nodeuuid'] = $nodeuuid;
-        $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['mirador'][$htmlid]['manifesturl'] = $main_manifesturl;
-        $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['mirador'][$htmlid]['manifestother'] = is_array($all_manifesturl) ? $all_manifesturl : [];
-        $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['mirador'][$htmlid]['width'] = $max_width_css;
-        $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['mirador'][$htmlid]['height'] = max(
-          $max_height,
-          480
+      if ($hide_on_embargo) {
+        $embargo_info = $this->embargoResolver->embargoInfo(
+          $item->getEntity()->uuid(), $jsondata
         );
-        $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['mirador'][$htmlid]['custom_js'] = $this->getSetting('custom_js') ?? FALSE;
-        if ($this->getSetting('custom_js')) {
-          $elements[$delta]['#attached']['library'][]
-            = 'format_strawberryfield/mirador_custom_strawberry';
-        }
-        else {
-          $elements[$delta]['#attached']['library'][]
-            = 'format_strawberryfield/mirador_strawberry';
-        }
 
 
-        if (isset($item->_attributes)) {
-          $elements[$delta] += ['#attributes' => []];
-          $elements[$delta]['#attributes'] += $item->_attributes;
-          // Unset field item attributes since they have been included in the
-          // formatter output and should not be rendered in the field template.
+        if (is_array($embargo_info)) {
+          $embargoed = $embargo_info[0];
+          $embargo_tags[] = 'format_strawberryfield:all_embargo';
+          if ($embargo_info[1]) {
+            $embargo_tags[] = 'format_strawberryfield:embargo:'
+              . $embargo_info[1];
+          }
+          if ($embargo_info[2]) {
+            $embargo_context[] = 'ip';
+          }
         }
+      }
+
+      // Only process render elements if hide on embargo is TRUE
+      if (!$embargoed || ($embargoed && !$hide_on_embargo)) {
+        foreach ($mediasource as $iiifsource) {
+          $pagestrategy = (string)$iiifsource;
+          switch ($pagestrategy) {
+            case 'metadataexposeentity':
+              $manifests['metadataexposeentity'] = $this->processManifestforMetadataExposeEntity(
+                $jsondata,
+                $item
+              );
+              continue 2;
+            case 'manifesturl':
+              $manifests['manifesturl'] = $this->processManifestforURL(
+                $jsondata,
+                $item
+              );
+              continue 2;
+            case 'manifestnodelist':
+              $manifests['manifestnodelist'] = $this->processManifestforNodeList(
+                $jsondata,
+                $item
+              );
+              continue 2;
+          }
+        }
+        // Check which one is our main source and if it really exists
+        if (isset($manifests[$main_mediasource]) && !empty($manifests[$main_mediasource])) {
+          // Take only the first since we could have more
+          $main_manifesturl = array_shift($manifests[$main_mediasource]);
+          $all_manifesturl =  array_reduce($manifests,'array_merge',[]);
+        } else {
+          // reduce flattens and applies a merge. Basically we get a simple list.
+          $all_manifesturl = array_reduce($manifests,'array_merge',[]);
+          $main_manifesturl = array_shift($all_manifesturl);
+        }
+
+        // Only process is we got at least one manifest
+        if (!empty($main_manifesturl)) {
+
+          $groupid = 'iiif-' . $item->getName() . '-' . $nodeuuid . '-' . $delta
+            . '-mirador';
+          $htmlid = $groupid;
+
+          $elements[$delta]['media'] = [
+            '#type'          => 'container',
+            '#default_value' => $htmlid,
+            '#attributes'    => [
+              'id'     => $htmlid,
+              'class'  => [
+                'strawberry-mirador-item',
+                'MiradorViewer',
+                'field-iiif',
+              ],
+              'style'  => "width:{$max_width_css}; height:{$max_height}px",
+              'height' => $max_height,
+            ],
+          ];
+
+          // get the URL to our Metadata Expose Endpoint, we will get a string here.
+
+          $elements[$delta]['media']['#attributes']['data-iiif-infojson'] = '';
+          $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['mirador'][$htmlid]['nodeuuid']
+            = $nodeuuid;
+          $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['mirador'][$htmlid]['manifesturl']
+            = $main_manifesturl;
+          $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['mirador'][$htmlid]['manifestother']
+            = is_array($all_manifesturl) ? $all_manifesturl : [];
+          $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['mirador'][$htmlid]['width']
+            = $max_width_css;
+          $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['mirador'][$htmlid]['height']
+            = max(
+            $max_height,
+            480
+          );
+          $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['mirador'][$htmlid]['custom_js']
+            = $this->getSetting('custom_js') ?? FALSE;
+          if ($this->getSetting('custom_js')) {
+            $elements[$delta]['#attached']['library'][]
+              = 'format_strawberryfield/mirador_custom_strawberry';
+          }
+          else {
+            $elements[$delta]['#attached']['library'][]
+              = 'format_strawberryfield/mirador_strawberry';
+          }
+        }
+      }
+      if (empty($elements[$delta])) {
+        $elements[$delta] = [
+          '#markup' => '<i class="d-none fas fa-times-circle"></i>',
+          '#prefix' => '<span>',
+          '#suffix' => '</span>',
+        ];
+      }
+
+      if (isset($item->_attributes)) {
+        $elements[$delta] += ['#attributes' => []];
+        $elements[$delta]['#attributes'] += $item->_attributes;
+        // Unset field item attributes since they have been included in the
+        // formatter output and should not be rendered in the field template.
+        unset($item->_attributes);
+      }
+
+      // Get rid of empty #attributes key to avoid render error
+      if (isset($elements[$delta]["#attributes"]) && empty($elements[$delta]["#attributes"])) {
+        unset($elements[$delta]["#attributes"]);
       }
     }
-    unset($item->_attributes);
+
+    $elements['#cache'] = [
+      'context' => Cache::mergeContexts($item->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
+      'tags' => Cache::mergeTags($item->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
+    ];
+
     return $elements;
   }
 


### PR DESCRIPTION
See #353, Closes #353

This adds a new Setting to IIIF enabled Viewers that allows a formatter to block the display of a Viewer completely. This allows users that don't want/know how to use the `data.data_embargo.embargoed` and `data.data_embargo.until` Metadata Display context variables to act/modify a IIIF Manifest  (or any Template driven output) on the presence of an embargo, to hide the Viewer completely. 

@alliomeria thanks