### PR TITLE
ISSUE-207-1.3 --- Moved twig context alter hook inside the render con…

### DIFF
--- a/src/Controller/MetadataExposeDisplayController.php
+++ b/src/Controller/MetadataExposeDisplayController.php
@@ -270,20 +270,19 @@ class MetadataExposeDisplayController extends ControllerBase {
               'format_strawberryfield.iiif_settings'
             )->get('pub_server_url');
             $original_context = $context + $context_embargo;
-            // Allow other modules to provide extra Context!
-            // Call modules that implement the hook, and let them add items.
-            \Drupal::moduleHandler()->alter(
-              'format_strawberryfield_twigcontext', $context
-            );
-            // In case someone decided to wipe the original context?
-            // We bring it back!
-            $context = $context + $original_context;
-            $cacheabledata = [];
             // @see https://www.drupal.org/node/2638686 to understand
             // What cacheable, Bubbleable metadata and early rendering means.
             $cacheabledata = $this->renderer->executeInRenderContext(
               new RenderContext(),
-              function () use ($context, $metadatadisplay_entity) {
+              function () use ($context, $original_context, $metadatadisplay_entity) {
+                // Allow other modules to provide extra Context!
+                // Call modules that implement the hook, and let them add items.
+                \Drupal::moduleHandler()->alter(
+                  'format_strawberryfield_twigcontext', $context
+                );
+                // In case someone decided to wipe the original context?
+                // We bring it back!
+                $context = $context + $original_context;
                 return $metadatadisplay_entity->renderNative($context);
               }
             );

--- a/src/Controller/MetadataExposeDisplayController.php
+++ b/src/Controller/MetadataExposeDisplayController.php
@@ -270,6 +270,7 @@ class MetadataExposeDisplayController extends ControllerBase {
               'format_strawberryfield.iiif_settings'
             )->get('pub_server_url');
             $original_context = $context + $context_embargo;
+            $cacheabledata = [];
             // @see https://www.drupal.org/node/2638686 to understand
             // What cacheable, Bubbleable metadata and early rendering means.
             $cacheabledata = $this->renderer->executeInRenderContext(


### PR DESCRIPTION
See #392 for 1.2.0 PR
- Moved twig context alter hook inside the render context to avoid potential cache 'leakage' errors.