### PR TITLE
Issue-414--leaflet-options --> 1.3.0

### DIFF
--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -662,6 +662,9 @@ field.formatter.settings.strawberry_map_formatter:
     min_zoom:
       type: integer
       label: 'Min Zoom for the Map'
+    disable_mouse_zoom:
+      type: string
+      label: "Disable mouse wheel zoom"
     tilemap_url:
       type: string
       label: 'Tile Map URL'

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -663,7 +663,7 @@ field.formatter.settings.strawberry_map_formatter:
       type: integer
       label: 'Min Zoom for the Map'
     disable_mouse_zoom:
-      type: string
+      type: boolean
       label: "Disable mouse wheel zoom"
     tilemap_url:
       type: string

--- a/js/leaflet_strawberry.js
+++ b/js/leaflet_strawberry.js
@@ -46,8 +46,12 @@
             if (drupalSettings.format_strawberryfield.leaflet[element_id]['initialzoom'] || drupalSettings.format_strawberryfield.leaflet[element_id]['initialzoom'] === 0) {
               $initialzoom = drupalSettings.format_strawberryfield.leaflet[element_id]['initialzoom'];
             }
+            var $scrollWheelZoom = !drupalSettings.format_strawberryfield.leaflet[element_id]['disable_mouse_zoom'];
             // initialize the map
-            var map = L.map(element_id).setView([40.1, -100], $initialzoom);
+            var map = L.map(
+              element_id,
+              {scrollWheelZoom: $scrollWheelZoom}
+            ).setView([40.1, -100], $initialzoom);
             // Use current's user lat/long
             // Does not work without HTTPS
             //  map.locate({setView: true, maxZoom: 8});

--- a/js/leaflet_strawberry.js
+++ b/js/leaflet_strawberry.js
@@ -46,7 +46,14 @@
             if (drupalSettings.format_strawberryfield.leaflet[element_id]['initialzoom'] || drupalSettings.format_strawberryfield.leaflet[element_id]['initialzoom'] === 0) {
               $initialzoom = drupalSettings.format_strawberryfield.leaflet[element_id]['initialzoom'];
             }
-            var $scrollWheelZoom = !drupalSettings.format_strawberryfield.leaflet[element_id]['disable_mouse_zoom'];
+
+            var $scrollWheelZoom = true;
+
+            if( typeof drupalSettings.format_strawberryfield.leaflet[element_id]['disable_mouse_zoom'] !== 'undefined') {
+              // Use the "truthy" value of the disable_mouse_zoom setting to determine if we should disable scroll wheel zoom
+                $scrollWheelZoom = !(!!drupalSettings.format_strawberryfield.leaflet[element_id]['disable_mouse_zoom']);
+            }
+
             // initialize the map
             var map = L.map(
               element_id,

--- a/src/Plugin/Field/FieldFormatter/StrawberryMapFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMapFormatter.php
@@ -150,6 +150,7 @@ class StrawberryMapFormatter extends StrawberryBaseFormatter implements Containe
         'max_zoom' => 10,
         'min_zoom' => 2,
         'initial_zoom' => 5,
+        'disable_mouse_zoom' => FALSE,
       ];
   }
 
@@ -476,10 +477,11 @@ class StrawberryMapFormatter extends StrawberryBaseFormatter implements Containe
           '#type' => 'number',
           '#title' => $this->t('Maximum height'),
           '#default_value' => $this->getSetting('max_height'),
+          '#description' => $this->t('The minimum permitted value is 62 pixels to ensure that the zoom controls are visible on the map.'),
           '#size' => 5,
           '#maxlength' => 5,
           '#field_suffix' => $this->t('pixels'),
-          '#min' => 0,
+          '#min' => 62,
           '#required' => TRUE
         ],
         'initial_zoom' => [
@@ -509,6 +511,12 @@ class StrawberryMapFormatter extends StrawberryBaseFormatter implements Containe
           '#maxlength' => 2,
           '#min' => 0,
           '#max' => 22,
+        ],
+        'disable_mouse_zoom' => [
+          '#type' => 'checkbox',
+          '#title' => $this->t('Disable mouse wheel zoom'),
+          '#description' => $this->t('If checked, scrolling the page will not suddenly zoom in or out of the map. This is useful for maps that are not the main focus of the page. The user can still zoom in and out using the +/- buttons, and double-clicking/shift-double-clicking the mouse.'),
+          '#default_value' => $this->getSetting('disable_mouse_zoom'),
         ],
       ] + parent::settingsForm($form, $form_state);
     return $settings_form;
@@ -745,11 +753,12 @@ class StrawberryMapFormatter extends StrawberryBaseFormatter implements Containe
     }
 
     $summary[] = $this->t(
-      'Zoom Levels: Min(%min_zoom)|Max(%max_zoom)|Initial(%initial_zoom)',
+      'Zoom Levels: Min(%min_zoom)|Max(%max_zoom)|Initial(%initial_zoom)|Mouse Wheel Zoom: %disable_mouse_zoom',
       [
         '%min_zoom' => (int) $this->getSetting('min_zoom'),
         '%max_zoom' => $this->getSetting('max_zoom'),
         '%initial_zoom' => $this->getSetting('initial_zoom'),
+        '%disable_mouse_zoom' => $this->getSetting('disable_mouse_zoom') ? 'Disabled' : 'Enabled',
       ]
     );
 
@@ -920,11 +929,12 @@ class StrawberryMapFormatter extends StrawberryBaseFormatter implements Containe
           $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['leaflet'][$htmlid]['width'] = $max_width_css;
           $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['leaflet'][$htmlid]['height'] = max(
             $max_height,
-            480
+            62 // 62 pixels is the minimum height to display the +/- buttons in the map interface.
           );
           $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['leaflet'][$htmlid]['maxzoom'] = $this->getSetting('max_zoom');
           $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['leaflet'][$htmlid]['minzoom'] = $this->getSetting('min_zoom');
           $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['leaflet'][$htmlid]['initialzoom'] = $this->getSetting('initial_zoom');
+          $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['leaflet'][$htmlid]['disable_mouse_zoom'] = $this->getSetting('disable_mouse_zoom');
 
           $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['leaflet'][$htmlid]['tilemap_url'] = $this->getSetting('tilemap_url');
           $elements[$delta]['media']['#attached']['drupalSettings']['format_strawberryfield']['leaflet'][$htmlid]['tilemap_attribution'] = $this->getSetting('tilemap_attribution');


### PR DESCRIPTION
### What
- Added leaflet map option for 'Disable mouse wheel zoom'. 
- Reduced the minimum allowable leaflet map height to 62px, which guarantees that the +/- buttons will display while permitting map heights smaller than 480 pixels.

### To Test:
- Edit "Map Display for Digital Objects SQL view (`/admin/structure/views/view/map_display_for_digital_objects_sql`) view
- Click on the field settings for "Content: 🍓 Strawberry (Descriptive Metadata source)" to bring up the configuration form for that field.
- Test the view with different values for "Maximum height". Any height equal to or larger than 62 pixels should be able to be saved, and should be reflected in height of the map that is displayed when the view is rendered for an object.
- Set the "Disable mouse wheel zoom" checkbox to unchecked (it's the default) and save the view. When viewing the map, scrolling the mouse wheel should cause the map to zoom in and out.
- Check the "Disable mouse wheel zoom" checkbox and save the view. Now, using the mouse wheel to scroll the page that the map is rendered on should not cause the map to zoom when the cursor enters the map area.

