### PR TITLE
ISSUE-389: add accessCheck() to FormatStrawberryfieldRestOaiPmhSettingsForm.php

### DIFF
--- a/modules/format_strawberryfield_rest_oai_pmh/src/Form/FormatStrawberryfieldRestOaiPmhSettingsForm.php
+++ b/modules/format_strawberryfield_rest_oai_pmh/src/Form/FormatStrawberryfieldRestOaiPmhSettingsForm.php
@@ -110,7 +110,7 @@ class FormatStrawberryfieldRestOaiPmhSettingsForm extends ConfigFormBase {
     $config = $this->config('format_strawberryfield_rest_oai_pmh.settings');
 
     $query = \Drupal::entityQuery('metadatadisplay_entity')
-      ->condition('mimetype', 'application/xml');
+      ->accessCheck()->condition('mimetype', 'application/xml');
     $results = $query->execute();
     $entities = \Drupal::entityTypeManager()->getStorage('metadatadisplay_entity')->loadMultiple($results);
     $options = [];


### PR DESCRIPTION
Needed explicitly in D10

See #389 

Even with this I can't make this module work on D10/Search API Solr driven view even using the 2.x-dev version of the module this extends. The issue (so far) is that the custom Caching system it uses is so DB based that it can not extract correctly an entity type (in a generic way) from the used and configured view. Maybe we need to discuss this module?