### PR TITLE
ISSUE-427: Adds data property (HTML) driven on click or on load Views loading via AJAX

### DIFF
--- a/modules/format_strawberryfield_views/format_strawberryfield_views.libraries.yml
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.libraries.yml
@@ -8,6 +8,7 @@ leaflet_strawberry_views:
     - core/drupal
     - core/drupalSettings
     - core/views
+    - views/views.ajax
     - format_strawberryfield/leaflet_ajax
     - format_strawberryfield/iiif_formatstrawberryfield_utils
 
@@ -20,7 +21,7 @@ modal-exposed-form-views-ajax:
     - core/once
     - core/drupalSettings
     - core/views
-    - core/views.ajax
+    - views/views.ajax
 modal-exposed-form-facet-views-ajax:
   js:
     js/facets-views-ajax.js: {minified: false}
@@ -28,7 +29,7 @@ modal-exposed-form-facet-views-ajax:
     - facets/widget
     - core/drupalSettings
     - core/drupal.ajax
-    - core/views.ajax
+    - views/views.ajax
     - core/once
 
 view-ajax-interactions:
@@ -40,7 +41,7 @@ view-ajax-interactions:
     - core/once
     - core/drupalSettings
     - core/views
-    - core/views.ajax
+    - views/views.ajax
     - format_strawberryfield/iiif_formatstrawberryfield_utils
 
 advanced-search-default-submit:
@@ -53,3 +54,16 @@ advanced-search-default-submit:
     - core/drupal
     - core/jquery
     - core/once
+
+views-ajax-dynamic:
+  version: 1.x
+  js:
+    js/sbf-views-ajax-dynamic.js: {minified: false}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/once
+    - core/drupal.ajax
+    - core/drupalSettings
+    - core/views
+    - views/views.ajax

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.libraries.yml
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.libraries.yml
@@ -22,6 +22,16 @@ modal-exposed-form-views-ajax:
     - core/drupalSettings
     - core/views
     - views/views.ajax
+modal-exposed-form-views-interactions:
+  js:
+    js/modal-exposed-form-interactions.js: {minified: false}
+  dependencies:
+    - core/drupal
+    - core/jquery
+    - core/once
+    - core/drupalSettings
+    - core/views
+
 modal-exposed-form-facet-views-ajax:
   js:
     js/facets-views-ajax.js: {minified: false}

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.module
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.module
@@ -7,6 +7,7 @@
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Template\Attribute;
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Utility\Error as ErrorAlias;
 use Drupal\views\ViewExecutable;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\Core\Block\BlockPluginInterface;
@@ -212,7 +213,7 @@ function format_strawberryfield_views_views_data_alter(array &$data) {
       $args = [
         '%index' => $index->label(),
       ];
-      watchdog_exception('format_strawberryfield_views', $e, '%type while computing Views data for index %index: @message in %function (line %line of %file).', $args);
+      ErrorAlias::logException('format_strawberryfield_views', $e, '%type while computing Views data for index %index: @message in %function (line %line of %file).', $args);
     }
   }
   return $data;
@@ -257,11 +258,15 @@ function format_strawberryfield_views_library_info_alter(&$libraries, $extension
 function format_strawberryfield_views_views_pre_render(ViewExecutable $view) {
   $current_display = $view->current_display;
   $view_config = $view->storage->getDisplay($current_display);
-  if (!empty($view_config['display_options']['display_extenders']['sbf_ajax_interactions'])) {
+  if (!empty($view_config['display_options']['display_extenders']['sbf_ajax_interactions'] ?? NULL)) {
     if ($view_config['display_options']['display_extenders']['sbf_ajax_interactions']) {
       $view->element['#attached']['library'][] = 'format_strawberryfield_views/view-ajax-interactions';
       $view->element['#attached']['drupalSettings']['sbf_ajax_interactions'][$view->dom_id] = $view_config['display_options']['display_extenders']['sbf_ajax_interactions']['sbf_ajax_interactions_arguments'];
     }
   }
+}
+
+function format_strawberryfield_views_page_attachments(array &$page) {
+  $page['#attached']['library'][] = "format_strawberryfield_views/views-ajax-dynamic";
 }
 

--- a/modules/format_strawberryfield_views/format_strawberryfield_views.routing.yml
+++ b/modules/format_strawberryfield_views/format_strawberryfield_views.routing.yml
@@ -4,3 +4,9 @@ exposed_views_form_modal.block.ajax:
     _controller: '\Drupal\format_strawberryfield_views\Controller\ViewsExposedFormModalBlockAjaxController::ajaxExposedFormBlockView'
   requirements:
     _access: 'TRUE'
+format_strawberryfield_views.views.sajax:
+  path: '/sbf/views-ajax'
+  defaults:
+    _controller: '\Drupal\format_strawberryfield_views\Controller\FormatStrawberryfieldViewAjaxController::ajaxViewAdd'
+  requirements:
+    _access: 'TRUE'

--- a/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
+++ b/modules/format_strawberryfield_views/js/modal-exposed-form-ajax.js
@@ -125,7 +125,7 @@
     }
   };
 
