### PR TITLE
ISSUE-498: Allow Panorama tour and single Panoramas to overriden on all properties

### DIFF
--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -393,6 +393,9 @@ field.formatter.settings.strawberry_pannellum_formatter:
     embargo_json_key_source:
       type: string
       label: 'When embargoed, comma separated list of Image Panorama Upload JSON keys to filter against'
+    viewer_overrides:
+      type: string
+      label: 'Pannellum JSON based Viewer Overrides'
 
 field.formatter.settings.strawberry_video_formatter:
   type: mapping

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -146,9 +146,47 @@
           const $vOffset = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.vOffset;
           const $maxPitch = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.maxPitch;
           const $minPitch = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.minPitch;
+          
+          // Additional Pannellum settings from documentation
+          const $hfov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.hfov;
+          const $minHfov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.minHfov;
+          const $maxHfov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.maxHfov;
+          const $pitch = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.pitch;
+          const $yaw = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.yaw;
+          const $horizonPitch = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.horizonPitch;
+          const $horizonRoll = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.horizonRoll;
+          const $compass = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.compass;
+          const $northOffset = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.northOffset;
+          const $preview = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.preview;
+          const $showZoomCtrl = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.showZoomCtrl;
+          const $keyboardZoom = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.keyboardZoom;
+          const $mouseZoom = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.mouseZoom;
+          const $draggable = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.draggable;
+          const $disableKeyboardCtrl = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.disableKeyboardCtrl;
+          const $showFullscreenCtrl = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.showFullscreenCtrl;
+          const $showControls = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.showControls;
+          const $autoRotate = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.autoRotate;
+          const $autoRotateInactivityDelay = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.autoRotateInactivityDelay;
+          const $autoRotateStopDelay = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.autoRotateStopDelay;
+          const $sceneFadeDuration = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.sceneFadeDuration;
 
+        
           // Check if we got some data passed via Drupal settings.
           if (typeof (drupalSettings.format_strawberryfield.pannellum[element_id]) != 'undefined') {
+            // Check if we have settings in the as:formatter path and merge them with existing settings
+            if (drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('as:formatter')) {
+              // If settings doesn't exist yet, create it
+              if (!drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('settings')) {
+                drupalSettings.format_strawberryfield.pannellum[element_id].settings = {};
+              }
+              // Merge the as:formatter settings with the settings object
+              
+              Object.assign(
+                drupalSettings.format_strawberryfield.pannellum[element_id].settings, 
+                drupalSettings.format_strawberryfield.pannellum[element_id]['as:formatter']
+              );
+            }
+            
             if (drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('hotspots') &&
               !$multiscene
             ) {
@@ -197,7 +235,29 @@
                 "minYaw": $minYaw || -180,
                 "vOffset": $vOffset || 0,
                 "maxPitch": $maxPitch || undefined,
-                "minPitch": $minPitch || undefined
+                "minPitch": $minPitch || undefined,
+                // Additional Pannellum settings
+                "hfov": $hfov || 100,
+                "minHfov": $minHfov || 50,
+                "maxHfov": $maxHfov || 120,
+                "pitch": $pitch || 0,
+                "yaw": $yaw || 0,
+                "horizonPitch": $horizonPitch || 0,
+                "horizonRoll": $horizonRoll || 0,
+                "compass": $compass !== undefined ? Boolean($compass) : false,
+                "northOffset": $northOffset || 0,
+                "preview": $preview || "",
+                "showZoomCtrl": $showZoomCtrl !== undefined ? Boolean($showZoomCtrl) : true,
+                "keyboardZoom": $keyboardZoom !== undefined ? Boolean($keyboardZoom) : true,
+                "mouseZoom": $mouseZoom !== undefined ? Boolean($mouseZoom) : true,
+                "draggable": $draggable !== undefined ? Boolean($draggable) : true,
+                "disableKeyboardCtrl": $disableKeyboardCtrl !== undefined ? Boolean($disableKeyboardCtrl) : false,
+                "showFullscreenCtrl": $showFullscreenCtrl !== undefined ? Boolean($showFullscreenCtrl) : true,
+                "showControls": $showControls !== undefined ? Boolean($showControls) : true,
+                "autoRotate": $autoRotate || 0,
+                "autoRotateInactivityDelay": $autoRotateInactivityDelay || 0,
+                "autoRotateStopDelay": $autoRotateStopDelay || 0,
+                "sceneFadeDuration": $sceneFadeDuration || 1000
               });
             } else {
               console.log('Pannellum Multiscene found.');
@@ -226,6 +286,26 @@
               });
               // Add Autoload property for global Tour Viewer
               drupalSettings.format_strawberryfield.pannellum[element_id].tour.autoLoad = Boolean(drupalSettings.format_strawberryfield.pannellum[element_id].settings.autoLoad);
