### PR TITLE
ISSUE-412: Tested on production. Finally IP embargoes can cut the Cache crap

### DIFF
--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -268,7 +268,10 @@ function format_strawberryfield_contextual_links_alter(array &$links, $group, ar
  * Implements hook_ENTITY_TYPE_view_alter().
  */
 function format_strawberryfield_node_view_alter(&$build, EntityInterface $entity, EntityDisplayInterface $display) {
-  // Empty. Issue is if this hook does not exist, the broader one will fail.
+    $resolved_embargo = \Drupal::service('format_strawberryfield.embargo_resolver')->getResolvedEmbargoesByUUid($entity->uuid());
+    if (($resolved_embargo[3] ?? TRUE) == FALSE) {
+      $build['#cache']['max-age'] = 0;
+    }
 }
 
 /**

--- a/src/Controller/MetadataExposeDisplayController.php
+++ b/src/Controller/MetadataExposeDisplayController.php
@@ -326,7 +326,7 @@ class MetadataExposeDisplayController extends ControllerBase {
           $response->getCacheableMetadata()->addCacheTags($embargo_tags);
           $response->getCacheableMetadata()->addCacheContexts(['user.roles']);
           $response->getCacheableMetadata()->addCacheContexts($embargo_context);
-          if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+          if (isset($embargo_info[3]) && $embargo_info[3] === FALSE) {
             $response->getCacheableMetadata()->setCacheMaxAge(0);
           }
         }

--- a/src/EmbargoResolver.php
+++ b/src/EmbargoResolver.php
@@ -50,6 +50,14 @@ class EmbargoResolver implements EmbargoResolverInterface {
 
 
   /**
+   * A Per HTTP Request static cache of resolved Embargoes
+   *
+   * @var array
+   */
+  protected array $resolvedEmbargos = [];
+
+
+  /**
    * DisplayResolver constructor.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
@@ -160,8 +168,22 @@ class EmbargoResolver implements EmbargoResolverInterface {
       $embargo_info = [!$noembargo, $date_embargo ? $date: FALSE , $ip_embargo, $cacheable];
     }
     $cache[$cache_id] = $embargo_info;
+    $this->resolvedEmbargos[$uuid] = $embargo_info;
     return $embargo_info;
   }
+
+  /**
+   * Getter for the resolved Static embargoe Cache
+   *
+   * @param string $uuid
+   *    The UUID of a node for which an embargo might/not have been resolved
+   * @return array
+   *    The embargo info in [!$noembargo, $date_embargo ? $date: FALSE , $ip_embargo, $cacheable];
+   */
+  public function getResolvedEmbargoesByUUid(string $uuid): array {
+    return $this->resolvedEmbargos[$uuid] ?? [];
+  }
+
 
   /**
    * Get a list of ADO types based on the SBF.

--- a/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
@@ -341,7 +341,7 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
-    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+    if (isset($embargo_info[3]) && $embargo_info[3] === FALSE) {
       $elements['#cache']['max-age'] = 0;
     }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
@@ -304,7 +304,7 @@ class StrawberryAudioFormatter extends StrawberryDirectJsonFormatter {
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
-    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+    if (isset($embargo_info[3]) && $embargo_info[3] === FALSE) {
       $elements['#cache']['max-age'] = 0;
     }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryCitationFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryCitationFormatter.php
@@ -384,7 +384,7 @@ class StrawberryCitationFormatter extends StrawberryBaseFormatter {
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
 
-    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+    if (isset($embargo_info[3]) && $embargo_info[3] === FALSE) {
       $elements['#cache']['max-age'] = 0;
     }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -216,7 +216,7 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
-    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+    if (isset($embargo_info[3]) && $embargo_info[3] === FALSE) {
       $elements['#cache']['max-age'] = 0;
     }
     return $elements;

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -352,7 +352,7 @@ Not all options can be overriden. `id`,`tileSources`, `element` and other might 
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
-    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+    if (isset($embargo_info[3]) && $embargo_info[3] === FALSE) {
       $elements['#cache']['max-age'] = 0;
     }
     return $elements;

--- a/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
@@ -245,7 +245,8 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
           $embargo_tags[]= 'format_strawberryfield:embargo:'.$embargo_info[1];
           $context_embargo['data_embargo']['until'] = $embargo_info[1];
         }
-        if ($embargo_info[2]) {
+        // even if not embargoed for a particular user, set to IP if not cacheable
+        if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
           $embargo_context[] = 'ip';
         }
       }
@@ -309,7 +310,7 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
-    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+    if (isset($embargo_info[3]) && $embargo_info[3] === FALSE) {
       $elements['#cache']['max-age'] = 0;
     }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
@@ -660,7 +660,7 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
-    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+    if (isset($embargo_info[3]) && $embargo_info[3] === FALSE) {
       $elements['#cache']['max-age'] = 0;
     }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
@@ -542,7 +542,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
       'context' => Cache::mergeContexts($item->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($item->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
-    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+    if (isset($embargo_info[3]) && $embargo_info[3] === FALSE) {
       $element['#cache']['max-age'] = 0;
     }
 

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -582,7 +582,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
-    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+    if (isset($embargo_info[3]) && $embargo_info[3] === FALSE) {
       $elements['#cache']['max-age'] = 0;
     }
     return $elements;

--- a/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
@@ -269,7 +269,7 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
-    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+    if (isset($embargo_info[3]) && $embargo_info[3] === FALSE) {
       $elements['#cache']['max-age'] = 0;
     }
     return $elements;

--- a/src/Plugin/Field/FieldFormatter/StrawberryUVFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryUVFormatter.php
@@ -383,7 +383,7 @@ class StrawberryUVFormatter extends StrawberryBaseFormatter implements Container
       'context' => Cache::mergeContexts($item->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($item->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
-    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+    if (isset($embargo_info[3]) && $embargo_info[3] === FALSE) {
       $elements['#cache']['max-age'] = 0;
     }
     return $elements;

--- a/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
@@ -332,7 +332,7 @@ class StrawberryVideoFormatter extends StrawberryDirectJsonFormatter {
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
-    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+    if (isset($embargo_info[3]) && $embargo_info[3] === FALSE) {
       $elements['#cache']['max-age'] = 0;
     }
     return $elements;

--- a/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
@@ -340,7 +340,7 @@ class StrawberryWarcFormatter extends StrawberryDirectJsonFormatter {
       'context' => Cache::mergeContexts($items->getEntity()->getCacheContexts(), ['user.permissions', 'user.roles'], $embargo_context),
       'tags' => Cache::mergeTags($items->getEntity()->getCacheTags(), $embargo_tags, ['config:format_strawberryfield.embargo_settings']),
     ];
-    if (isset($embargo_info[4]) && $embargo_info[4] === FALSE) {
+    if (isset($embargo_info[3]) && $embargo_info[3] === FALSE) {
       $elements['#cache']['max-age'] = 0;
     }
     return $elements;


### PR DESCRIPTION
see #412 

This pull makes something wonderful. Embargoes are still resolved per Entity. (and I can do better I know and will) on each SBF formatter call/exposed endpoint etc. But the response is statically cached and accumulated during an HTTP request (means 10 fields == 1 calculation). We still `kill` the page cache & dynamic cache if there is an IP embargo for an object (even if resolves to not embargoed bc there is no context/saved data in Drupal I can use to differentiate on Anonymous from another, all comes in the request itself), but also (to make Drupal's weirdness/lack of consistency) happy, just after the  View Mode/Display (ignoring the internal render array elements) decides to cache everything, we make the cache time to live == 0 for the whole Node. And bum. It works.

How to test this works.

Add to an embargoed object the proper IP allowanced metadata and on the same Object, in the Description template add this:

```Twig
{{ "now"|date("F jS \\a\\t g:ia") }}
```

Notice that if accessing the ADO as an anonymous, the time will be changing/dynamically. If accessing the same ADO as an `admin` the last time it was cached it will stay fixed (reload see how nothing changes). Same for Objects (anonymous and not) that have no embargo. Cached once, served from there on.

Anyhow. I need a life

