### PR TITLE
ISSUE-395: Make IP based embargoed ADOs + Anonymous users un-cacheable

### DIFF
--- a/src/Controller/MetadataExposeDisplayController.php
+++ b/src/Controller/MetadataExposeDisplayController.php
@@ -241,9 +241,6 @@ class MetadataExposeDisplayController extends ControllerBase {
               $embargo_context[] = 'ip';
             }
           }
-          else {
-            $embargoed = $embargo_info;
-          }
 
           if ($metadataexposeconfig_entity->getHideOnEmbargo() && $embargoed) {
             // If embargoed and hide on embargo TRUE,
@@ -329,6 +326,9 @@ class MetadataExposeDisplayController extends ControllerBase {
           $response->getCacheableMetadata()->addCacheTags($embargo_tags);
           $response->getCacheableMetadata()->addCacheContexts(['user.roles']);
           $response->getCacheableMetadata()->addCacheContexts($embargo_context);
+          if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+            $response->getCacheableMetadata()->setCacheMaxAge(0);
+          }
         }
         return $response;
 

--- a/src/EmbargoResolver.php
+++ b/src/EmbargoResolver.php
@@ -66,13 +66,14 @@ class EmbargoResolver implements EmbargoResolverInterface {
 
   /**
    * Checks if we can bypass embargo.
-   *    If not possible we return an array with more info
+   *    If not possible we return an array with more info.
+   *    If the user is anonymous, and IP data is present in the ADO, we kill the cache too.
    *
    * @param array $jsondata
    *
    * @return array
    *    Returns array
-   *    with [(bool) embargoed, $date|FALSE, (bool) IP is enforced]
+   *    with [(bool) embargoed, $date|FALSE, (bool) IP is enforced], (bool) if cacheable at all or not
    *
    */
   public function embargoInfo(string $uuid, array $jsondata) {
@@ -82,11 +83,14 @@ class EmbargoResolver implements EmbargoResolverInterface {
     // This cache will only work per extending class
     // If we want the cache to survive longer
     // We need to make the function itself static
+    // but also add the varying IP to it.
     // @TODO evaluate if making it static is worth the effort.
     // Since all act on the same data/entity
     // And will share during the life
     // of the static cache
     // Same user/roles/etc
+    // but IP can vary, even for the same user.
+    // But never on a single HTTP call.
     if (isset($cache[$cache_id])) {
       return $cache[$cache_id];
     }
@@ -96,16 +100,17 @@ class EmbargoResolver implements EmbargoResolverInterface {
     $ip_embargo = FALSE;
     // If embargo by date is enforced
     $date_embargo = FALSE;
+    $cacheable = TRUE;
 
     if (!$this->embargoConfig->get('enabled')) {
-      $embargo_info = [!$noembargo, FALSE, FALSE];
+      $embargo_info = [!$noembargo, FALSE, FALSE, $cacheable];
     }
     $user_roles = $this->currentUser->getRoles();
     if (in_array('administrator', $user_roles)) {
-      $embargo_info = [!$noembargo, FALSE, FALSE];
+      $embargo_info = [!$noembargo, FALSE, FALSE, $cacheable];
     }
     elseif ($this->currentUser->hasPermission('see strawberryfield embargoed ados')) {
-      $embargo_info = [!$noembargo, FALSE , FALSE];
+      $embargo_info = [!$noembargo, FALSE , FALSE, $cacheable];
     }
     else {
       // Check the actual embargo options
@@ -125,6 +130,16 @@ class EmbargoResolver implements EmbargoResolverInterface {
       $ip_embargo_key = $this->embargoConfig->get('ip_json_key');
       if (strlen($ip_embargo_key) > 0 && !empty($jsondata[$ip_embargo_key])) {
         $current_ip =  $this->requestStack->getCurrentRequest()->getClientIp();
+        if ($this->currentUser->isAnonymous()) {
+          if (\Drupal::moduleHandler()->moduleExists('page_cache')) {
+            // we won't be able to cache varying contexts for anonymous, so
+            // simply kill the page cache
+            \Drupal::service('page_cache_kill_switch')->trigger();
+            $cacheable = FALSE;
+          }
+        }
+        // Why would the current IP not be present? Should we deny all if that
+        // exception happens?
         if ($current_ip) {
           if (is_array($jsondata[$ip_embargo_key])) {
             foreach($jsondata[$ip_embargo_key] as $ip_embargo_value) {
@@ -142,7 +157,7 @@ class EmbargoResolver implements EmbargoResolverInterface {
           }
         }
       }
-      $embargo_info = [!$noembargo, $date_embargo ? $date: FALSE , $ip_embargo];
+      $embargo_info = [!$noembargo, $date_embargo ? $date: FALSE , $ip_embargo, $cacheable];
     }
     $cache[$cache_id] = $embargo_info;
     return $embargo_info;

--- a/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
@@ -304,7 +304,7 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
         // Attach the Library
         $elements[$delta]['#attached']['library'][] = 'format_strawberryfield/jsm_modeler';
         // Add the texture
-        // Its always the same.
+        // It is always the same.
 
         foreach ($elements[$delta] as &$element) {
           if (isset($element['#attributes'])) {
@@ -341,6 +341,10 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
+    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+      $elements['#cache']['max-age'] = 0;
+    }
+
     return $elements;
   }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
@@ -304,6 +304,9 @@ class StrawberryAudioFormatter extends StrawberryDirectJsonFormatter {
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
+    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+      $elements['#cache']['max-age'] = 0;
+    }
 
     return $elements;
   }
@@ -319,9 +322,7 @@ class StrawberryAudioFormatter extends StrawberryDirectJsonFormatter {
     $max_height = $this->getSetting('max_height');
     $nodeuuid = $items->getEntity()->uuid();
     $nodeid = $items->getEntity()->id();
-    $imagefile = NULL;
-    $publicimageurl = NULL;
-    $fieldname = $items->getName();
+
 
     // We assume here file could not be accessible publicly
     $route_parameters = [

--- a/src/Plugin/Field/FieldFormatter/StrawberryBaseFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryBaseFormatter.php
@@ -17,7 +17,6 @@ use Drupal\format_strawberryfield\EmbargoResolverInterface;
 use Drupal\format_strawberryfield\Tools\IiifHelper;
 use Drupal\strawberryfield\Tools\Ocfl\OcflHelper;
 use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
-use mysql_xdevapi\Exception;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\format_strawberryfield\Tools\IiifUrlValidator;
 use Drupal\Core\Access\AccessResult;
@@ -296,7 +295,7 @@ abstract class StrawberryBaseFormatter extends FormatterBase implements Containe
           $form_state->setErrorByName(implode('][', $parents), t("Value is not a valid JSON"));
         }
       }
-      catch (Exception $e) {
+      catch (\Exception $e) {
         $form_state->setErrorByName(implode('][', $parents), t("Value is not a valid JSON"));
       }
     }

--- a/src/Plugin/Field/FieldFormatter/StrawberryCitationFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryCitationFormatter.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\format_strawberryfield\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
@@ -378,6 +379,15 @@ class StrawberryCitationFormatter extends StrawberryBaseFormatter {
         ];
       }
     }
+    $elements['#cache'] = [
+      'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
+      'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
+    ];
+
+    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+      $elements['#cache']['max-age'] = 0;
+    }
+
     return $elements;
   }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -9,9 +9,9 @@
 namespace Drupal\format_strawberryfield\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\strawberryfield\Tools\Ocfl\OcflHelper;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Cache\Cache;
+use Drupal\file\FileInterface;
 use Drupal\format_strawberryfield\Tools\IiifHelper;
 use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
 use Drupal\Core\StreamWrapper\StreamWrapperManager;
@@ -32,23 +32,23 @@ use Drupal\Core\StreamWrapper\StreamWrapperManager;
  * )
  */
 class StrawberryImageFormatter extends StrawberryBaseFormatter {
-  
+
   /**
    * {@inheritdoc}
    */
   public static function defaultSettings() {
     return
       parent::defaultSettings() + [
-      'json_key_source' => 'as:image',
-      'max_width' => 180,
-      'max_height' => 0,
-      'image_type' => 'jpg',
-      'number_images' => 1,
-      'quality' => 'default',
-      'rotation' => '0',
-      'image_link' =>  TRUE,
-      'webannotations' => FALSE,
-    ];
+        'json_key_source' => 'as:image',
+        'max_width' => 180,
+        'max_height' => 0,
+        'image_type' => 'jpg',
+        'number_images' => 1,
+        'quality' => 'default',
+        'rotation' => '0',
+        'image_link' =>  TRUE,
+        'webannotations' => FALSE,
+      ];
   }
 
   /**
@@ -134,17 +134,21 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
-    $max_width = $this->getSetting('max_width');
-    $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
-    $max_height = $this->getSetting('max_height');
+    $upload_keys_string = strlen(trim($this->getSetting('upload_json_key_source') ?? '')) > 0 ? trim($this->getSetting('upload_json_key_source')) : '';
+    $upload_keys = explode(',', $upload_keys_string);
+    $upload_keys = array_filter($upload_keys);
+    $embargo_upload_keys_string = strlen(trim($this->getSetting('embargo_json_key_source') ?? '')) > 0 ? trim($this->getSetting('embargo_json_key_source')) : '';
+    $embargo_upload_keys_string = explode(',', $embargo_upload_keys_string);
+    $embargo_upload_keys = array_filter($embargo_upload_keys_string);
+    $hide_on_embargo =  $this->getSetting('hide_on_embargo') ?? FALSE;
     $number_images =  $this->getSetting('number_images');
     /* @var \Drupal\file\FileInterface[] $files */
     // Fixing the key to extract while coding to 'Media'
     $key = $this->getSetting('json_key_source');
+    $embargo_context = [];
+    $embargo_tags = [];
+    $embargoed = FALSE;
 
-    $nodeuuid = $items->getEntity()->uuid();
-    $nodeid = $items->getEntity()->id();
-    $fieldname = $items->getName();
     foreach ($items as $delta => $item) {
       $main_property = $item->getFieldDefinition()->getFieldStorageDefinition()->getMainPropertyName();
       $value = $item->{$main_property};
@@ -157,14 +161,30 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
       // @TODO use future flatversion precomputed at field level as a property
       $json_error = json_last_error();
       if ($json_error != JSON_ERROR_NONE) {
-        $message= $this->t('We could had an issue decoding as JSON your metadata for node @id, field @field',
-          [
-            '@id' => $nodeid,
-            '@field' => $items->getName(),
-          ]);
         return $elements[$delta] = ['#markup' => $this->t('ERROR')];
       }
-      /* Expected structure of an Media item inside JSON
+
+      $embargo_info = $this->embargoResolver->embargoInfo($items->getEntity()->uuid(), $jsondata);
+      // This one is for the Twig template
+      // We do not need the IP here. No use of showing the IP at all?
+      $context_embargo = ['data_embargo' => ['embargoed' => false, 'until' => NULL]];
+
+      if (is_array($embargo_info)) {
+        $embargoed = $embargo_info[0];
+        $context_embargo['data_embargo']['embargoed'] = $embargoed;
+
+        $embargo_tags[] = 'format_strawberryfield:all_embargo';
+        if ($embargo_info[1]) {
+          $embargo_tags[] = 'format_strawberryfield:embargo:' . $embargo_info[1];
+          $context_embargo['data_embargo']['until'] = $embargo_info[1];
+        }
+        if ($embargo_info[2]) {
+          $embargo_context[] = 'ip';
+        }
+      } else {
+        $context_embargo['data_embargo']['embargoed'] = $embargo_info;
+      }
+      /* Expected structure of a Media item inside JSON
       "as:image": {
          "s3:\/\/f23\/new-metadata-en-image-58455d91acf7290275c1cab77531b7f561a11a84.jpg": {
          "dr:fid": 32, // Drupal's FID
@@ -175,146 +195,108 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
          "checksum": "f231aed5ae8c2e02ef0c5df6fe38a99b"
          }
       }*/
-      $i = 0;
-      if (isset($jsondata[$key])) {
-        // Order Images based on a given 'sequence' key
+      if ($embargoed) {
+        $upload_keys = $embargo_upload_keys;
+      }
+
+      if (!$embargoed || (!empty($embargo_upload_keys_string))) {
         $ordersubkey = 'sequence';
-        StrawberryfieldJsonHelper::orderSequence($jsondata, $key, $ordersubkey);
-        $iiifhelper = new IiifHelper($this->getIiifUrls()['public'], $this->getIiifUrls()['internal']);
-        foreach ($jsondata[$key] as $mediaitem) {
-          $i++;
-          if ($i > $number_images) {
-            break;
-          }
-          if (isset($mediaitem['type']) && $mediaitem['type'] == 'Image') {
-            if (isset($mediaitem['dr:fid'])) {
-              // @TODO check if loading the entity is really needed to check access.
-              // @TODO we can refactor a lot here and move it to base methods
-              $file = OcflHelper::resolvetoFIDtoURI(
-                $mediaitem['dr:fid']
-              );
-              if (!$file) {
-                continue;
-              }
-              //@TODO if no media key to file loading was possible
-              // means we have a broken/missing media reference
-              // we should inform to logs and continue
-              if ($this->checkAccess($file)) {
-                $iiifidentifier = urlencode(
-                  StreamWrapperManager::getTarget($file->getFileUri())
-                );
-
-                if ($iiifidentifier == NULL || empty($iiifidentifier)) {
-                  continue;
-                  // @TODO add a default Thumbnail here.
-                }
-                $filecachetags = $file->getCacheTags();
-                //@TODO check this filecachetags and see if they make sense
-
-
-                $uniqueid =
-                  'iiif-'.$items->getName(
-                  ).'-'.$nodeuuid.'-'.$delta.'-image'.$i;
-
-                $cache_contexts = ['url.site', 'url.path', 'url.query_args','user.permissions'];
-                // @ see https://www.drupal.org/files/issues/2517030-125.patch
-                $cache_tags = Cache::mergeTags($filecachetags, $items->getEntity()->getCacheTags());
-                // http://localhost:8183/iiif/2/e8c%2Fa-new-label-en-image-05066d9ae32580cffb38342323f145f74faf99a1.jpg/full/220,/0/default.jpg
-
-                $iiifpublicinfojson = $iiifhelper->getPublicInfoJson($iiifidentifier);
-                $iiifsizes = $iiifhelper->getImageSizes($iiifidentifier);
-
-                if (!$iiifsizes) {
-                  $message= $this->t('We could not fetch Image sizes from IIIF @url <br> for node @id, defaulting to base formatter configuration.',
-                    [
-                      '@url' => $iiifpublicinfojson,
-                      '@id' => $nodeid,
-                    ]);
-                  \Drupal::logger('format_strawberryfield')->warning($message);
-                  //continue; // Nothing can be done here?
-                }
-                else {
-                  //@see \template_preprocess_image for further theme_image() attributes.
-                  // Look. This one uses the public accesible base URL. That is how world works.
-                  if (($max_width == 0) && ($max_height == 0)) {
-                    $max_width = $iiifsizes[0]['width'];
-                    $max_height = $iiifsizes[0]['height'];
-                  }
-                  if (($max_width == 0) &&  ($max_height > 0)){
-                    $max_width = round($iiifsizes[0]['width']/$iiifsizes[0]['height'] * $max_height,0);
-
-                  }
-                  elseif (($max_width > 0) &&  ($max_height == 0)){
-                    $max_height = round($iiifsizes[0]['height']/$iiifsizes[0]['width'] * $max_width,0);
-                  }
-
-                  $iiifserverthumb = "{$this->getIiifUrls()['public']}/{$iiifidentifier}"."/full/{$max_width},/0/default.jpg";
-                  $image_render_array = [
-                    '#theme' => 'image',
-                    '#attributes' => [
-                      'class' => ['field-iiif', 'image-iiif'],
-                      'id' => 'thumb_' . $uniqueid,
-                      'src' => $iiifserverthumb,
-
-                    ],
-                    '#alt' => $this->t(
-                      'Thumbnail for @label',
-                      ['@label' => $items->getEntity()->label()]
-                    ),
-                    '#width' => $max_width,
-                    '#height' => $max_height,
-                  ];
-
-                  // With Link
-                  if (boolval($this->getSetting('image_link')) === TRUE && !$items->getEntity()->isNew()) {
-                    $elements[$delta]['media_thumb' . $i] = [
-                      '#type' => 'link',
-                      '#title' => $image_render_array,
-                      '#url' => $items->getEntity()->toUrl(),
-                      '#attributes' => [
-                        'alt' => $items->getEntity()->label()
-                        ]
-                      ];
-                  }
-                  else {
-                    $elements[$delta]['media_thumb' . $i] = $image_render_array;
-                  }
-
-                  if (isset($item->_attributes)) {
-                    $elements[$delta] += ['#attributes' => []];
-                    $elements[$delta]['#attributes'] += $item->_attributes;
-                    // Unset field item attributes since they have been included in the
-                    // formatter output and should not be rendered in the field template.
-                    unset($item->_attributes);
-                  }
-                }
-              }
-              else {
-                // @TODO Deal with no access here
-                // Should we put a thumb? Just hide?
-                // @TODO we can bring a plugin here and there that deals with
-                $elements[$delta]['media_thumb'.$i] = [
-                  '#markup' => '<i class="fas fa-times-circle"></i>',
-                  '#prefix' => '<span>',
-                  '#suffix' => '</span>',
-                ];
-              }
-            } elseif (isset($mediaitem['url'])) {
-              $elements[$delta]['media_thumb'.$i] = [
-                '#markup' => 'Non managed '.$mediaitem['url'],
-                '#prefix' => '<pre>',
-                '#suffix' => '</pre>',
-              ];
-            }
-
-          }
-        }
+        $media = $this->fetchMediaFromJsonWithFilter(
+          $delta, $items, $elements,
+          TRUE, $jsondata, 'Image', $key, $ordersubkey, $number_images, $upload_keys
+        );
       }
       // Get rid of empty #attributes key to avoid render error
       if (isset( $elements[$delta]["#attributes"]) && empty( $elements[$delta]["#attributes"])) {
         unset($elements[$delta]["#attributes"]);
       }
     }
+
+    $elements['#cache'] = [
+      'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
+      'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
+    ];
+    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+      $elements['#cache']['max-age'] = 0;
+    }
     return $elements;
+  }
+
+  protected function generateElementForItem(int $delta, FieldItemListInterface $items, FileInterface $file, IiifHelper $iiifhelper, int $i, array &$elements, array $jsondata, array $mediaitem) {
+
+    $max_width = $this->getSetting('max_width');
+    $max_width = empty($max_width) || $max_width == 0 ? NULL : $max_width;
+    $max_height = $this->getSetting('max_height');
+    $nodeuuid = $items->getEntity()->uuid();
+    $nodeid = $items->getEntity()->id();
+    $uniqueid = 'iiif-'.$items->getName().'-'.$nodeuuid.'-'.$delta.'-image-'.$i;
+
+    $iiifidentifier = urlencode(
+      StreamWrapperManager::getTarget($file->getFileUri())
+    );
+
+    if ($iiifidentifier == NULL || empty($iiifidentifier)) {
+      return;
+    }
+
+    $iiifpublicinfojson = $iiifhelper->getPublicInfoJson($iiifidentifier);
+    $iiifsizes = $iiifhelper->getImageSizes($iiifidentifier);
+
+    if (!$iiifsizes) {
+      $message= $this->t('We could not fetch Image sizes from IIIF @url <br> for node @id, defaulting to base formatter configuration.',
+        [
+          '@url' => $iiifpublicinfojson,
+          '@id' => $nodeid,
+        ]);
+      \Drupal::logger('format_strawberryfield')->warning($message);
+      //continue; // Nothing can be done here?
+    }
+    else {
+      //@see \template_preprocess_image for further theme_image() attributes.
+      // Look. This one uses the public accesible base URL. That is how world works.
+      if (($max_width == 0) && ($max_height == 0)) {
+        $max_width = $iiifsizes[0]['width'];
+        $max_height = $iiifsizes[0]['height'];
+      }
+      if (($max_width == 0) &&  ($max_height > 0)){
+        $max_width = round($iiifsizes[0]['width']/$iiifsizes[0]['height'] * $max_height,0);
+
+      }
+      elseif (($max_width > 0) &&  ($max_height == 0)){
+        $max_height = round($iiifsizes[0]['height']/$iiifsizes[0]['width'] * $max_width,0);
+      }
+
+      $iiifserverthumb = "{$this->getIiifUrls()['public']}/{$iiifidentifier}"."/full/{$max_width},/0/default.jpg";
+      $image_render_array = [
+        '#theme' => 'image',
+        '#attributes' => [
+          'class' => ['field-iiif', 'image-iiif'],
+          'id' => 'thumb_' . $uniqueid,
+          'src' => $iiifserverthumb,
+
+        ],
+        '#alt' => $this->t(
+          'Thumbnail for @label',
+          ['@label' => $items->getEntity()->label()]
+        ),
+        '#width' => $max_width,
+        '#height' => $max_height,
+      ];
+
+      // With Link
+      if (boolval($this->getSetting('image_link')) === TRUE && !$items->getEntity()->isNew()) {
+        $elements[$delta]['media_thumb' . $i] = [
+          '#type' => 'link',
+          '#title' => $image_render_array,
+          '#url' => $items->getEntity()->toUrl(),
+          '#attributes' => [
+            'alt' => $items->getEntity()->label()
+          ]
+        ];
+      }
+      else {
+        $elements[$delta]['media_thumb' . $i] = $image_render_array;
+      }
+    }
   }
 }

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -304,7 +304,7 @@ Not all options can be overriden. `id`,`tileSources`, `element` and other might 
         }
       }
       else {
-        $embargoed = $embargo_info;
+        $embargoed = FALSE;
       }
       if ($embargoed) {
         $upload_keys = $embargo_upload_keys_string;
@@ -352,6 +352,9 @@ Not all options can be overriden. `id`,`tileSources`, `element` and other might 
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
+    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+      $elements['#cache']['max-age'] = 0;
+    }
     return $elements;
   }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
