### PR TITLE
ISSUE-400: Advanced Search Classic mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         }
     ],
     "require": {
-	"drupal/core":"^10.1", 
         "strawberryfield/strawberryfield":"1.3.0.x-dev",
         "league/html-to-markdown":"^5.0.0",
         "erusev/parsedown": "^1.7",
@@ -22,5 +21,8 @@
         "drupal/jquery_ui_effects":"^2.0",
         "ext-json": "*",
 	"seboettg/citeproc-php": "dev-master"
+    },
+    "conflict": {
+        "drupal/core":"<10.1"
     }
 }

--- a/format_strawberryfield.info.yml
+++ b/format_strawberryfield.info.yml
@@ -2,7 +2,7 @@ name: Strawberry Metadata and Media Field Formatters
 description: Provides Various Strawberries field formatters because plain JSON is boring.
 package: Archipelago
 type: module
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^9.5 || ^10.1 || ^10.2
 php: 8
 dependencies:
   - 'drupal:field'

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.libraries.yml
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.libraries.yml
@@ -52,3 +52,4 @@ advanced-search-default-submit:
   dependencies:
     - core/drupal
     - core/jquery
+    - core/once

--- a/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
+++ b/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
@@ -17,8 +17,31 @@
           const $form = defaultSubmitInput.closest('.views-exposed-form');
           let $count = $form.querySelector('input[name="'+$name+'"]');
           if ($count) {
-            $count.value = Number($count.value) + 1;
-            defaultSubmitInput.click();
+            if (ev.target.dataset.advancedSearchMode !== 'undefined' && ev.target.dataset.advancedSearchMax !== 'undefined') {
+              if ($count.value < Number(ev.target.dataset.advancedSearchMax)) {
+                $count.value = Number($count.value) + 1;
+              }
+              if (ev.target.dataset.advancedSearchMode == "true") {
+                if ($count.value <= Number(ev.target.dataset.advancedSearchMax)) {
+                  const $first_hidden_one = $form.querySelector(".hidden[data-advanced-wrapper='true']");
+                  if ($first_hidden_one) {
+                    $first_hidden_one.classList.toggle('hidden');
+                  }
+                }
+                if ($count.value == Number(ev.target.dataset.advancedSearchMax)) {
+                  ev.target.classList.add('hidden');
+                }
+                if ($count.value > Number(ev.target.dataset.advancedSearchMin)) {
+                  const $hidden_del_one = $form.querySelector('.hidden[data-advanced-search-delone]');
+                  if ($hidden_del_one) {
+                    $hidden_del_one.classList.remove('hidden')
+                  }
+                }
+              }
+              else {
+                defaultSubmitInput.click();
+              }
+            }
           }
         }
       };
@@ -31,13 +54,41 @@
           const $form = defaultSubmitInput.closest('.views-exposed-form');
           let $count = $form.querySelector('input[name="'+$name+'"]');
           if ($count) {
-            $count.value = Number($count.value) - 1;
-            const $tounsetSelector = ev.target.dataset.advancedSearchPrefix + '_' + $count.value;
-            let $tounset = $form.querySelector('input[name="' + $tounsetSelector + '"]');
-            if ($tounset) {
-              $tounset.value = '';
+            if (ev.target.dataset.advancedSearchMode !== 'undefined' && ev.target.dataset.advancedSearchMin !== 'undefined') {
+              if ($count.value > Number(ev.target.dataset.advancedSearchMin)) {
+                $count.value = Number($count.value) - 1;
+              }
+              if (ev.target.dataset.advancedSearchMode == "true") {
+                if ($count.value >= Number(ev.target.dataset.advancedSearchMin)) {
+                  const $first_not_hidden_one = $form.querySelector(":not(.hidden)[data-advanced-wrapper='true']");
+                  if ($first_not_hidden_one) {
+                    $first_not_hidden_one.classList.toggle('hidden');
+                    // name^= means starts with.
+                    let $tounset = $first_not_hidden_one.querySelector('input[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
+                    if ($tounset) {
+                      $tounset.value = '';
+                    }
+                  }
+                }
+                if ($count.value == Number(ev.target.dataset.advancedSearchMin)) {
+                  ev.target.classList.add('hidden');
+                }
+                if ($count.value < Number(ev.target.dataset.advancedSearchMax)) {
+                  const $hidden_add_more = $form.querySelector('.hidden[data-advanced-search-addone]');
+                  if ($hidden_add_more) {
+                    $hidden_add_more.classList.remove('hidden')
+                  }
+                }
+              }
+              else {
+                const $tounsetSelector = ev.target.dataset.advancedSearchPrefix + '_' + $count.value;
+                let $tounset = $form.querySelector('input[name="' + $tounsetSelector + '"]');
+                if ($tounset) {
+                  $tounset.value = '';
+                }
+                defaultSubmitInput.click();
+              }
             }
-            defaultSubmitInput.click();
           }
         }
       };

