### PR TITLE
ISSUE-363: Wrong empty defaults break View Ajax settings on Map formatter

### DIFF
--- a/src/Plugin/Field/FieldFormatter/StrawberryMapFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMapFormatter.php
@@ -229,13 +229,13 @@ class StrawberryMapFormatter extends StrawberryBaseFormatter implements Containe
     ];
 
 
-    $options_for_mainsource = array_filter($options_for_mainsource);
+    $options_for_mainsource = array_filter($options_for_mainsource ?? []);
     $options_for_mainsource = array_intersect_key(
       $options_for_mainsource,
       $all_options_form_source
     );
 
-    $options_for_mainoverlaysource = array_filter($options_for_mainoverlaysource);
+    $options_for_mainoverlaysource = array_filter($options_for_mainoverlaysource ?? []);
     $options_for_mainoverlaysource = array_intersect_key(
       $options_for_mainoverlaysource,
       $all_options_form_overlaysource


### PR DESCRIPTION
See #363 

This value can be in fact be null but bc we have to compare (when it has one) against valid sources, so we do an array filter and break hell loose. This should fix it