+              
+              // Add additional Pannellum settings to the tour configuration
+              if ($hfov !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.hfov = $hfov;
+              if ($minHfov !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.minHfov = $minHfov;
+              if ($maxHfov !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.maxHfov = $maxHfov;
+              if ($compass !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.compass = Boolean($compass);
+              if ($northOffset !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.northOffset = $northOffset;
+              if ($preview !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.preview = $preview;
+              if ($showZoomCtrl !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.showZoomCtrl = Boolean($showZoomCtrl);
+              if ($keyboardZoom !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.keyboardZoom = Boolean($keyboardZoom);
+              if ($mouseZoom !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.mouseZoom = Boolean($mouseZoom);
+              if ($draggable !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.draggable = Boolean($draggable);
+              if ($disableKeyboardCtrl !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.disableKeyboardCtrl = Boolean($disableKeyboardCtrl);
+              if ($showFullscreenCtrl !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.showFullscreenCtrl = Boolean($showFullscreenCtrl);
+              if ($showControls !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.showControls = Boolean($showControls);
+              if ($autoRotate !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.autoRotate = $autoRotate;
+              if ($autoRotateInactivityDelay !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.autoRotateInactivityDelay = $autoRotateInactivityDelay;
+              if ($autoRotateStopDelay !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.autoRotateStopDelay = $autoRotateStopDelay;
+              if ($sceneFadeDuration !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.sceneFadeDuration = $sceneFadeDuration;
+              
               var viewer = window.pannellum.viewer(element_id, drupalSettings.format_strawberryfield.pannellum[element_id].tour);
               viewer.on('scenechange',
                 function (e) {

--- a/js/iiif-pannellum_strawberry.js
+++ b/js/iiif-pannellum_strawberry.js
@@ -114,20 +114,21 @@
 
       const elementsToAttach = once('attache_pnl', '.strawberry-panorama-item[data-iiif-image]', context);
       $(elementsToAttach).each(function (index, value) {
-          // New 2019.
-          // If value is an array then we have a multiscene panorama
-          // Mostlikely, if i coded this right, hotspots will also be arrays
+
+        // Get the node uuid for this element
+        var element_id = $(this).attr("id");
+        if (typeof (drupalSettings.format_strawberryfield.pannellum[element_id]) != 'undefined') {
+
           var hotspots = [];
-          // Get the node uuid for this element
-          var element_id = $(this).attr("id");
           var $multiscene = drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('tour');
           var default_width = drupalSettings.format_strawberryfield.pannellum[element_id]['width'];
           var default_height = drupalSettings.format_strawberryfield.pannellum[element_id]['height'];
           var externalConfigURL = drupalSettings.format_strawberryfield.pannellum[element_id]['configjsonurl'];
-          //@TODO make this work?
+          let panellum_default_settings = {}
+
           if (externalConfigURL) {
-            $.getJSON(drupalSettings.format_strawberryfield.pannellum[element_id]['configjsonurl'], function (data) {
-              console.log(data);
+            $.getJSON(externalConfigURL, function (data) {
+              panellum_default_settings = data;
             });
           }
 
@@ -138,187 +139,149 @@
             console.log('Max webGL texture size is' +
               gl.getParameter(gl.MAX_TEXTURE_SIZE));
           }
-
-          const $haov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.haov;
-          const $vaov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.vaov;
-          const $minYaw = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.minYaw;
-          const $maxYaw = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.maxYaw;
-          const $vOffset = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.vOffset;
-          const $maxPitch = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.maxPitch;
-          const $minPitch = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.minPitch;
-          
-          // Additional Pannellum settings from documentation
-          const $hfov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.hfov;
-          const $minHfov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.minHfov;
-          const $maxHfov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.maxHfov;
-          const $pitch = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.pitch;
-          const $yaw = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.yaw;
-          const $horizonPitch = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.horizonPitch;
-          const $horizonRoll = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.horizonRoll;
-          const $compass = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.compass;
-          const $northOffset = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.northOffset;
-          const $preview = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.preview;
-          const $showZoomCtrl = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.showZoomCtrl;
-          const $keyboardZoom = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.keyboardZoom;
-          const $mouseZoom = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.mouseZoom;
-          const $draggable = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.draggable;
-          const $disableKeyboardCtrl = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.disableKeyboardCtrl;
-          const $showFullscreenCtrl = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.showFullscreenCtrl;
-          const $showControls = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.showControls;
-          const $autoRotate = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.autoRotate;
-          const $autoRotateInactivityDelay = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.autoRotateInactivityDelay;
-          const $autoRotateStopDelay = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.autoRotateStopDelay;
-          const $sceneFadeDuration = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.sceneFadeDuration;
-
-        
-          // Check if we got some data passed via Drupal settings.
-          if (typeof (drupalSettings.format_strawberryfield.pannellum[element_id]) != 'undefined') {
-            // Check if we have settings in the as:formatter path and merge them with existing settings
-            if (drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('as:formatter')) {
-              // If settings doesn't exist yet, create it
-              if (!drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('settings')) {
-                drupalSettings.format_strawberryfield.pannellum[element_id].settings = {};
-              }
-              // Merge the as:formatter settings with the settings object
-              
-              Object.assign(
-                drupalSettings.format_strawberryfield.pannellum[element_id].settings, 
-                drupalSettings.format_strawberryfield.pannellum[element_id]['as:formatter']
-              );
+          // There are the defaults for the used Panellum release.
+          if (Object.keys(panellum_default_settings).length == 0) {
+            panellum_default_settings = {
+              "type": "equirectangular",
+              "hotSpotDebug": false,
+              "autoLoad": true,
+              "haov": 360,
+              "vaov": 180,
+              "friction": 0.5,
+              "maxYaw": 180,
+              "minYaw": -180,
+              "vOffset": 0,
+              "maxPitch": undefined,
+              "minPitch": undefined,
+              // Additional Pannellum settings
+              "hfov": 100,
+              "minHfov": 50,
+              "maxHfov": 120,
+              "pitch": 0,
+              "yaw": 0,
+              "horizonPitch": 0,
+              "horizonRoll": 0,
+              "compass": false,
+              "northOffset": 0,
+              "preview": "",
+              "showZoomCtrl": true,
+              "keyboardZoom": true,
+              "mouseZoom": true,
+              "draggable": true,
+              "disableKeyboardCtrl": false,
+              "showFullscreenCtrl": true,
+              "showControls": true,
+              "autoRotate": false,
+              "autoRotateInactivityDelay": 0,
+              "autoRotateStopDelay": 0,
+              "sceneFadeDuration": 1000
             }
-            
-            if (drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('hotspots') &&
-              !$multiscene
-            ) {
-              $.each(drupalSettings.format_strawberryfield.pannellum[element_id].hotspots, function (id, hotspotdata) {
-                // Also add Popups for Standalone Panoramas if they have an URL.
-                if (hotspotdata.hasOwnProperty('URL') && hotspotdata.URL !== null) {
-                  if (hotspotdata.URL.indexOf('http://') === 0 || hotspotdata.URL.indexOf('https://') === 0) {
-                    hotspotdata.text = hotspotdata.text + Drupal.t(' (External URL)');
-                  }
-                  else {
-                    hotspotdata.text = hotspotdata.text + Drupal.t(' (Digital Object)');
-                  }
-                  hotspotdata.clickHandlerFunc = Drupal.FormatStrawberryfieldhotspotPopUp;
-                  hotspotdata.clickHandlerArgs = hotspotdata.URL;
-                }
-                hotspots.push(hotspotdata);
-              });
-            }
-            $(this).height(default_height);
-            $(this).css("width", default_width);
-
-            console.log('Initializing Pannellum.')
-            // When loading a webform with an embeded Viewer
-            // The context of Pannellum is not global
-            // So we can't really use 'pannellum' directly
-            let mobile = false;
-            if (checkMobileDevice()) {
-              mobile = true;
-              console.log('Mobile defaulting to smaller version');
-              var sourceimage = $(value).data('iiifImageMobile');
-            } else {
-              mobile = false;
-              var sourceimage = $(value).data('iiifImage');
-            }
-            if (!$multiscene) {
-              var viewer = window.pannellum.viewer(element_id, {
-                "type": "equirectangular",
-                "panorama": sourceimage,
-                "hotSpotDebug": drupalSettings.format_strawberryfield.pannellum[element_id].settings.hotSpotDebug,
-                "autoLoad": Boolean(drupalSettings.format_strawberryfield.pannellum[element_id].settings.autoLoad),
-                "hotSpots": hotspots,
-                "haov": $haov || 360,
-                "vaov": $vaov || 180,
-                "friction": 0.5,
-                "maxYaw": $maxYaw || 180,
-                "minYaw": $minYaw || -180,
-                "vOffset": $vOffset || 0,
-                "maxPitch": $maxPitch || undefined,
-                "minPitch": $minPitch || undefined,
-                // Additional Pannellum settings
-                "hfov": $hfov || 100,
-                "minHfov": $minHfov || 50,
-                "maxHfov": $maxHfov || 120,
-                "pitch": $pitch || 0,
-                "yaw": $yaw || 0,
-                "horizonPitch": $horizonPitch || 0,
-                "horizonRoll": $horizonRoll || 0,
-                "compass": $compass !== undefined ? Boolean($compass) : false,
-                "northOffset": $northOffset || 0,
-                "preview": $preview || "",
-                "showZoomCtrl": $showZoomCtrl !== undefined ? Boolean($showZoomCtrl) : true,
-                "keyboardZoom": $keyboardZoom !== undefined ? Boolean($keyboardZoom) : true,
-                "mouseZoom": $mouseZoom !== undefined ? Boolean($mouseZoom) : true,
-                "draggable": $draggable !== undefined ? Boolean($draggable) : true,
-                "disableKeyboardCtrl": $disableKeyboardCtrl !== undefined ? Boolean($disableKeyboardCtrl) : false,
-                "showFullscreenCtrl": $showFullscreenCtrl !== undefined ? Boolean($showFullscreenCtrl) : true,
-                "showControls": $showControls !== undefined ? Boolean($showControls) : true,
-                "autoRotate": $autoRotate || 0,
-                "autoRotateInactivityDelay": $autoRotateInactivityDelay || 0,
-                "autoRotateStopDelay": $autoRotateStopDelay || 0,
-                "sceneFadeDuration": $sceneFadeDuration || 1000
-              });
-            } else {
-              console.log('Pannellum Multiscene found.');
-              $.each(drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes, function (sceneid, data) {
-                // Add Model Window Behaviour to hotSpots with Links
-                if (data.hasOwnProperty('hotSpots')) {
-                  $.each(data.hotSpots, function (hotspotid, hotspotdata) {
-                    if (hotspotdata.hasOwnProperty('URL') && hotspotdata.URL !== null) {
-                      if (hotspotdata.URL.indexOf('http://') === 0 || hotspotdata.URL.indexOf('https://') === 0) {
-                        hotspotdata.text = hotspotdata.text + Drupal.t(' (External URL)');
-                      }
-                      else {
-                        hotspotdata.text = hotspotdata.text + Drupal.t(' (Digital Object)');
-                      }
-                      drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes[sceneid].hotSpots[hotspotid].clickHandlerFunc = Drupal.FormatStrawberryfieldhotspotPopUp;
-                      drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes[sceneid].hotSpots[hotspotid].clickHandlerArgs = hotspotdata.URL;
-                    }
-                  });
-                }
-                if (mobile) {
-                  // Since the settings for other scenes is built by the Formatter as an Object
-                  // We need to replace the right Image for a mobile.
-                  drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes[sceneid].panorama = drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes[sceneid].panoramaMobile;
-                }
-                delete drupalSettings.format_strawberryfield.pannellum[element_id].tour.scenes[sceneid].panoramaMobile;
-              });
-              // Add Autoload property for global Tour Viewer
-              drupalSettings.format_strawberryfield.pannellum[element_id].tour.autoLoad = Boolean(drupalSettings.format_strawberryfield.pannellum[element_id].settings.autoLoad);
-              
-              // Add additional Pannellum settings to the tour configuration
-              if ($hfov !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.hfov = $hfov;
-              if ($minHfov !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.minHfov = $minHfov;
-              if ($maxHfov !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.maxHfov = $maxHfov;
-              if ($compass !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.compass = Boolean($compass);
-              if ($northOffset !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.northOffset = $northOffset;
-              if ($preview !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.preview = $preview;
-              if ($showZoomCtrl !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.showZoomCtrl = Boolean($showZoomCtrl);
-              if ($keyboardZoom !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.keyboardZoom = Boolean($keyboardZoom);
-              if ($mouseZoom !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.mouseZoom = Boolean($mouseZoom);
-              if ($draggable !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.draggable = Boolean($draggable);
-              if ($disableKeyboardCtrl !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.disableKeyboardCtrl = Boolean($disableKeyboardCtrl);
-              if ($showFullscreenCtrl !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.showFullscreenCtrl = Boolean($showFullscreenCtrl);
-              if ($showControls !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.showControls = Boolean($showControls);
-              if ($autoRotate !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.autoRotate = $autoRotate;
-              if ($autoRotateInactivityDelay !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.autoRotateInactivityDelay = $autoRotateInactivityDelay;
-              if ($autoRotateStopDelay !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.autoRotateStopDelay = $autoRotateStopDelay;
-              if ($sceneFadeDuration !== undefined) drupalSettings.format_strawberryfield.pannellum[element_id].tour.sceneFadeDuration = $sceneFadeDuration;
-              
-              var viewer = window.pannellum.viewer(element_id, drupalSettings.format_strawberryfield.pannellum[element_id].tour);
-              viewer.on('scenechange',
-                function (e) {
-                  const event = new CustomEvent('sbf:ado:change', { bubbles: true, detail: {nodeid: e} });
-                  const el = document.getElementById(element_id);
-                  el.dispatchEvent(event);
-                }
-              );
-            }
-            FormatStrawberryfieldPanoramas.panoramas.set(element_id, new FormatStrawberryfieldPanoramas(viewer));
+          }
+          let panellum_default_settings_from_element = {}
+          if (typeof drupalSettings.format_strawberryfield.pannellum[element_id].settings == "object") {
+            panellum_default_settings_from_element = drupalSettings.format_strawberryfield.pannellum[element_id].settings;
+          }
+          if ($multiscene) {
+            Object.assign(
+              panellum_default_settings_from_element,
+              drupalSettings.format_strawberryfield.pannellum[element_id].tour || {}
+            );
           }
 
-        })
+
+          // Merge Default with settings passed by the formatter.
+          if (panellum_default_settings_from_element != {}) {
+            Object.assign(
+              panellum_default_settings,
+              panellum_default_settings_from_element|| {}
+            );
+          }
+
+          $(this).height(default_height);
+          $(this).css("width", default_width);
+
+          if (drupalSettings.format_strawberryfield.pannellum[element_id].hasOwnProperty('hotspots') &&
+            !$multiscene
+          ) {
+            $.each(drupalSettings.format_strawberryfield.pannellum[element_id].hotspots, function (id, hotspotdata) {
+              // Also add Popups for Standalone Panoramas if they have an URL.
+              if (hotspotdata.hasOwnProperty('URL') && hotspotdata.URL !== null) {
+                if (hotspotdata.URL.indexOf('http://') === 0 || hotspotdata.URL.indexOf('https://') === 0) {
+                  hotspotdata.text = hotspotdata.text + Drupal.t(' (External URL)');
+                }
+                else {
+                  hotspotdata.text = hotspotdata.text + Drupal.t(' (Digital Object)');
+                }
+                hotspotdata.clickHandlerFunc = Drupal.FormatStrawberryfieldhotspotPopUp;
+                hotspotdata.clickHandlerArgs = hotspotdata.URL;
+              }
+              hotspots.push(hotspotdata);
+            });
+          }
+
+          // When loading a webform with an embeded Viewer
+          // The context of Pannellum is not global
+          // So we can't really use 'pannellum' directly
+          let mobile = false;
+          if (checkMobileDevice()) {
+            mobile = true;
+            console.log('Mobile defaulting to smaller version');
+            var sourceimage = $(value).data('iiifImageMobile');
+          } else {
+            mobile = false;
+            var sourceimage = $(value).data('iiifImage');
+          }
+          if (!$multiscene) {
+            // Sets the source image and hotspots
+            panellum_default_settings.panorama = sourceimage;
+            panellum_default_settings.hotSpots = hotspots;
+            console.log('Initializing Pannellum.')
+            var viewer = window.pannellum.viewer(element_id, panellum_default_settings);
+          }
+          else {
+            console.log('Initializing Multiscene Pannellum.');
+            $.each(panellum_default_settings?.scenes , function (sceneid, data) {
+              //permeate also per scene defaults from global ones ?
+              Object.assign(
+                panellum_default_settings.scenes[sceneid],
+                panellum_default_settings || {}
+              );
+              // Add Model Window Behaviour to hotSpots with Links
+              if (data.hasOwnProperty('hotSpots')) {
+                $.each(data.hotSpots, function (hotspotid, hotspotdata) {
+                  if (hotspotdata.hasOwnProperty('URL') && hotspotdata.URL !== null) {
+                    if (hotspotdata.URL.indexOf('http://') === 0 || hotspotdata.URL.indexOf('https://') === 0) {
+                      hotspotdata.text = hotspotdata.text + Drupal.t(' (External URL)');
+                    }
+                    else {
+                      hotspotdata.text = hotspotdata.text + Drupal.t(' (Digital Object)');
+                    }
+                    panellum_default_settings.scenes[sceneid].hotSpots[hotspotid].clickHandlerFunc = Drupal.FormatStrawberryfieldhotspotPopUp;
+                    panellum_default_settings.scenes[sceneid].hotSpots[hotspotid].clickHandlerArgs = hotspotdata.URL;
+                  }
+                });
+              }
+              if (mobile) {
+                // Since the settings for other scenes is built by the Formatter as an Object
+                // We need to replace the right Image for a mobile.
+                panellum_default_settings.scenes[sceneid].panorama = panellum_default_settings.scenes[sceneid].panoramaMobile;
+              }
+              delete panellum_default_settings.scenes[sceneid].panoramaMobile;
+            });
+
+            var viewer = window.pannellum.viewer(element_id, panellum_default_settings);
+            viewer.on('scenechange',
+              function (e) {
+                const event = new CustomEvent('sbf:ado:change', { bubbles: true, detail: {nodeid: e} });
+                const el = document.getElementById(element_id);
+                el.dispatchEvent(event);
+              }
+            );
+          }
+          FormatStrawberryfieldPanoramas.panoramas.set(element_id, new FormatStrawberryfieldPanoramas(viewer));
+        }
+
+      })
     }
   }
   /**

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -126,11 +126,12 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
         'max_width' => 600,
         'max_height' => 400,
         'panorama_type' => 'equirectangular',
-        'json_key_settings' => 'as:formatter',
+        'json_key_settings' => 'ap:viewerhints',
         'image_type' => 'jpg',
         'number_images' => 1,
         // todo: quality, rotation, and hotspotdebug not used but I put them in schema for now
         'quality' => 'default',
+        'viewer_overrides' => '',
         'rotation' => '0',
         'hotSpotDebug' => TRUE,
         'autoLoad' => FALSE,
@@ -165,8 +166,21 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
         ],
         'json_key_settings' => [
           '#type' => 'textfield',
-          '#title' => t('JSON Key from where to fetch Pannellum Viewer Settings'),
-          '#default_value' => $this->getSetting('json_key_settings'),
+          '#title' => t('JSON Key from where to fetch Pannellum Viewer Settings.'),
+          '#description' => t('To conform to other Strawberryfield formatters and their Viewers overrides settings, this should be set to <em>ap:viewerhints</em>, but this formatter allows to use the legacy as:formatter too'),
+          '#default_value' => 'ap:viewerhints',
+        ],
+        'viewer_overrides' => [
+          '#type' => 'textarea',
+          '#title' => $this->t('Advanced: a JSON with Panellum viewer Settings.'),
+          '#description' => $this->t('See <a href="https://github.com/mpetroff/pannellum/blob/master/doc/json-config-parameters.md">https://github.com/mpetroff/pannellum/blob/master/doc/json-config-parameters.md</a>. Leave Empty to use defaults.
+   <em>panorama</em> can not be overriden. Use with caution. An ADO can also override this formatter\'s settings by providing the following JSON key for a single panorama: @ado_override or for a tour per scene (with scene 1 as an example) as  @ado_override_tour',[
+            '@ado_override' => json_encode(["ap:viewerhints" => ["strawberry_pannellum_formatter" => ["mouseZoom" => FALSE]]], JSON_FORCE_OBJECT|JSON_PRETTY_PRINT),
+            '@ado_override_tour' => json_encode(["ap:viewerhints" => ["strawberry_pannellum_formatter" => ["1" => ["mouseZoom" => FALSE]]]], JSON_FORCE_OBJECT|JSON_PRETTY_PRINT)
+          ]),
+          '#default_value' => $this->getSetting('viewer_overrides'),
+          '#element_validate' => [[$this, 'validateJSON']],
+          '#required' => FALSE,
         ],
         'number_images' => [
           '#type' => 'number',
@@ -257,7 +271,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
     $multiscene = trim($this->getSetting('json_key_multiscene') ?? '');
     $settings_hotspotdebug = $this->getSetting('hotSpotDebug');
     $settings_autoload = $this->getSetting('autoLoad');
-    $settings_key = $this->getSetting('json_key_settings');
+    $settings_key = $this->getSetting('json_key_settings') ?? "ap:viewerhints";
 
     $upload_keys_string = strlen(trim($this->getSetting('upload_json_key_source') ?? '')) > 0 ? trim($this->getSetting('upload_json_key_source')) : '';
     $upload_keys = explode(',', $upload_keys_string);
@@ -284,7 +298,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
       }
 
       $jsondata = json_decode($item->value, TRUE);
-      // @TODO use future flatversion precomputed at field level as a property
+
       $json_error = json_last_error();
       if ($json_error != JSON_ERROR_NONE) {
         $message = $this->t(
@@ -296,6 +310,33 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
         );
         \Drupal::logger('format_strawberryfield')->warning($message);
         return $elements[$delta] = ['#markup' => $this->t('ERROR')];
+      }
+
+      $viewer_overrides = $this->getSetting('viewer_overrides');
+      $viewer_overrides_json = json_decode(trim($viewer_overrides), TRUE);
+
+      $json_error = json_last_error();
+      if ($json_error == JSON_ERROR_NONE) {
+        $viewer_overrides = $viewer_overrides_json;
+      }
+      else {
+        // Because this particular formatter will pass a single config, we need
+        // to ensure it is an array, so we can merge it later in the code.
+        $viewer_overrides = [];
+      }
+
+      if (isset($jsondata[$settings_key][$this->getPluginId()]) &&
+        is_array($jsondata[$settings_key][$this->getPluginId()]) &&
+        !empty($jsondata[$settings_key][$this->getPluginId()])) {
+        // if we could decode it, it is already JSON.
+        $viewer_overrides = $jsondata[$settings_key][$this->getPluginId()];
+        foreach ($viewer_overrides as $setting_key => $setting_value) {
+            if (is_array($setting_value)) {
+              // We remove any legacy $mediakey][setting here. We only deal with that if the mediakey matches
+              // further down.
+              unset($viewer_overrides[$setting_key]);
+            }
+        }
       }
 
       $embargo_info = $this->embargoResolver->embargoInfo($item->getEntity()->uuid(), $jsondata);
@@ -338,6 +379,14 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
             $nodeid
           );
           if (is_array($elements[$delta]) && !empty($elements[$delta])) {
+            // because we are calling each individual panorama recursively here
+            // we need to merge the settings back. Panorama level settings should win.
+            // But we don't have the $htmlid anymore. So we iterate.
+            foreach ($elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'] ?? [] as $hmtl_id_scene => $attached_settings) {
+              $scene_settings = $attached_settings['settings'] ?? [];
+              $elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'][$hmtl_id_scene]['settings'] = array_merge($scene_settings,
+                $viewer_overrides);
+            }
             continue;
           }
         }
@@ -471,7 +520,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
                     /* @TODO This might go better in a general page template preprocess
                     or template. Having two (by mistake) modals with the same
                     ID might be a mess.
-                    */
+                     */
                     $elements[$delta]['modal'] =  [
                       '#type' => 'markup',
                       '#allowed_tags' => ['button','span','div', 'h5'],
@@ -490,35 +539,30 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
         </div>
     </div>'
                     ];
-                    // Lets add hotspots
-                    $elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'][$htmlid]['settings'] = [
+
+                    $elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'][$htmlid]['settings'] = array_merge($viewer_overrides, [
                       'hotSpotDebug' => $settings_hotspotdebug,
                       'autoLoad' => $settings_autoload,
-                    ];
-                    // Let's check if the user provided in-metadata settings for the viewer
-                    // This is needed to adjust ROLL/PITCH/ETC for partial panoramas.
-                    // @TODO. We can maybe have an option where $mediaitemkey is not set
-                    // And then have general settings for every image?
+                    ]);
+
+                    // @NOTE: for 1.5.0 the use of a $mediaitemkey item and a settings keys is discouraged.
+                    // For a panorama, if one of the scenes (at each individual ADO level) had a key, those would be merged here
+                    // But since many panoramas could commpete, and also each panorama would not have more than a single Image,
+                    // having  "as:formatter": {
+                    //"strawberry_pannellum_formatter": {
+                    //"urn:uuid:b999aec3-dd4d-4894-af5e-7f8f0b651f1e": {
+                    //"settings": {
+                    //"mouseZoom": false
+                    //}
+                    // is more complex to write than
+                    // ap:viewerhints:{"strawberry_pannellum_formatter": {"mouseZoom": false}} which is the prefered way
+                    // Still, for backwayds compatibility reasons we will keep this.
                     if (isset($jsondata[$settings_key][$this->pluginId][$mediaitemkey]['settings'])) {
-                      // We only want a few settings here.
-                      // Question is do we allow everything pannellum can?
-                      // Or do we control this?
-                      // @see https://pannellum.org/documentation/reference/
-                      /*
-                      const $haov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.haov;
-                      const $vaov = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.vaov;
-                      const $minYaw = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.minYaw;
-                      const $maxYaw = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.maxYaw;
-                      const $vOffset = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.vOffset;
-                      const $maxPitch = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.maxPitch;
-                      const $minPitch = drupalSettings.format_strawberryfield.pannellum[element_id].settings?.minPitch;
-                       */
                       $viewer_settings = $elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'][$htmlid]['settings'];
                       $viewer_settings = array_merge($viewer_settings,
                         $jsondata[$settings_key][$this->pluginId][$mediaitemkey]['settings']);
                       $elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'][$htmlid]['settings'] = $viewer_settings;
                     }
-
 
                     $elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'][$htmlid]['nodeuuid'] = $nodeuuid;
                     $elements[$delta]['#attached']['drupalSettings']['format_strawberryfield']['pannellum'][$htmlid]['width'] = $max_width_css;
@@ -534,7 +578,6 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
                       "type": "info",
                       "pitch": "-4.409886580572494"
                      }, */
-                    // @TODO enable multiple scenes and more hotspot options
 
                     if (isset($jsondata[$hotspots])) {
                       $hotspotsjs = [];
@@ -628,73 +671,73 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
         // Don't allow circular references
         if ($nid != $ownnodeid)
           $node = $this->entityTypeManager->getStorage('node')->load($nid);
-          if (!$node) {
-            continue;
-          }
-          $type = $this->pluginId;
-          $settings = $this->getSettings();
-          // Let's reuse the same settings we have!
-          // but remove 'multiscene' key to make sure
-          // That we don't end loading circular
-          // references, deep tours in tours or even ourselves!
-          $settings['json_key_multiscene'] = '';
-          if ($this->checkAccess($node)) {
-            foreach ($node->{$fieldname} as $i => $delta) {
-              // @see \Drupal\Core\Entity\EntityViewBuilderInterface::viewField()
-              $renderarray = $delta->view(
-                ['type' => $type, 'settings' => $settings]
-              );
-              // We only want first image always.
-              if (isset($renderarray['panorama1'])) {
-                if ($key == 0) {
-                  $reusedarray = $renderarray;
-                  // Lets build our objects here!
-                  $default_scene->firstScene = "{$nid}";
-                  $single_scene_details = new \stdClass();
-                  $single_scene_details->title = $node->label();
-                  $single_scene_details->type = 'equirectangular';
-                  if (isset($scenes['hfov'])) {
-                    $single_scene_details->hfov = (int) $scenes['hfov'];
-                  }
-                  if (isset($scenes['pitch'])) {
-                    $single_scene_details->pitch = (int) $scenes['pitch'];
-                  }
-                  if (isset($scenes['yaw'])) {
-                    $single_scene_details->yaw = (int) $scenes['yaw'];
-                  }
-                  $single_scene_details->panorama = $renderarray['panorama1']['#attributes']['data-iiif-image'];
-                  $single_scene_details->panoramaMobile = $renderarray['panorama1']['#attributes']['data-iiif-image-mobile'];
-                  $single_scene_details->hotSpots = isset($scenes['hotspots']) ? $scenes['hotspots'] : [];
-                  // So. All scenes have this form: scene1-0 (more than 0-1 if SBF is multivalued)
-                  $single_scenes->{"$nid"} = clone $single_scene_details;
-                  $panorama_id = $renderarray['panorama1']['#attributes']['id'];
+        if (!$node) {
+          continue;
+        }
+        $type = $this->pluginId;
+        $settings = $this->getSettings();
+        // Let's reuse the same settings we have!
+        // but remove 'multiscene' key to make sure
+        // That we don't end loading circular
+        // references, deep tours in tours or even ourselves!
+        $settings['json_key_multiscene'] = '';
+        if ($this->checkAccess($node)) {
+          foreach ($node->{$fieldname} as $i => $delta) {
+            // @see \Drupal\Core\Entity\EntityViewBuilderInterface::viewField()
+            $renderarray = $delta->view(
+              ['type' => $type, 'settings' => $settings]
+            );
+            // We only want first image always.
+            if (isset($renderarray['panorama1'])) {
+              if ($key == 0) {
+                $reusedarray = $renderarray;
+                // Lets build our objects here!
+                $default_scene->firstScene = "{$nid}";
+                $single_scene_details = new \stdClass();
+                $single_scene_details->title = $node->label();
+                $single_scene_details->type = 'equirectangular';
+                if (isset($scenes['hfov'])) {
+                  $single_scene_details->hfov = (int) $scenes['hfov'];
+                }
+                if (isset($scenes['pitch'])) {
+                  $single_scene_details->pitch = (int) $scenes['pitch'];
+                }
+                if (isset($scenes['yaw'])) {
+                  $single_scene_details->yaw = (int) $scenes['yaw'];
+                }
+                $single_scene_details->panorama = $renderarray['panorama1']['#attributes']['data-iiif-image'];
+                $single_scene_details->panoramaMobile = $renderarray['panorama1']['#attributes']['data-iiif-image-mobile'];
+                $single_scene_details->hotSpots = isset($scenes['hotspots']) ? $scenes['hotspots'] : [];
+                // So. All scenes have this form: scene1-0 (more than 0-1 if SBF is multivalued)
+                $single_scenes->{"$nid"} = clone $single_scene_details;
+                $panorama_id = $renderarray['panorama1']['#attributes']['id'];
 
-                  unset($reusedarray['panorama1']["#attached"]["drupalSettings"]["format_strawberryfield"][$panorama_id]["hotspots"]);
+                unset($reusedarray['panorama1']["#attached"]["drupalSettings"]["format_strawberryfield"][$panorama_id]["hotspots"]);
+              }
+              else {
+                $single_scene_details->title = $node->label();
+                $single_scene_details->type = 'equirectangular';
+                if (isset($scenes['hfov'])) {
+                  $single_scene_details->hfov = (int) $scenes['hfov'];
                 }
-                else {
-                  $single_scene_details->title = $node->label();
-                  $single_scene_details->type = 'equirectangular';
-                  if (isset($scenes['hfov'])) {
-                    $single_scene_details->hfov = (int) $scenes['hfov'];
-                  }
-                  if (isset($scenes['pitch'])) {
-                    $single_scene_details->pitch = (int) $scenes['pitch'];
-                  }
-                  if (isset($scenes['yaw'])) {
-                    $single_scene_details->yaw = (int) $scenes['yaw'];
-                  }
-                  $single_scene_details->panorama = $renderarray['panorama1']['#attributes']['data-iiif-image'];
-                  // Adds the mobile version which on the JS will replace the normal panorama if
-                  // we are on mobile mode.
-                  $single_scene_details->panoramaMobile = $renderarray['panorama1']['#attributes']['data-iiif-image-mobile'];
-                  $single_scene_details->hotSpots = isset($scenes['hotspots']) ? $scenes['hotspots'] : [];
-                  $single_scenes->{"$nid"} = clone $single_scene_details;
+                if (isset($scenes['pitch'])) {
+                  $single_scene_details->pitch = (int) $scenes['pitch'];
                 }
+                if (isset($scenes['yaw'])) {
+                  $single_scene_details->yaw = (int) $scenes['yaw'];
+                }
+                $single_scene_details->panorama = $renderarray['panorama1']['#attributes']['data-iiif-image'];
+                // Adds the mobile version which on the JS will replace the normal panorama if
+                // we are on mobile mode.
+                $single_scene_details->panoramaMobile = $renderarray['panorama1']['#attributes']['data-iiif-image-mobile'];
+                $single_scene_details->hotSpots = isset($scenes['hotspots']) ? $scenes['hotspots'] : [];
+                $single_scenes->{"$nid"} = clone $single_scene_details;
               }
             }
           }
         }
       }
+    }
     $full_tour->default = $default_scene;
     $full_tour->scenes = $single_scenes;
     //@TODO we should validate these puppies probably.


### PR DESCRIPTION
@roromedia this includes your commits too. I hope this aligns with your needs and also the other override options.

Using this you can now avoid the more complex override that used the media key, and go for overrides at the formatter/settings level using the new JS override

like 
```
{
"mouseZoom": false
}
```

AND/Or at the Panorama Tour level like:

```
"ap:viewerhints": {
        "strawberry_pannellum_formatter": {
            "author": "RoRO"
        }
    },
```

AND/OR at the individual Panoramas referenced from the tour (so at the Panorama ADO level/raw JSON) via 


```
"ap:viewerhints": {
        "strawberry_pannellum_formatter": {
            "mouseZoom": true
        }
    },
```

And of course using as:formatter instead of "ap:viewerhints" and/or a $mediakey if you prefer that instead (which is not standard but I left it as a config option since this JS/PHP was the first one we extended before we made "ap:viewerhints" a global Viewer Override option)

Please test and let me know

This pull overrides #495 but includes your commits and also preserves your authorship/attribution.

Thanks