--- a/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
+++ b/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
@@ -66,31 +66,51 @@
               }
               if (ev.target.dataset.advancedSearchMode == "true") {
                 if ($count.value >= Number(ev.target.dataset.advancedSearchMin)) {
-                  let $not_hidden_one = [];
+                  let $not_hidden_one = $form.querySelectorAll(":not(.hidden)[data-advanced-wrapper='true']");
                   if (ev.target.dataset.advancedSearchTarget == "last") {
-                    $not_hidden_one = $form.querySelectorAll(":not(.hidden)[data-advanced-wrapper='true']");
+                    if ($not_hidden_one.length > 0) {
+                      const $last_not_hidden_one = $not_hidden_one[$not_hidden_one.length - 1];
+                      $last_not_hidden_one.classList.toggle('hidden');
+                      // name^= means starts with.
+                      let $tounset = $last_not_hidden_one.querySelector('input[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
+                      if ($tounset) {
+                        $tounset.value = '';
+                      }
+                      let $tounsetselect = $last_not_hidden_one.querySelectorAll('select[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
+                      if ($tounsetselect.length > 0) {
+                        [].forEach.call($tounsetselect, function(el) {
+                          // -1 means nothing which is not the drupal default...
+                          el.selectedIndex = 0;
+                        });
+                      }
+                    }
                   }
                   else if (ev.target.dataset.advancedSearchTarget == "self") {
-                    // I don't use the NodeList object, i just iterate over its members, so this is valid.
-                    $not_hidden_one.push(ev.target.closest(":not(.hidden)[data-advanced-wrapper='true']"));
+                    // But here is the trick. I need to clear this one but hide still the last one...
+                    // and then shift, per wrapper all values one step starting from the one cleared ...
+                    // Side note: there are chances that $not_hidden_one last and $to_clear are the same
+                    // when we are at the "last" remove button.
+                    const $to_clear = ev.target.closest(":not(.hidden)[data-advanced-wrapper='true']");
+                    if ($to_clear) {
+                      // this will clear the values from the current without hiding.
+                      let $tounset = $to_clear.querySelector('input[name^="' + ev.target.dataset.advancedSearchPrefix + '"]');
+                      if ($tounset) {
+                        $tounset.value = '';
+                      }
+                      let $tounsetselect = $to_clear.querySelectorAll('select[name^="' + ev.target.dataset.advancedSearchPrefix + '"]');
+                      if ($tounsetselect.length > 0) {
+                        [].forEach.call($tounsetselect, function (el) {
+                          // -1 means nothing which is not the drupal default...
+                          el.selectedIndex = 0;
+                        });
+                      }
+                    }
+                    // Now, shift values one step back
+                    // Then hide the last.
+                    
                   }
 
-                  if ($not_hidden_one.length > 0) {
-                    const $last_not_hidden_one = $not_hidden_one[$not_hidden_one.length - 1];
-                    $last_not_hidden_one.classList.toggle('hidden');
-                    // name^= means starts with.
-                    let $tounset = $last_not_hidden_one.querySelector('input[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
-                    if ($tounset) {
-                      $tounset.value = '';
-                    }
-                    let $tounsetselect = $last_not_hidden_one.querySelectorAll('select[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
-                    if ($tounsetselect.length > 0) {
-                      [].forEach.call($tounsetselect, function(el) {
-                        // -1 means nothing which is not the drupal default...
-                        el.selectedIndex = 0;
-                      });
-                    }
-                  }
+
                 }
                 if ($count.value == Number(ev.target.dataset.advancedSearchMin)) {
                   ev.target.classList.add('hidden');

--- a/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
+++ b/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
@@ -9,6 +9,11 @@
         }
       };
 
+      var shiftFormElementValues = function (StartWrapper) {
+
+      }
+
+
       var addMoreInterception = function(defaultSubmitInput, ev) {
         ev.preventDefault();
         ev.stopPropagation();
@@ -23,8 +28,9 @@
               }
               if (ev.target.dataset.advancedSearchMode == "true") {
                 if ($count.value <= Number(ev.target.dataset.advancedSearchMax)) {
-                  const $first_hidden_one = $form.querySelector(".hidden[data-advanced-wrapper='true']");
-                  if ($first_hidden_one) {
+                  const $hidden_ones = $form.querySelectorAll(".hidden[data-advanced-wrapper='true']");
+                  if ($hidden_ones) {
+                    const $first_hidden_one = $hidden_ones[0];
                     $first_hidden_one.classList.toggle('hidden');
                   }
                 }
@@ -60,13 +66,21 @@
               }
               if (ev.target.dataset.advancedSearchMode == "true") {
                 if ($count.value >= Number(ev.target.dataset.advancedSearchMin)) {
-                  const $first_not_hidden_one = $form.querySelector(":not(.hidden)[data-advanced-wrapper='true']");
-                  if ($first_not_hidden_one) {
-                    $first_not_hidden_one.classList.toggle('hidden');
+                  const $not_hidden_one = $form.querySelectorAll(":not(.hidden)[data-advanced-wrapper='true']");
+                  if ($not_hidden_one) {
+                    const $last_not_hidden_one = $not_hidden_one[$not_hidden_one.length - 1];
+                    $last_not_hidden_one.classList.toggle('hidden');
                     // name^= means starts with.
-                    let $tounset = $first_not_hidden_one.querySelector('input[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
+                    let $tounset = $last_not_hidden_one.querySelector('input[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
                     if ($tounset) {
                       $tounset.value = '';
+                    }
+                    let $tounsetselect = $last_not_hidden_one.querySelectorAll('select[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
+                    if ($tounsetselect) {
+                      [].forEach.call($tounsetselect, function(el) {
+                        // -1 means nothing which is not the drupal default...
+                        el.selectedIndex = 0;
+                      });
                     }
                   }
                 }

--- a/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
+++ b/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
@@ -29,7 +29,7 @@
               if (ev.target.dataset.advancedSearchMode == "true") {
                 if ($count.value <= Number(ev.target.dataset.advancedSearchMax)) {
                   const $hidden_ones = $form.querySelectorAll(".hidden[data-advanced-wrapper='true']");
-                  if ($hidden_ones) {
+                  if ($hidden_ones.length > 0) {
                     const $first_hidden_one = $hidden_ones[0];
                     $first_hidden_one.classList.toggle('hidden');
                   }
@@ -66,8 +66,16 @@
               }
               if (ev.target.dataset.advancedSearchMode == "true") {
                 if ($count.value >= Number(ev.target.dataset.advancedSearchMin)) {
-                  const $not_hidden_one = $form.querySelectorAll(":not(.hidden)[data-advanced-wrapper='true']");
-                  if ($not_hidden_one) {
+                  let $not_hidden_one = [];
+                  if (ev.target.dataset.advancedSearchTarget == "last") {
+                    $not_hidden_one = $form.querySelectorAll(":not(.hidden)[data-advanced-wrapper='true']");
+                  }
+                  else if (ev.target.dataset.advancedSearchTarget == "self") {
+                    // I don't use the NodeList object, i just iterate over its members, so this is valid.
+                    $not_hidden_one.push(ev.target.closest(":not(.hidden)[data-advanced-wrapper='true']"));
+                  }
+
+                  if ($not_hidden_one.length > 0) {
                     const $last_not_hidden_one = $not_hidden_one[$not_hidden_one.length - 1];
                     $last_not_hidden_one.classList.toggle('hidden');
                     // name^= means starts with.
@@ -76,7 +84,7 @@
                       $tounset.value = '';
                     }
                     let $tounsetselect = $last_not_hidden_one.querySelectorAll('select[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
-                    if ($tounsetselect) {
+                    if ($tounsetselect.length > 0) {
                       [].forEach.call($tounsetselect, function(el) {
                         // -1 means nothing which is not the drupal default...
                         el.selectedIndex = 0;
@@ -125,7 +133,7 @@
       }
       const delOnes = once('sbf-adv-addmore', '.views-exposed-form [data-advanced-search-delone]');
       for (const delOne of delOnes) {
-        let $parent_edit_actions = delOne.closest('[data-drupal-selector="edit-actions"]');
+        let $parent_edit_actions = delOne.closest('.views-exposed-form').querySelector('[data-drupal-selector="edit-actions"]');
         if ($parent_edit_actions) {
           const $submitForAdv = $parent_edit_actions.querySelector('[data-default-submit]');
           if ($submitForAdv) {

--- a/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
+++ b/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
@@ -1,4 +1,4 @@
-(function ($, Drupal) {
+(function ($, Drupal, once) {
   Drupal.behaviors.sbfAdvancedSearchViewsForm = {
     attach(context) {
       var formInterception = function(defaultSubmitInput, ev) {
@@ -42,29 +42,32 @@
         }
       };
 
-      for (const defaultSubmitInput of document.querySelectorAll('.views-exposed-form [data-default-submit]')) {
+      const defaultSubmitInputs = once('sbf-adv-default', '.views-exposed-form [data-default-submit]');
+      for (const defaultSubmitInput of defaultSubmitInputs) {
         for (const formInput of defaultSubmitInput.form.querySelectorAll('input')) {
           formInput.addEventListener('keypress', formInterception.bind(null, defaultSubmitInput));
         }
-        for (const addMore of document.querySelectorAll('.views-exposed-form [data-advanced-search-addone]')) {
-          let $parent_edit_actions = addMore.closest('[data-drupal-selector="edit-actions"]');
-          if ($parent_edit_actions) {
-            const $submitForAdv = $parent_edit_actions.querySelector('[data-default-submit]');
-            if ($submitForAdv) {
-              addMore.addEventListener('click', addMoreInterception.bind(null, $submitForAdv));
-            }
+      }
+      const addMores = once('sbf-adv-addmore', '.views-exposed-form [data-advanced-search-addone]');
+      for (const addMore of addMores) {
+        let $parent_edit_actions = addMore.closest('[data-drupal-selector="edit-actions"]');
+        if ($parent_edit_actions) {
+          const $submitForAdv = $parent_edit_actions.querySelector('[data-default-submit]');
+          if ($submitForAdv) {
+            addMore.addEventListener('click', addMoreInterception.bind(null, $submitForAdv));
           }
         }
-        for (const delOne of document.querySelectorAll('.views-exposed-form [data-advanced-search-delone]')) {
-          let $parent_edit_actions = delOne.closest('[data-drupal-selector="edit-actions"]');
-          if ($parent_edit_actions) {
-            const $submitForAdv = $parent_edit_actions.querySelector('[data-default-submit]');
-            if ($submitForAdv) {
-              delOne.addEventListener('click', delOneInterception.bind(null, $submitForAdv));
-            }
+      }
+      const delOnes = once('sbf-adv-addmore', '.views-exposed-form [data-advanced-search-delone]');
+      for (const delOne of delOnes) {
+        let $parent_edit_actions = delOne.closest('[data-drupal-selector="edit-actions"]');
+        if ($parent_edit_actions) {
+          const $submitForAdv = $parent_edit_actions.querySelector('[data-default-submit]');
+          if ($submitForAdv) {
+            delOne.addEventListener('click', delOneInterception.bind(null, $submitForAdv));
           }
         }
       }
     }
   }
-})(jQuery, Drupal);
+})(jQuery, Drupal, once);

--- a/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
+++ b/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
@@ -104,10 +104,46 @@
                           el.selectedIndex = 0;
                         });
                       }
-                    }
+
                     // Now, shift values one step back
+                    if ($not_hidden_one.length > 0) {
+                      let previous = $to_clear;
+                      let found = false;
+                      [].forEach.call($not_hidden_one, function(el) {
+                        if (!found && el.id == $to_clear.id) {
+                          found = true;
+                          // that way we skip this one too.
+                          return;
+                        }
+                        if (!found) {
+                          return;
+                        }
+                        const $tocopy = el.querySelector('input[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
+                        const $tocopyinto = previous.querySelector('input[name^="' + ev.target.dataset.advancedSearchPrefix + '"]');
+                        if ($tocopy && $tounset) {
+                          $tocopyinto.value = $tocopy.value;
+                        }
+                        let $tocopyselect = el.querySelectorAll('select[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
+                        if ($tocopyselect.length > 0 && $tocopy) {
+                          [].forEach.call($tocopyselect, function(select) {
+                            // fetch the same by data attribute from the previous
+                            const $which = select.dataset.advancedSearchType;
+                            const $sameSelectTo = previous.querySelector('[data-advanced-search-type="'+ $which + '"]');
+                            const currentSelectValue = select.selectedIndex;
+                            if (currentSelectValue && $sameSelectTo) {
+                              $sameSelectTo.selectedIndex = currentSelectValue
+                            }
+                            else if ($sameSelectTo) {
+                              //if null set to the first
+                              $sameSelectTo.selectedIndex = 0;
+                            }
+                          });
+                        }
+                        previous = el;
+                      });
+                    }
                     // Then hide the last.
-                    
+                    }
                   }
 
 

--- a/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
+++ b/modules/format_strawberryfield_views/js/sbf-advanced-search-default-submit.js
@@ -105,50 +105,63 @@
                         });
                       }
 
-                    // Now, shift values one step back
-                    if ($not_hidden_one.length > 0) {
-                      let previous = $to_clear;
-                      let found = false;
-                      [].forEach.call($not_hidden_one, function(el) {
-                        if (!found && el.id == $to_clear.id) {
-                          found = true;
-                          // that way we skip this one too.
-                          return;
+                      // Now, shift values one step back
+                      if ($not_hidden_one.length > 0) {
+                        let previous = $to_clear;
+                        let found = false;
+                        [].forEach.call($not_hidden_one, function(el) {
+                          if (!found && el.id == $to_clear.id) {
+                            found = true;
+                            // that way we skip this one too.
+                            return;
+                          }
+                          if (!found) {
+                            return;
+                          }
+                          const $tocopy = el.querySelector('input[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
+                          const $tocopyinto = previous.querySelector('input[name^="' + ev.target.dataset.advancedSearchPrefix + '"]');
+                          if ($tocopy && $tocopyinto) {
+                            $tocopyinto.value = $tocopy.value;
+                          }
+                          let $tocopyselect = el.querySelectorAll('select[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
+                          if ($tocopyselect.length > 0 && $tocopy) {
+                            [].forEach.call($tocopyselect, function(select) {
+                              // fetch the same by data attribute from the previous
+                              const $which = select.dataset.advancedSearchType;
+                              const $sameSelectTo = previous.querySelector('[data-advanced-search-type="'+ $which + '"]');
+                              const currentSelectValue = select.selectedIndex;
+                              if (currentSelectValue && $sameSelectTo) {
+                                $sameSelectTo.selectedIndex = currentSelectValue
+                              }
+                              else if ($sameSelectTo) {
+                                //if null set to the first
+                                $sameSelectTo.selectedIndex = 0;
+                              }
+                            });
+                          }
+                          previous = el;
+                        });
+                        // Then hide the last.
+                        const $last_not_hidden_one = $not_hidden_one[$not_hidden_one.length - 1];
+                        $last_not_hidden_one.classList.toggle('hidden');
+                        // name^= means starts with.
+                        let $tounset = $last_not_hidden_one.querySelector('input[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
+                        if ($tounset) {
+                          $tounset.value = '';
                         }
-                        if (!found) {
-                          return;
-                        }
-                        const $tocopy = el.querySelector('input[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
-                        const $tocopyinto = previous.querySelector('input[name^="' + ev.target.dataset.advancedSearchPrefix + '"]');
-                        if ($tocopy && $tounset) {
-                          $tocopyinto.value = $tocopy.value;
-                        }
-                        let $tocopyselect = el.querySelectorAll('select[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
-                        if ($tocopyselect.length > 0 && $tocopy) {
-                          [].forEach.call($tocopyselect, function(select) {
-                            // fetch the same by data attribute from the previous
-                            const $which = select.dataset.advancedSearchType;
-                            const $sameSelectTo = previous.querySelector('[data-advanced-search-type="'+ $which + '"]');
-                            const currentSelectValue = select.selectedIndex;
-                            if (currentSelectValue && $sameSelectTo) {
-                              $sameSelectTo.selectedIndex = currentSelectValue
-                            }
-                            else if ($sameSelectTo) {
-                              //if null set to the first
-                              $sameSelectTo.selectedIndex = 0;
-                            }
+                        let $tounsetselect = $last_not_hidden_one.querySelectorAll('select[name^="' +  ev.target.dataset.advancedSearchPrefix + '"]');
+                        if ($tounsetselect.length > 0) {
+                          [].forEach.call($tounsetselect, function(el) {
+                            // -1 means nothing which is not the drupal default...
+                            el.selectedIndex = 0;
                           });
                         }
-                        previous = el;
-                      });
-                    }
-                    // Then hide the last.
+                      }
                     }
                   }
-
-
                 }
-                if ($count.value == Number(ev.target.dataset.advancedSearchMin)) {
+                if ($count.value == Number(ev.target.dataset.advancedSearchMin) && ev.target.dataset.advancedSearchTarget != "self") {
+                  // Don't hide if we are using individual buttons, the last wrapper container already gets hidden.
                   ev.target.classList.add('hidden');
                 }
                 if ($count.value < Number(ev.target.dataset.advancedSearchMax)) {
@@ -159,6 +172,7 @@
                 }
               }
               else {
+                // Normal behavior. Simple stuff
                 const $tounsetSelector = ev.target.dataset.advancedSearchPrefix + '_' + $count.value;
                 let $tounset = $form.querySelector('input[name="' + $tounsetSelector + '"]');
                 if ($tounset) {

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -167,6 +167,30 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
       ],
     ];
 
+    $form['expose']['advanced_search_classic_mode'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Use Classic Mode'),
+      '#description' => $this->t('This mode mimics older catalog search interfaces, where adding/removing fields does not trigger automatic refreshing of the Search results. Search only triggers on the default Form Filter submit button. Fully depends on Javascript to get around Views Exposed Filters in forms always submitting on any interaction. '),
+      '#default_value' => !empty($this->options['expose']['advanced_search_classic_mode']),
+      '#states' => [
+        'visible' => [
+          ':input[name="options[expose][advanced_search_fields_multiple]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    $form['expose']['advanced_search_multiple_remove'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Add a Remove button to every Advanced Search Field combo.'),
+      '#description' => $this->t('This will allow a user to remove a specific Advanced Search Field/And/or/Text. Only works on Classic Mode'),
+      '#default_value' => !empty($this->options['expose']['advanced_search_multiple_remove']),
+      '#states' => [
+        'visible' => [
+          ':input[name="options[expose][advanced_search_classic_mode]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
     $form['expose']['advanced_search_operator_id'] = [
       '#type' => 'textfield',
       '#default_value' => $this->options['expose']['advanced_search_operator_id'],
@@ -628,6 +652,20 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     }
     $return = parent::acceptExposedInput($input);
     // Now do things a bit differently:
+
+    /* $input here is
+    result = {array[8]}
+ sbf_advanced_search_api_fulltext = ""
+ sbf_advanced_search_api_fulltext_searched_fields = ""
+ sbf_advanced_search_api_fulltext_group_operator = "or"
+ sbf_advanced_search_api_fulltext_advanced_search_fields_count = {int} 1
+ submit = "Apply"
+ form_build_id = "form-qFadZL0soLf1yzlfcjPkunovchJ1RloShoCGc9sSP8w"
+ form_id = "views_exposed_form"
+ op = "Apply"
+    */
+
+
     // Value in our case needs to be multiple values (bc of the multiple options)
     if ($return && $realcount = $input[$this->options['expose']['identifier'].'_advanced_search_fields_count']) {
       $this->value = [];
@@ -705,7 +743,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
         $advanced_search_operator_id = $this->options['expose']['advanced_search_operator_id'];
       }
       // Group operators are used to connected multiple exposed forms/groups
-      // for this Filters between each other at query time
+      // for these Filters between each other at query time
       $group_operator = [
         'and' => $this->t('AND'),
         'or'  => $this->t('OR'),
@@ -821,6 +859,10 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     ) {
       return;
     }
+
+    // Note to myself ... interesting .. $form_state->isMethodType('POST') so a direct link will be $form_state->isMethodType('GET') ?
+
+
 
     // Store searched fields.
     $searched_fields_identifier = $this->options['id'] . '_searched_fields';

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -729,6 +729,9 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
         '#multiple' => $this->options['expose']['multiple'] ?? FALSE,
         '#size'     => $multiple_exposed_fields,
         '#default_value' => $form_state->getValue($searched_fields_identifier),
+        '#attributes' => [
+          'data-advanced-search-type' => 'fields'
+        ]
       ];
 
       if (empty($form[$this->options['id'] . '_wrapper'])) {
@@ -760,6 +763,9 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
         '#weight' => '-10',
         '#access' => FALSE,
         '#default_value' => $form_state->getValue($advanced_search_operator_id,'or'),
+        '#attributes' => [
+          'data-advanced-search-type' => 'op'
+        ]
       ];
       $form[$this->options['id'] . '_wrapper'][$advanced_search_operator_id] = $newelements[$advanced_search_operator_id];
     }
@@ -889,6 +895,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
            $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#default_value'] = $form_state->getValue($key.'_'.$i);
            if ($key == $advanced_search_operator_id) {
              $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#access'] = TRUE;
+             $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#attributes']['data-advanced-search-type'] = 'group_op';
            }
          }
        }

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -69,6 +69,8 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     $options['expose']['contains']['advanced_search_fields_remove_one_label'] = ['default' => 'remove one'];
     $options['advanced_search_fields_add_one_label'] = ['default' => ['add one']];
     $options['advanced_search_fields_remove_one_label'] = ['default' => ['remove one']];
+    $options['expose']['contains']['advanced_search_classic_mode'] = ['default' => FALSE];
+    $options['expose']['contains']['advanced_search_multiple_remove'] = ['default' => FALSE];
     $options['fields_label_replace'] = ['default' => NULL];
     return $options;
   }
@@ -80,6 +82,8 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     $this->options['expose']['advanced_search_fields_count'] = 2;
     $this->options['expose']['advanced_search_fields_count_min'] = 1;
     $this->options['expose']['advanced_search_use_operator'] = FALSE;
+    $this->options['expose']['advanced_search_classic_mode'] = FALSE;
+    $this->options['expose']['advanced_search_multiple_remove'] = FALSE;
     $this->options['expose']['advanced_search_operator_id'] = $this->options['id'] . '_group_operator';
     $this->options['expose']['advanced_search_fields_add_one_label'] = $this->options['advanced_search_fields_add_one_label'];
     $this->options['expose']['advanced_search_fields_remove_one_label'] = $this->options['advanced_search_fields_remove_one_label'];

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -767,7 +767,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
     // Yes over complicated but so far the only way i found to keep the state
     // Of this value between calls/rebuilds and searches.
     // @TODO move this into Accept input. That is easier?
-    $nextcount = (int) ($form_state->getUserInput()[$this->options['id'] . '_advanced_search_fields_count'] ?? 1);
+    $nextcount = (int) ($form_state->getUserInput()[$this->options['id'] . '_advanced_search_fields_count'] ?? ($this->options['expose']['advanced_search_fields_count_min'] ?? 1));
     //$prevcount = $this->view->exposed_raw_input[$this->options['id'].'_advanced_search_fields_count'] ?? NULL;
     $form_state_count = $form_state->getValue($this->options['id'] . '_advanced_search_fields_count', NULL);
 
@@ -803,7 +803,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
       ];
 
       // Here is where we need one per row! if enabled.
-
+      // Pass if Classic Mode is enabled as a data property so we can act via JS.
       $form[$this->options['id'].'_delone'] = [
         '#type' => 'link',
         '#title' => t($this->options['expose']['advanced_search_fields_remove_one_label'] ?? 'delete one'),
@@ -811,6 +811,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
         '#attributes' => [
           'data-disable-refocus' => "true",
           'data-advanced-search-delone' => "true",
+          'data-advanced-mode' => $this->options['expose']['advanced_search_classic_mode'] ? "true" : "false",
           'data-advanced-search-min' => $this->options['expose']['advanced_search_fields_count_min'],
           'data-advanced-search-prefix' => $this->options['id'],
           'tabindex' => 3,
@@ -832,11 +833,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
       '#value' => $realcount,
     ];
 
-    // Pass if Classic Mode is enabled as a hidden form element so we can act via JS.
-    $form[$this->options['id'] . '_advanced_search_classic_mode'] = [
-      '#type' => 'hidden',
-      '#value' => $this->options['expose']['advanced_search_classic_mode']
-    ];
+
 
     // Here is where the trick happens if classic mode is enabled. The idea is:
     /* - instead of only rendering the amount (realcount) based on the max/add more
@@ -863,7 +860,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
          }
        }
        $form[$this->options['id'].'_wrapper_'.$i]['#title_display'] = 'invisible';
-       if ($i > max($this->options['expose']['advanced_search_fields_count_min'], $realcount)) {
+       if ($i >= max($this->options['expose']['advanced_search_fields_count_min'], $realcount)) {
          $form[$this->options['id'].'_wrapper_'.$i]['#attributes']['class'] = ['hidden'];
          $form[$this->options['id'].'_wrapper_'.$i]['#attributes']['aria-hidden'] = TRUE;
        }

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -801,6 +801,9 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
         '#weight' => '-100',
         '#group' => 'actions',
       ];
+
+      // Here is where we need one per row! if enabled.
+
       $form[$this->options['id'].'_delone'] = [
         '#type' => 'link',
         '#title' => t($this->options['expose']['advanced_search_fields_remove_one_label'] ?? 'delete one'),
@@ -829,26 +832,66 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
       '#value' => $realcount,
     ];
 
-    for($i=1;$i < $realcount && $realcount > 1; $i++) {
-      foreach ($form[$this->options['id'].'_wrapper'] as $key => $value) {
-        if (strpos($key, '#') !== FALSE) {
-          $form[$this->options['id'].'_wrapper_'.$i][$key] = $value;
-        }
-        else {
-          $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i] = $value;
-        }
-        if ($key == $this->options['expose']['identifier']) {
-          $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#default_value'] = is_array($this->value) ? $this->value[$key.'_'.$i] ?? '' : '';
-        }
-        elseif (is_array($value) && strpos($key, '#') === FALSE) {
-          $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#default_value'] = $form_state->getValue($key.'_'.$i);
-          if ($key == $advanced_search_operator_id) {
-            $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#access'] = TRUE;
-          }
-        }
-      }
-      $form[$this->options['id'].'_wrapper_'.$i]['#title_display'] = 'invisible';
-    }
+    // Pass if Classic Mode is enabled as a hidden form element so we can act via JS.
+    $form[$this->options['id'] . '_advanced_search_classic_mode'] = [
+      '#type' => 'hidden',
+      '#value' => $this->options['expose']['advanced_search_classic_mode']
+    ];
+
+    // Here is where the trick happens if classic mode is enabled. The idea is:
+    /* - instead of only rendering the amount (realcount) based on the max/add more
+         we render all max/allowed ones, but make hide them all the ones that are not
+         originally requested OR without values.
+    */
+   if ($this->options['expose']['advanced_search_classic_mode']) {
+     for($i=1;$i < $this->options['expose']['advanced_search_fields_count']; $i++) {
+       foreach ($form[$this->options['id'].'_wrapper'] as $key => $value) {
+         if (strpos($key, '#') !== FALSE) {
+           $form[$this->options['id'].'_wrapper_'.$i][$key] = $value;
+         }
+         else {
+           $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i] = $value;
+         }
+         if ($key == $this->options['expose']['identifier']) {
+           $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#default_value'] = is_array($this->value) ? $this->value[$key.'_'.$i] ?? '' : '';
+         }
+         elseif (is_array($value) && strpos($key, '#') === FALSE) {
+           $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#default_value'] = $form_state->getValue($key.'_'.$i);
+           if ($key == $advanced_search_operator_id) {
+             $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#access'] = TRUE;
+           }
+         }
+       }
+       $form[$this->options['id'].'_wrapper_'.$i]['#title_display'] = 'invisible';
+     }
+   }
+   else {
+     // Normal behavior
+     for($i=1;$i < $realcount && $realcount > 1; $i++) {
+       foreach ($form[$this->options['id'].'_wrapper'] as $key => $value) {
+         if (strpos($key, '#') !== FALSE) {
+           $form[$this->options['id'].'_wrapper_'.$i][$key] = $value;
+         }
+         else {
+           $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i] = $value;
+         }
+         if ($key == $this->options['expose']['identifier']) {
+           $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#default_value'] = is_array($this->value) ? $this->value[$key.'_'.$i] ?? '' : '';
+         }
+         elseif (is_array($value) && strpos($key, '#') === FALSE) {
+           $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#default_value'] = $form_state->getValue($key.'_'.$i);
+           if ($key == $advanced_search_operator_id) {
+             $form[$this->options['id'].'_wrapper_'.$i][$key.'_'.$i]['#access'] = TRUE;
+           }
+         }
+       }
+       $form[$this->options['id'].'_wrapper_'.$i]['#title_display'] = 'invisible';
+     }
+   }
+
+
+
+
     $form = $form;
   }
 

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -844,7 +844,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
          originally requested OR without values.
     */
    if ($this->options['expose']['advanced_search_classic_mode']) {
-     for($i=1;$i < $this->options['expose']['advanced_search_fields_count']; $i++) {
+     for($i=1; $i < $this->options['expose']['advanced_search_fields_count']; $i++) {
        foreach ($form[$this->options['id'].'_wrapper'] as $key => $value) {
          if (strpos($key, '#') !== FALSE) {
            $form[$this->options['id'].'_wrapper_'.$i][$key] = $value;
@@ -863,6 +863,10 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
          }
        }
        $form[$this->options['id'].'_wrapper_'.$i]['#title_display'] = 'invisible';
+       if ($i > max($this->options['expose']['advanced_search_fields_count_min'], $realcount)) {
+         $form[$this->options['id'].'_wrapper_'.$i]['#attributes']['class'] = ['hidden'];
+         $form[$this->options['id'].'_wrapper_'.$i]['#attributes']['aria-hidden'] = TRUE;
+       }
      }
    }
    else {

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -815,7 +815,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
       if ($enable_more && $this->options['expose']['advanced_search_classic_mode'] && $realcount == $this->options['expose']['advanced_search_fields_count']) {
         $form[$this->options['id'] . '_addone']['#attributes']['class'][] = 'hidden';
       }
-      $multiple_delone = $this->options['expose']['advanced_search_classic_mode'] && $this->options['expose']['advanced_search_fields_multiple'];
+      $multiple_delone = $this->options['expose']['advanced_search_classic_mode'] && $this->options['expose']['advanced_search_multiple_remove'];
 
       // Here is where we need one per row! if enabled.
       // Pass if Classic Mode is enabled as a data property so we can act via JS.


### PR DESCRIPTION
See #400 

This is ready to be tested.

New settings:

![image](https://github.com/esmero/format_strawberryfield/assets/6946023/ebee2f9a-60e7-4056-b634-d879a6c52957)


Classic mode basically uses JS for everything but keeps the sequential logic of fields named with a suffix `_$count` and ordered. Does not solve the other need (facet summaries)