@@ -9,6 +9,7 @@
 
 namespace Drupal\format_strawberryfield\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
@@ -219,17 +220,17 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
 
       // Probably good idea to strip our own keys here.
       // @TODO remove private access to keys
-
       // @TODO use future flatversion precomputed at field level as a property
       $json_error = json_last_error();
       if ($json_error != JSON_ERROR_NONE) {
-        $message = $this->t('We could had an issue decoding as JSON your metadata for node @id, field @field',
+        $message = $this->t('We had an issue decoding as JSON your metadata for node @id, field @field',
           [
             '@id' => $nodeid,
             '@field' => $items->getName(),
           ]);
-        return $elements[$delta] = ['#markup' => $message];
+        return  ['#markup' => $message, '#cache' => ['max-age' => 0]];
       }
+
       $embargo_info = $this->embargoResolver->embargoInfo($items->getEntity()->uuid(), $jsondata);
       // This one is for the Twig template
       // We do not need the IP here. No use of showing the IP at all?
@@ -304,6 +305,13 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
         ];
       }
     }
+    $elements['#cache'] = [
+      'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
+      'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
+    ];
+    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+      $elements['#cache']['max-age'] = 0;
+    }
 
     return $elements;
   }
@@ -313,7 +321,6 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
    */
   public function setSetting($key, $value) {
     $this->twig->invalidate();
-
     return parent::setSetting($key, $value);
   }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
