### PR TITLE
ISSUE-384: Fixes Manifest v/s Image driven OSD issue with configuration default/formatter settings form

### DIFF
--- a/modules/format_strawberryfield_views/format_strawberryfield_views.libraries.yml
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.libraries.yml
@@ -18,7 +18,6 @@ modal-exposed-form-views-ajax:
     - core/drupal
     - core/jquery
     - core/once
-    - core/once
     - core/drupalSettings
     - core/views
     - core/views.ajax

--- a/modules/format_strawberryfield_views/src/Plugin/views/style/LeaftletGeoJSON.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/style/LeaftletGeoJSON.php
@@ -106,18 +106,7 @@ class LeaftletGeoJSON extends StylePluginBase {
       'callback' => __CLASS__ . '::ajaxCallbackMainSource',
       'wrapper'  => 'main-mediasource-ajax-container',
     ];
-    // Because main media source needs to update its choices based on
-    // Media Source checked options, we need to recalculate its default
-    // Value also.
-    $default_value_main_mediasoruce = ($this->options['main_mediasource']
-      && array_key_exists(
-        $this->options['main_mediasource'],
-        $options_for_mainsource
-      ))
-      ? $this->options['main_mediasource']
-      : reset(
-        $options_for_mainsource
-      );
+
 
     $form['tilemap_url'] = [
       '#type'          => 'textfield',

--- a/src/Plugin/Field/FieldFormatter/StrawberryBaseIIIFManifestFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryBaseIIIFManifestFormatter.php
@@ -134,7 +134,7 @@ abstract class StrawberryBaseIIIFManifestFormatter extends StrawberryBaseFormatt
     // Because main media source needs to update its choices based on
     // Media Source checked options, we need to recalculate its default
     // Value also.
-    $default_value_main_mediasoruce = ($this->getSetting(
+    $default_value_main_mediasource = ($this->getSetting(
         'main_mediasource'
       ) && array_key_exists(
         $this->getSetting('main_mediasource'),
@@ -164,7 +164,7 @@ abstract class StrawberryBaseIIIFManifestFormatter extends StrawberryBaseFormatt
             'Select which Source will be handled as the primary one.'
           ),
           '#options' => $options_for_mainsource,
-          '#default_value' => $default_value_main_mediasoruce,
+          '#default_value' => $default_value_main_mediasource,
           '#required' => FALSE,
           '#prefix' => '<div id="main-mediasource-ajax-container">',
           '#suffix' => '</div>',

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -313,6 +313,7 @@ Not all options can be overriden. `id`,`tileSources`, `element` and other might 
 
       $mediasource = is_array($this->getSetting('mediasource'))
         ? $this->getSetting('mediasource') : [];
+      $mediasource = array_filter($mediasource);
       $main_mediasource = $this->getSetting('main_mediasource');
       if (!empty($mediasource) && ($main_mediasource)) {
         if (!$embargoed || ($embargoed && !$hide_on_embargo)


### PR DESCRIPTION
See #384 
But really the important bit is:

`$mediasource = array_filter($mediasource);`