-  // Helper function, return modal view blocks blocks with a given submit URL
+  // Helper function, return modal view blocks with a given submit URL
   var modalViewsFormBlocks = function (url) {
     // Get all ajax modal view blocks from the current page.
     var modalviews_blocks = {};

--- a/modules/format_strawberryfield_views/js/modal-exposed-form-interactions.js
+++ b/modules/format_strawberryfield_views/js/modal-exposed-form-interactions.js
@@ -18,18 +18,29 @@
     attach: function (context, drupalSettings) {
       this.onChangeHandler = function(event) {
         // Get first the closes Form to the target. WE want to exclude it from the copy destination
-        const selfForm = event.target.closest('form')
-        const othersame_inputs = document.querySelectorAll('div[data-drupal-modalblock-selector] form:not(#'+selfForm.id+') input[name='+event.target.name+']');
-        othersame_inputs.forEach(function (targetElement) {
-          targetElement.value = event.target.value;
-        });
+        const selfForm = event.target.closest('div[data-sbf-modalblock-copytothers=true] form');
+        if (selfForm) {
+          const othersame_inputs = document.querySelectorAll('div[data-drupal-modalblock-selector] form:not(#' + selfForm.id + ') input[name=' + event.target.name + ']');
+          othersame_inputs.forEach(function (targetElement) {
+            targetElement.value = event.target.value;
+          });
+        }
+        // Note that hidden is allowed bc there might be cases where we override Selects to use Bootstrap components. So the
+        // original value/and trigger is the hidden element after being set by the component.
+        const allowed_autosubmit_types = ['select', 'checkbox', 'radio', 'hidden'];
+        if (allowed_autosubmit_types.includes(event.target.type)) {
+          const autosubmit_form = event.target.closest('div[data-sbf-modalblock-autosubmit=true] form');
+          if (autosubmit_form) {
+            autosubmit_form.submit();
+          }
+        }
       };
       var $context = $(context);
       this.attachModalFormInteractions = function (input) {
         input.addEventListener("change", this.onChangeHandler);
         //const $combined_view = $input.data('drupal-target-view');
       }
-      if ($context.is('div[ata-sbf-modalblock-copytothers=true]')) {
+      if ($context.is('div[ata-sbf-modalblock-copytothers=true], div[data-sbf-modalblock-autosubmit=true] form')) {
         var $that = this;
         once('modal-block-form', 'form', context).forEach(function (value, index) {
             $that.attachModalFormInteractions(value);
@@ -37,7 +48,7 @@
       }
       else {
         var $that = this;
-        once('modal-block-form', 'div[data-sbf-modalblock-copytothers=true] form', context).forEach(function (value, index) {
+        once('modal-block-form', 'div[data-sbf-modalblock-copytothers=true] form, div[data-sbf-modalblock-autosubmit=true] form', context).forEach(function (value, index) {
             $that.attachModalFormInteractions(value);
         });
       }

--- a/modules/format_strawberryfield_views/js/modal-exposed-form-interactions.js
+++ b/modules/format_strawberryfield_views/js/modal-exposed-form-interactions.js
@@ -1,0 +1,47 @@
+/**
+ * @file
+ * Copy values from visible to hidden ones between exposed elements inside Modal Exposed Views Forms
+ */
+
+
+(function ($, Drupal, once, drupalSettings) {
+  'use strict';
+
+
+  Drupal.behaviors.sbfModalExposedFormViewsInteractions = {
+
+    detach: function (context, drupalSettings, trigger) {
+      if (trigger === 'unload') {
+        //@see https://www.drupal.org/node/3158256
+      }
+    },
+    attach: function (context, drupalSettings) {
+      this.onChangeHandler = function(event) {
+        // Get first the closes Form to the target. WE want to exclude it from the copy destination
+        const selfForm = event.target.closest('form')
+        const othersame_inputs = document.querySelectorAll('div[data-drupal-modalblock-selector] form:not(#'+selfForm.id+') input[name='+event.target.name+']');
+        othersame_inputs.forEach(function (targetElement) {
+          targetElement.value = event.target.value;
+        });
+      };
+      var $context = $(context);
+      this.attachModalFormInteractions = function (input) {
+        input.addEventListener("change", this.onChangeHandler);
+        //const $combined_view = $input.data('drupal-target-view');
+      }
+      if ($context.is('div[ata-sbf-modalblock-copytothers=true]')) {
+        var $that = this;
+        once('modal-block-form', 'form', context).forEach(function (value, index) {
+            $that.attachModalFormInteractions(value);
+        });
+      }
+      else {
+        var $that = this;
+        once('modal-block-form', 'div[data-sbf-modalblock-copytothers=true] form', context).forEach(function (value, index) {
+            $that.attachModalFormInteractions(value);
+        });
+      }
+    }
+  };
+})(jQuery, Drupal, once, drupalSettings);
+

--- a/modules/format_strawberryfield_views/js/sbf-views-ajax-dynamic.js
+++ b/modules/format_strawberryfield_views/js/sbf-views-ajax-dynamic.js
@@ -1,0 +1,112 @@
+(function ($, Drupal, drupalSettings) {
+
+  function loadViewOnEvent(e) {
+    let base = e.target.id;
+    // Retrieve the path to use for views' ajax.
+    let ajaxPath = drupalSettings.views.ajax_path ?? '/views/ajax' ;
+
+    // If there are multiple views this might've ended up showing up multiple
+    // times.
+    if (ajaxPath.constructor.toString().indexOf('Array') !== -1) {
+      ajaxPath = ajaxPath[0];
+    }
+
+    // Check if there are any GET parameters to send to views.
+    let queryString = window.location.search || '';
+    if (queryString !== '') {
+      // Remove the question mark and Drupal path component if any.
+      queryString = queryString
+        .slice(1)
+        .replace(/q=[^&]+&?|&?render=[^&]+/, '');
+      if (queryString !== '') {
+        // If there is a '?' in ajaxPath, clean URL are on and & should be
+        // used to add parameters.
+        queryString = (/\?/.test(ajaxPath) ? '&' : '?') + queryString;
+      }
+    }
+
+    const base_views_settings =  {
+      view_name: e.currentTarget.dataset.sbfViewId,
+      view_display_id: e.currentTarget.dataset.sbfViewDisplayId,
+      //@TODO use the argument separator settings here.
+      view_args: e.currentTarget.dataset.sbfViewArguments,
+      view_dom_id: e.currentTarget.dataset.sbfViewRenderTarget,
+      views_path: window.location.pathname,
+    };
+    let submit_settings =
+      $.extend(
+        {},
+        base_views_settings,
+      );
+
+    const element_settings = {
+      url: drupalSettings.path.baseUrl + drupalSettings.path.pathPrefix + 'sbf/views-ajax' + queryString,
+      event: 'loadView',
+      base: base,
+      element: e.currentTarget,
+      httpMethod: "GET",
+      progress: {
+        type: 'throbber'
+      },
+      submit: submit_settings
+      /* {
+       view_name: "solr_search_content",
+       view_display_id: "grid",
+       view_args: "",
+       view_path: "/search_grid",
+       view_base_path: "search_grid"
+     }*/
+
+    };
+    /*
+        event: "RefreshView"
+
+        httpMethod: "GET"
+
+        progress: {type: "fullscreen"}
+
+        selector: ".js-view-dom-id-528e1cb3d57bc28e7da980750fff6a29c3da664d1370e9aca859ac188823b32d"
+
+        setClick: true
+
+        submit: {view_name: "solr_search_content", view_display_id: "grid", view_args: "", view_path: "/search_grid", view_base_path: "search_grid", …}
+
+        url: "/views/ajax?search_api_fulltext=&op=Search"
+        */
+
+
+
+    //Drupal.ajax[base] =
+    let ajaxObject = new Drupal.ajax(element_settings);
+    ajaxObject.execute();
+  };
+
+  Drupal.behaviors.sbf_views_ajax_interactions = {
+    attach: function (context, settings) {
+      // the data attributes one can use
+      // [data-sbf-view-id="machine_name_of_a_view"]
+      // [data-sbf-view-display-id="machine_name_of_the_views_display"]
+      // [data-sbf-view-arguments="one,two,tree"]
+      const elementsToAttach = once('data-sbf-views', '[data-sbf-view-id]', context);
+      elementsToAttach.forEach(function (value, index) {
+        console.log("initializing 'Ajax Dynamic Views'");
+        // Requires an ID.
+        if (value?.dataset?.sbfViewId &&
+          value?.dataset?.sbfViewDisplayId &&
+          value?.dataset?.sbfViewRenderTarget &&
+          value?.id
+        ) {
+
+          let event = value?.dataset?.sbfViewEvent
+          if (typeof(event == "undefined")) {
+            event = "click";
+          }
+          if (['click','load'].includes(event)) {
+            value.addEventListener(event, loadViewOnEvent, {passive: true, once: true});
+          }
+        }
+      });
+    }
+  }
+})(jQuery, Drupal, drupalSettings);
+

--- a/modules/format_strawberryfield_views/js/sbf-views-ajax-dynamic.js
+++ b/modules/format_strawberryfield_views/js/sbf-views-ajax-dynamic.js
@@ -3,7 +3,7 @@
   function loadViewOnEvent(e) {
     let base = e.target.id;
     // Retrieve the path to use for views' ajax.
-    let ajaxPath = drupalSettings.views.ajax_path ?? '/views/ajax' ;
+    let ajaxPath = drupalSettings?.views?.ajax_path ?? '/views/ajax' ;
 
     // If there are multiple views this might've ended up showing up multiple
     // times.

--- a/modules/format_strawberryfield_views/js/sbf-views-ajax-dynamic.js
+++ b/modules/format_strawberryfield_views/js/sbf-views-ajax-dynamic.js
@@ -98,7 +98,7 @@
         ) {
 
           let event = value?.dataset?.sbfViewEvent
-          if (typeof(event == "undefined")) {
+          if (typeof(event) == "undefined") {
             event = "click";
           }
           if (['click','load'].includes(event)) {

--- a/modules/format_strawberryfield_views/js/sbf-views-ajax-dynamic.js
+++ b/modules/format_strawberryfield_views/js/sbf-views-ajax-dynamic.js
@@ -1,6 +1,9 @@
 (function ($, Drupal, drupalSettings) {
 
-  function loadViewOnEvent(e) {
+  function loadViewOnClickEvent(e) {
+    // If using the load even we can't relay on the target anymore because
+    // it is bound to the document/window.
+
     let base = e.target.id;
     // Retrieve the path to use for views' ajax.
     let ajaxPath = drupalSettings?.views?.ajax_path ?? '/views/ajax' ;
@@ -97,12 +100,17 @@
           value?.id
         ) {
 
-          let event = value?.dataset?.sbfViewEvent
-          if (typeof(event) == "undefined") {
-            event = "click";
+          let eventtype = value?.dataset?.sbfViewEvent
+          if (typeof(eventtype) == "undefined") {
+            eventtype = "click";
           }
-          if (['click','load'].includes(event)) {
-            value.addEventListener(event, loadViewOnEvent, {passive: true, once: true});
+          if (eventtype == "click") {
+            value.addEventListener(eventtype, loadViewOnClickEvent, {passive: true, once: true});
+          }
+          else if (eventtype == "load") {
+              value.addEventListener('afterload', loadViewOnClickEvent, {passive: true, once: true});
+              const event = new Event('afterload');
+              value.dispatchEvent(event);
           }
         }
       });

--- a/modules/format_strawberryfield_views/src/Controller/FormatStrawberryfieldViewAjaxController.php
+++ b/modules/format_strawberryfield_views/src/Controller/FormatStrawberryfieldViewAjaxController.php
@@ -135,9 +135,9 @@ class FormatStrawberryfieldViewAjaxController extends ViewAjaxController {
         return ($arg == '' ? NULL : $arg);
       }, $args);
 
-      $path = $request->get('view_path');
+      $path = $request->get('view_path') ?? Html::escape($this->currentPath->getPath());
       // If a view has an invalid Path (e.g you added some % somewhere) this will be null.
-      $target_url = $this->pathValidator->getUrlIfValid($path);
+      $target_url = $this->pathValidator->getUrlIfValid($path ?? '/');
       $dom_id = $request->get('view_dom_id');
       $dom_id = isset($dom_id) ? preg_replace('/[^a-zA-Z0-9_-]+/', '-', $dom_id) : NULL;
       $pager_element = $request->get('pager_element');
@@ -291,6 +291,13 @@ class FormatStrawberryfieldViewAjaxController extends ViewAjaxController {
     else {
       throw new NotFoundHttpException();
     }
+  }
+  public function ajaxViewAdd(Request $request)
+  {
+    //$dom_id = "blabla";
+    //$request->request->set('view_dom_id', $dom_id);
+    $response = $this->ajaxView($request);
+    return $response;
   }
 
 }

--- a/modules/format_strawberryfield_views/src/Plugin/Block/ViewsExposedFilterBlockModal.php
+++ b/modules/format_strawberryfield_views/src/Plugin/Block/ViewsExposedFilterBlockModal.php
@@ -431,6 +431,25 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
         ],
       ],
     ];
+    $form['views_exposed_sbf_autosubmit_js'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Auto submits the form, on user interaction/change of select, checkboxes and option elements. '),
+      '#default_value' => !empty($this->configuration['views_exposed_sbf_autosubmit_js']),
+      '#fieldset' => 'views_exposed_sbf_fieldset',
+      '#states' => [
+        'enabled' => [
+          [
+            [':input[name="settings[views_exposed_sbf_show_sort_filter]"]' => ['checked' => TRUE]],
+            'OR',
+            [':input[name="settings[views_exposed_sbf_show_checksandoptions_filter]"]' => ['checked' => TRUE]],
+            'OR',
+            [':input[name="settings[views_exposed_sbf_show_text_filter]"]' => ['checked' => TRUE]],
+            'OR',
+            [':input[name="settings[views_exposed_sbf_show_select_filter]"]' => ['checked' => TRUE]],
+          ],
+        ],
+      ],
+    ];
 
     $form['views_exposed_sbf_rename_submit_label'] = [
       '#title' => $this->t('Submit button label'),

--- a/modules/format_strawberryfield_views/src/Plugin/Block/ViewsExposedFilterBlockModal.php
+++ b/modules/format_strawberryfield_views/src/Plugin/Block/ViewsExposedFilterBlockModal.php
@@ -38,7 +38,8 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
    *   A renderable array representing the content of the block with additional
    *   context of current view and display ID.
    */
-  public function build() {
+  public function build()
+  {
 
     $is_sort_exposed = FALSE;
 
@@ -46,7 +47,14 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
     $sort_ids = [];
     foreach ($this->view->display_handler->getHandlers('sort') as $key => $sort) {
       if ($sort->isExposed()) {
+        // We really don't know if sorting is exposed. So we will have to ask the view
         $sort_ids[$sort->options['expose']['field_identifier']] = $sort->options['expose']['field_identifier'];
+        // Never the case that a SORT as a select is going to keep its own value
+        // But if a hanlder decides to make it a checkbox? Or some theme does that?
+        $is_sort_exposed = true;
+        // New in Drupal 10.2? But these are fixed. When combined by Better exposed Filters they will appear inside #info (still)
+        $sort_ids['sort_by'] = 'sort_by';
+        $sort_ids['sort_order'] = 'sort_order';
       }
     }
 
@@ -68,7 +76,7 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
     // \Drupal\views\ViewExecutable::buildRenderable() using
     // \Drupal\views\Plugin\views\display\DisplayPluginBase::buildRenderable().
     $output['#attributes']['data-drupal-target-view'] = $this->view->storage->id() . '-' . $this->view->current_display;
-
+    // This changes after an Ajax call, but out settings have not ...
     $output['#id'] = Html::getUniqueId('views_exposed_form_modal-' .  $this->view->storage->id() . '-' . $this->view->current_display);
     $exposed_elements = $output['#info'] ?? [];
     foreach ($exposed_elements as $key => $exposed_values) {
@@ -77,12 +85,15 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
           $filter_ids[$exposed_values['value']] = $exposed_values['value'];
         }
       }
+      // Leaving this for posterity. No longer true that #info will contain sort elements
+      // Sorts are now named simply sort_by and sort_order in the main key ...
       if (strpos($key,'sort-') === 0) {
         if (isset($exposed_values['value'])) {
           $sort_ids[$exposed_values['value']] = $exposed_values['value'];
         }
       }
     }
+
 
     // Hide Filters if needed
     foreach ($filter_ids as $field_id) {
@@ -97,6 +108,7 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
         $hide = $this->checkIfNeedsToHideFilter($output[$real_id] ?? []);
         if ($hide) {
           $output[$real_id]['#attributes']['class'][] = 'visually-hidden';
+          $output[$real_id]['#attributes']['aria-hidden'] = 'true';
           $output[$real_id]['#title_display'] = 'invisible';
           $output[$real_id]['#description_display'] = 'invisible';
           if (isset($output['#info']["filter-$field_id"]['label'])) {
@@ -111,6 +123,7 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
             $hide = $this->checkIfNeedsToHideFilter($value ?? []);
             if ($hide) {
               $value['#type'] = 'hidden';
+              $value['#attributes']['aria-hidden'] = 'true';
               $value['#attributes']['class'][] = 'visually-hidden';
               $output['#info']["filter-$field_id"]['label'] = '';
             }
@@ -132,6 +145,7 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
         $hide = $this->checkIfNeedsToHideSort($output[$real_id] ?? []);
         if ($hide) {
           $output[$real_id]['#attributes']['class'][] = 'visually-hidden';
+          $output[$real_id]['#attributes']['aria-hidden'] = 'true';
           $output[$real_id]['#title_display'] = 'invisible';
           $output[$real_id]['#description_display'] = 'invisible';
           if (isset($output['#info']["sort-$field_id"]['label'])) {
@@ -147,6 +161,7 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
             if ($hide) {
               $value['#type'] = 'hidden';
               $value['#attributes']['class'][] = 'visually-hidden';
+              $value['#attributes']['aria-hidden'] = 'true';
               $output['#info']["sort-$field_id"]['label'] = '';
             }
           }
@@ -164,10 +179,12 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
     }
     elseif (isset($output['actions']['submit'])) {
       $output['actions']['submit']['#attributes']['class'][] = 'visually-hidden';
+      $output['actions']['submit']['#attributes']['aria-hidden'] = 'true';
     }
 
     if (!$this->configuration['views_exposed_sbf_show_reset'] && isset($output['actions']['reset'])) {
       $output['actions']['reset']['#attributes']['class'][] = 'visually-hidden';
+      $output['actions']['reset']['#attributes']['aria-hidden'] = 'true';
     }
 
     if ($this->view->display_handler->ajaxEnabled()) {
@@ -184,6 +201,16 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
       $output['#attached']['library'][] = 'format_strawberryfield_views/modal-exposed-form-views-ajax';
     }
 
+    if ($this->configuration['views_exposed_sbf_copy_values_to_other_js']) {
+      $output['#attributes']['data-sbf-modalblock-copytothers'] = "true";
+    }
+    if ($this->configuration['views_exposed_sbf_autosubmit_js']) {
+      $output['#attributes']['data-sbf-modalblock-autosubmit'] = "true";
+    }
+    if ($this->configuration['views_exposed_sbf_autosubmit_js'] || $this->configuration['views_exposed_sbf_copy_values_to_other_js']) {
+      $output['#attached']['library'][] = 'format_strawberryfield_views/modal-exposed-form-views-interactions';
+    }
+
     if (is_array($output) && !empty($output)) {
       $output += [
         '#view' => $this->view,
@@ -193,7 +220,7 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
 
     // Before returning the block output, convert it to a renderable array with
     // contextual links.
-    $this->addContextualLinks($output, 'views_exposed_filter_block_sbf');
+    $this->addContextualLinks($output, 'exposed_filter');
 
     // Set the blocks title.
     if (!empty($this->configuration['label_display']) && ($this->view->getTitle() || !empty($this->configuration['views_label']))) {
@@ -254,7 +281,7 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
     if (!$this->configuration['views_exposed_sbf_show_sort_filter']
       && isset($element['#type'])
       && in_array(
-        $element['#type'], ['select']
+        $element['#type'], ['select', 'radio']
       )
     ) {
       $hide = TRUE;
@@ -273,6 +300,8 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
     $default_config['views_exposed_sbf_show_submit'] = 1;
     $default_config['views_exposed_sbf_show_reset'] = 1;
     $default_config['views_exposed_sbf_rename_submit_label'] = '';
+    $default_config['views_exposed_sbf_copy_values_to_other_js'] = 0;
+    $default_config['views_exposed_sbf_autosubmit_js'] = 0;
     return $default_config;
   }
 
@@ -302,13 +331,15 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
     $this->configuration['views_exposed_sbf_show_pager'] = $form_state->getValue('views_exposed_sbf_show_pager',0);
     $this->configuration['views_exposed_sbf_show_submit'] = $form_state->getValue('views_exposed_sbf_show_submit',0);
     $this->configuration['views_exposed_sbf_show_reset'] = $form_state->getValue('views_exposed_sbf_show_reset',0);
+    $this->configuration['views_exposed_sbf_copy_values_to_other_js'] = $form_state->getValue('views_exposed_sbf_copy_values_to_other_js',0);
+    $this->configuration['views_exposed_sbf_autosubmit_js'] = $form_state->getValue('views_exposed_sbf_autosubmit_js',0);
 
     $form_state->unsetValue('views_label_checkbox');
     $form_state->unsetValue('views_exposed_sbf_rename_submit');
   }
 
   public function buildConfigurationForm(array $form,
-    FormStateInterface $form_state
+                                         FormStateInterface $form_state
   ) {
     $form = parent::buildConfigurationForm(
       $form, $form_state
@@ -381,7 +412,25 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
         ],
       ],
     ];
-
+    $form['views_exposed_sbf_copy_values_to_other_js'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Copy visible Input Values (on user interaction/change) to other View Exposed Form Modal Blocks belonging to the same View'),
+      '#default_value' => !empty($this->configuration['views_exposed_sbf_copy_values_to_other_js']),
+      '#fieldset' => 'views_exposed_sbf_fieldset',
+      '#states' => [
+        'enabled' => [
+          [
+            [':input[name="settings[views_exposed_sbf_show_sort_filter]"]' => ['checked' => TRUE]],
+            'OR',
+            [':input[name="settings[views_exposed_sbf_show_checksandoptions_filter]"]' => ['checked' => TRUE]],
+            'OR',
+            [':input[name="settings[views_exposed_sbf_show_text_filter]"]' => ['checked' => TRUE]],
+            'OR',
+            [':input[name="settings[views_exposed_sbf_show_select_filter]"]' => ['checked' => TRUE]],
+          ],
+        ],
+      ],
+    ];
 
     $form['views_exposed_sbf_rename_submit_label'] = [
       '#title' => $this->t('Submit button label'),
@@ -390,7 +439,7 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
       '#states' => [
         'visible' => [
           [
-            ':input[name="settings[views_exposed_sbf_rename_submit]"]' => ['checked' => TRUE],
+            ':input[name="settings[views_exposed_sbf_show_submit]"]' => ['checked' => TRUE],
           ],
         ],
       ],
@@ -398,6 +447,14 @@ class ViewsExposedFilterBlockModal extends ViewsBlockBase implements TrustedCall
     ];
 
     return $form;
+  }
+
+  public function getCacheTags() {
+    $tags = parent::getCacheTags();
+    if ($this->view) {
+      $tags = Cache::mergeTags($tags, $this->view->display_handler->getCacheMetadata()->getCacheTags() ?? []);
+    }
+    return $tags;
   }
 
 


### PR DESCRIPTION
see #427

This includes now also:

- Override for poorly coded thing in Drupal that does not allow nested Ajax Views Pagers
- Option to allow an on-click (`data-sbf-view-event="click"`)  or on-load (`data-sbf-view-event="load"`) for loading dynamically Views
- Works perfect. Just don't use the mini-pager because there is something wrong with it? Like globally (not us/but on them)

Tested with dozens of children, each child with 3K children. Paging works. All works!