@@ -483,6 +483,7 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
     // if hide_on_embargo is not enabled
     // bc all embargo decision will anyways be delegated to the
     // Exposed Metadata endpoints.
+    $embargo_info = [];
     $embargo_context = [];
     $embargo_tags = [];
     $embargoed = FALSE;
@@ -517,7 +518,7 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
       // @TODO use future flatversion precomputed at field level as a property
       $json_error = json_last_error();
       if ($json_error != JSON_ERROR_NONE) {
-        return $elements[$delta] = ['#markup' => $this->t('ERROR')];
+        return ['#markup' => $this->t('ERROR')];
       }
 
       if (isset($jsondata["ap:viewerhints"][$this->getPluginId()]) &&
@@ -656,9 +657,12 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
     }
 
     $elements['#cache'] = [
-      'context' => Cache::mergeContexts($item->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
-      'tags' => Cache::mergeTags($item->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
+      'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
+      'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
+    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+      $elements['#cache']['max-age'] = 0;
+    }
 
     return $elements;
   }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
@@ -464,7 +464,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
             'data'        => $jsondata,
             'node'        => $item->getEntity(),
             'iiif_server' => $this->getIiifUrls()['public'],
-          ];
+          ] + $context_embargo;
           $original_context = $context;
           // Allow other modules to provide extra Context!
           // Call modules that implement the hook, and let them add items.
