### PR TITLE
ISSUE-472: Passes correctly multiple SBF to ADO relationships on JOINs

### DIFF
--- a/modules/format_strawberryfield_views/src/EventSubscriber/SearchApiSolrEventSubscriber.php
+++ b/modules/format_strawberryfield_views/src/EventSubscriber/SearchApiSolrEventSubscriber.php
@@ -36,30 +36,34 @@ class SearchApiSolrEventSubscriber implements EventSubscriberInterface {
     }
     if ($query->getOption('sbf_join_flavor')) {
       $options = $query->getOption('sbf_join_flavor');
-      if (is_array($options) &&
-        !empty($options['from']) &&
-        !empty($options['to']) &&
-        !empty($options['v'])) {
-        // Options might contain more data used for HL/Advanced search etc.
-        // see \Drupal\format_strawberryfield_views\Plugin\views\filter\StrawberryFlavorsJoin::query
-        $conjunction = $options['#conjunction'] ?? 'OR'; // Used to connect the join with the main one
-        $join_term['from'] = $options['from'];
-        $join_term['to'] = $options['to'];
-        $subquery = $options['v'];
-        $join_term['v'] = '$subquery';
-        // $options['method'] = 'topLevelDV' or 'dvWithScore' This requires docvalues to be set on the joined fields
-        // This is desired because it will be faster
-        // Also adding $options['score'] = 'none' even faster.
-        // @TODO enable extra UUID type Solr field to be used as joined ones
-        $join = $solarium_query->getHelper()->qparser(
-          'join',
-          $join_term
-        );
-        $new_query_string = $solarium_query->getQuery() . " {$conjunction} " . $join;
-        $solarium_query->setQuery($new_query_string);
-        $solarium_query->addParam(
-          'subquery', $subquery
-        );
+      if (is_array($options)) {
+        foreach ($options as $key => $option) {
+          if (is_array($option) &&
+            !empty($option['from']) &&
+            !empty($option['to']) &&
+            !empty($option['v'])) {
+            // Options might contain more data used for HL/Advanced search etc.
+            // see \Drupal\format_strawberryfield_views\Plugin\views\filter\StrawberryFlavorsJoin::query
+            $conjunction = $option['#conjunction'] ?? 'OR'; // Used to connect the join with the main one
+            $join_term['from'] = $option['from'];
+            $join_term['to'] = $option['to'];
+            $subquery = $option['v'];
+            $join_term['v'] = '$subquery_'.$key;
+            // $options['method'] = 'topLevelDV' or 'dvWithScore' This requires docvalues to be set on the joined fields
+            // This is desired because it will be faster
+            // Also adding $options['score'] = 'none' even faster.
+            // @TODO enable extra UUID type Solr field to be used as joined ones
+            $join = $solarium_query->getHelper()->qparser(
+              'join',
+              $join_term
+            );
+            $new_query_string = $solarium_query->getQuery() . " {$conjunction} " . $join;
+            $solarium_query->setQuery($new_query_string);
+            $solarium_query->addParam(
+              'subquery_'.$key, $subquery
+            );
+          }
+        }
       }
     }
     elseif ($query->getOption('sbf_join_flavor_advanced')) {
@@ -69,7 +73,7 @@ class SearchApiSolrEventSubscriber implements EventSubscriberInterface {
         !empty($options['to']) &&
         !empty($options['v'])) {
         $subquery = $options['v'];
-        $options['v'] = '$subquery';
+        $options['v'] = '$subquery_adv';
         // $options['method'] = 'topLevelDV' or 'dvWithScore' This requires docvalues to be set on the joined fields
         // This is desired because it will be faster
         // Also adding $options['score'] = 'none' even faster.
@@ -81,7 +85,7 @@ class SearchApiSolrEventSubscriber implements EventSubscriberInterface {
         $new_query_string = $solarium_query->getQuery() . ' OR ' . $join;
         $solarium_query->setQuery($new_query_string);
         $solarium_query->addParam(
-          'subquery', $subquery
+          'subquery_adv', $subquery
         );
       }
     }
@@ -119,25 +123,27 @@ class SearchApiSolrEventSubscriber implements EventSubscriberInterface {
     }
     elseif ($query->getOption('sbf_join_ado_advanced')) {
       $substitutions = $query->getOption('sbf_join_ado_advanced');
-      if (is_array($substitutions) &&
-        !empty($options['from']) &&
-        !empty($options['to']) &&
-        !empty($options['v'])) {
-        $subquery = $options['v'];
-        $options['v'] = '$subquery_ado';
-        // $options['method'] = 'topLevelDV' or 'dvWithScore' This requires docvalues to be set on the joined fields
-        // This is desired because it will be faster
-        // Also adding $options['score'] = 'none' even faster.
-        // @TODO enable extra UUID type Solr field to be used as joined ones
-        $join = $solarium_query->getHelper()->qparser(
-          'join',
-          $options
-        );
-        $new_query_string = $solarium_query->getQuery() . ' OR ' . $join;
-        $solarium_query->setQuery($new_query_string);
-        $solarium_query->addParam(
-          'subquery_ado', $subquery
-        );
+      foreach ($substitutions as $key => $options) {
+        if (is_array($options) &&
+          !empty($options['from']) &&
+          !empty($options['to']) &&
+          !empty($options['v'])) {
+          $subquery = $options['v'];
+          $options['v'] = '$subquery_ado_adv' . $key;
+          // $options['method'] = 'topLevelDV' or 'dvWithScore' This requires docvalues to be set on the joined fields
+          // This is desired because it will be faster
+          // Also adding $options['score'] = 'none' even faster.
+          // @TODO enable extra UUID type Solr field to be used as joined ones
+          $join = $solarium_query->getHelper()->qparser(
+            'join',
+            $options
+          );
+          $new_query_string = $solarium_query->getQuery() . ' OR ' . $join;
+          $solarium_query->setQuery($new_query_string);
+          $solarium_query->addParam(
+            'subquery_ado_adv'. $key, $subquery
+          );
+        }
       }
     }
   }

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/AdvancedSearchApiFulltext.php
@@ -381,7 +381,8 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
       // used to query the Aggregated field.
       $sbf_highligh_solr_fields = [];
       $flat_key_sbf_highlight = [];
-
+      // Keeps track of the source fields configured at the aggregated field level for the HL processor.
+      $sbf_highligh_join_fields_from_config = [];
       foreach ($query_able_data as &$query_able_datum_fields) {
         foreach ($query_able_datum_fields['fields'] ?? [] as $field) {
           if (isset($solr_field_names[$field])
@@ -420,6 +421,7 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
                     && $index_field_item->getPropertyPath() == 'plaintext'
                   ) {
                     $sbf_names = [];
+                    $sbf_highligh_join_fields_from_config = array_merge($sbf_highligh_join_fields_from_config, $index_field->getConfiguration()['join_fields'] ?? ['parent_id']);
                     $sbf_first_name = reset($field_names[$sbf_field]);
                     if (strpos($sbf_first_name, 't') === 0) {
                       // Add all language-specific field names. This should work for
@@ -521,6 +523,8 @@ class AdvancedSearchApiFulltext extends SearchApiFulltext {
       $this->getQuery()->setFulltextFields([]);
       if (count($flat_key_sbf_highlight)) {
         $this->getQuery()->setOption('sbf_advanced_search_filter_flavor_hl', implode(" ", $flat_key_sbf_highlight));
+        // also adds as an option the fields the aggregated one is using so he HL processor can dig deeper when Querying.
+        $this->getQuery()->setOption('sbf_advanced_search_filter_flavor_join_search_api_fields_hl', array_unique(array_values($sbf_highligh_join_fields_from_config)));
       }
     }
     else {

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/StrawberryADOJoin.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/StrawberryADOJoin.php
@@ -249,15 +249,24 @@ class StrawberryADOJoin extends FilterPluginBase {
         }
       }
       elseif ($type == 'advanced_fulltext') {
+        $join_structure = [];
         if ($subtitutions = $this->getQuery()->getOption('sbf_advanced_search_filter_join', NULL)) {
           foreach ($subtitutions as $placeholder => $subquery) {
-            $join_structure[$placeholder] = [
-              'from' => 'its_parent_id',
-              'to'   => 'its_nid',
-              'v'    => $subquery
-            ];
+            foreach ($this->options['join_fields'] as $key => $join_field) {
+              if (isset($solr_field_names[$join_field])) {
+                $join_structure[$placeholder . $key] = [
+                  'from' => $solr_field_names[$join_field],
+                  'to' => $solr_field_names[$this->options['join_field_to'] ?? 'its_nid'],
+                  'v' => $subquery,
+                ];
+              }
+            }
           }
-          $this->getQuery()->setOption('sbf_join_ado_advanced', $join_structure);
+          // 'hl' might be used in the future at @TODO. Right HL is limited to Strawberry Flavors.
+          // \Drupal\strawberryfield\Plugin\search_api\processor\StrawberryFieldHighlight::highlightFlavorsFromIndex
+          if (!empty($join_structure)) {
+            $this->getQuery()->setOption('sbf_join_ado_advanced', $join_structure);
+          }
         }
       }
     }

--- a/modules/format_strawberryfield_views/src/Plugin/views/filter/StrawberryADOfilter.php
+++ b/modules/format_strawberryfield_views/src/Plugin/views/filter/StrawberryADOfilter.php
@@ -310,6 +310,7 @@ class StrawberryADOfilter extends InOperator /* FilterPluginBase */
         '#default_value' => $nodes,
         '#selection_handler' => 'default:nodewithstrawberry',
         '#validate_reference'=> TRUE,
+        '#maxlength' => 300,
       ];
     }
     elseif ($this->isExposed()) {

--- a/src/Form/MetadataAPIConfigEntityForm.php
+++ b/src/Form/MetadataAPIConfigEntityForm.php
@@ -198,6 +198,7 @@ class MetadataAPIConfigEntityForm extends EntityForm {
         '#validate_reference' => TRUE,
         '#required' => TRUE,
         '#default_value' =>  $wrapper_template,
+        '#maxlength' => 300,
       ],
       'processor_item_level_entity_id' => [
         '#type' => 'sbf_entity_autocomplete_uuid',
@@ -207,6 +208,7 @@ class MetadataAPIConfigEntityForm extends EntityForm {
         '#validate_reference' => TRUE,
         '#required' => TRUE,
         '#default_value' => $item_template,
+        '#maxlength' => 300,
       ],
       'active' => [
         '#type' => 'checkbox',

--- a/src/Plugin/Field/FieldFormatter/StrawberryCitationFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryCitationFormatter.php
@@ -172,6 +172,7 @@ class StrawberryCitationFormatter extends StrawberryBaseFormatter {
         '#validate_reference' => TRUE,
         '#required' => TRUE,
         '#default_value' => $entity,
+        '#maxlength' => 300,
       ],
       'citationstyle' => [
         '#type' => 'select',

--- a/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
@@ -141,6 +141,7 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
         '#selection_handler' => 'default:metadatadisplay',
         '#validate_reference' => TRUE,
         '#required' => TRUE,
+        '#maxlength' => 300,
         '#default_value' => $entity,
       ],
       'specs' => [

--- a/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
@@ -214,6 +214,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
           '#selection_handler' => 'default:metadatadisplay',
           '#validate_reference' => FALSE,
           '#default_value' => $entity,
+          '#maxlength' => 300,
           '#states' => [
             'visible' => [
               ':input[data-formatter-selector="mediasource"]' => ['value' => 'metadatadisplayentity'],


### PR DESCRIPTION
See #472 

Needs https://github.com/esmero/strawberryfield/pull/339 so Backend Highlights for JOINED Flavors are queried using the name SBF to ADO (NID) relationship fields and thus match the hits