### PR TITLE
ISSUE-385: Drupal 10.1 compatibility for our overriden Controllers/facet/exposed forms (Symphony 5 v/s GET)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         }
     ],
     "require": {
+	"drupal/core":"^10.1", 
         "strawberryfield/strawberryfield":"1.3.0.x-dev",
         "league/html-to-markdown":"^5.0.0",
         "erusev/parsedown": "^1.7",

--- a/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
+++ b/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
@@ -230,6 +230,9 @@
        options.data = $.param(params);
      }
      else {
+       if  ((options.data == null) || (typeof(options.data) == 'undefined')) {
+         options.data = {};
+       }
        options.data['exposed_form_display'] = $exposed_form;
      }
     }

--- a/modules/format_strawberryfield_views/src/Controller/FormatStrawberryfieldViewAjaxController.php
+++ b/modules/format_strawberryfield_views/src/Controller/FormatStrawberryfieldViewAjaxController.php
@@ -14,7 +14,7 @@ use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Render\RenderContext;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Routing\RedirectDestinationInterface;
-use Drupal\views\Ajax\ScrollTopCommand;
+use Drupal\Core\Ajax\ScrollTopCommand;
 use Drupal\views\Ajax\ViewAjaxResponse;
 use Drupal\views\ViewExecutableFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -122,10 +122,10 @@ class FormatStrawberryfieldViewAjaxController extends ViewAjaxController {
    *   Thrown when the view was not found.
    */
   public function ajaxView(Request $request) {
-    $name = $request->request->get('view_name');
-    $display_id = $request->request->get('view_display_id');
+    $name = $request->get('view_name');
+    $display_id = $request->get('view_display_id');
     if (isset($name) && isset($display_id)) {
-      $args = $request->request->get('view_args', '');
+      $args = $request->get('view_args', '');
       $args = $args !== '' ? explode('/', Html::decodeEntities($args)) : [];
 
       // Arguments can be empty, make sure they are passed on as NULL so that
@@ -134,15 +134,15 @@ class FormatStrawberryfieldViewAjaxController extends ViewAjaxController {
         return ($arg == '' ? NULL : $arg);
       }, $args);
 
-      $path = $request->request->get('view_path');
+      $path = $request->get('view_path');
       // If a view has an invalid Path (e.g you added some % somewhere) this will be null.
       $target_url = $this->pathValidator->getUrlIfValid($path);
-      $dom_id = $request->request->get('view_dom_id');
+      $dom_id = $request->get('view_dom_id');
       $dom_id = isset($dom_id) ? preg_replace('/[^a-zA-Z0-9_-]+/', '-', $dom_id) : NULL;
-      $pager_element = $request->request->get('pager_element');
+      $pager_element = $request->get('pager_element');
       $pager_element = isset($pager_element) ? intval($pager_element) : NULL;
       // Assume its there if not told otherwise
-      $exposed_form_display = (bool) $request->request->get('exposed_form_display', TRUE);
+      $exposed_form_display = (bool) $request->get('exposed_form_display', TRUE);
 
       $response = new ViewAjaxResponse();
 

--- a/modules/format_strawberryfield_views/src/Controller/ViewsExposedFormModalBlockAjaxController.php
+++ b/modules/format_strawberryfield_views/src/Controller/ViewsExposedFormModalBlockAjaxController.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
- * Defines a controller to load an Modal Exposed Views Form Block via AJAX.
+ * Defines a controller to load a Modal Exposed Views Form Block via AJAX.
  */
 class ViewsExposedFormModalBlockAjaxController extends ControllerBase {
 


### PR DESCRIPTION
See #385 

This enables us to move forward with Drupal 10.1. Views now use by default GET which also means the arguments we need for our overrides for facets/ custom exposed form block approach are somewhere else. 

I'm not sure of these changes work with 10.0.x so for now will pull against 1.3.0 but might have to change my mind and roll YET another release. (thanks blue drop)