@@ -542,6 +542,9 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
       'context' => Cache::mergeContexts($item->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($item->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
+    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+      $element['#cache']['max-age'] = 0;
+    }
 
     return $element;
   }
@@ -610,6 +613,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
         }
       }
     }
+
     return $element;
   }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -582,6 +582,9 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
+    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+      $elements['#cache']['max-age'] = 0;
+    }
     return $elements;
   }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
@@ -269,6 +269,9 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
+    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+      $elements['#cache']['max-age'] = 0;
+    }
     return $elements;
   }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryUVFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryUVFormatter.php
@@ -383,6 +383,9 @@ class StrawberryUVFormatter extends StrawberryBaseFormatter implements Container
       'context' => Cache::mergeContexts($item->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($item->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
+    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+      $elements['#cache']['max-age'] = 0;
+    }
     return $elements;
   }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
@@ -332,6 +332,9 @@ class StrawberryVideoFormatter extends StrawberryDirectJsonFormatter {
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
+    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+      $elements['#cache']['max-age'] = 0;
+    }
     return $elements;
   }
 
@@ -346,7 +349,6 @@ class StrawberryVideoFormatter extends StrawberryDirectJsonFormatter {
     $max_height_css = empty($max_height) || $max_height == 0 ? 'auto' : $max_height .'px';
     $nodeuuid = $items->getEntity()->uuid();
     $nodeid = $items->getEntity()->id();
-    $fieldname = $items->getName();
 
     // We assume here file could not be accessible publicly
     $route_parameters = [

--- a/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
@@ -340,6 +340,9 @@ class StrawberryWarcFormatter extends StrawberryDirectJsonFormatter {
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
+    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+      $elements['#cache']['max-age'] = 0;
+    }
     return $elements;
 
   }


### PR DESCRIPTION
See #395 

This has been tested a lot. But I will give my today's self a bit of slack, test again later tonight and merge. Solves the issue with Anonymous users from a different IP/Network seen a stale cache generated by other anonymous users + makes also cache more robust on all viewers +  brings to 2023 the simpler image formatter nobody uses (a "classic")