### PR TITLE
Issue 510b: Adds Explicit "hide on embargo" checkboxes to all Field Formatters (means Viewers too) + File Embargo

### DIFF
--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -84,6 +84,15 @@ format_strawberryfield.embargo_settings:
       type: boolean
       label: 'If Embargo is Globally enabled'
       default: false
+    global_ip_bypass_mode:
+      type: boolean
+      label: 'If Global IP Range Bypass Mode is enabled'
+      default: false
+    global_ip_bypass_addresses:
+      type: array
+      items:
+        type: string
+      label: 'global_ip_bypass_addresses list'
 
 field.formatter.settings.strawberry_audio_formatter:
   type: mapping

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -127,6 +127,9 @@ field.formatter.settings.strawberry_audio_formatter:
     embargo_json_key_source:
       type: string
       label: 'When embargoed, comma separated list of Audio and Subtitle Upload JSON keys to filter against'
+    hide_on_embargo:
+      type: string
+      label: 'Hide Viewer if embargo is resolved as embargoed.'
 field.formatter.settings.strawberry_image_formatter:
   type: mapping
   label: 'Specific Config for strawberry_image_formatter'
@@ -168,6 +171,9 @@ field.formatter.settings.strawberry_image_formatter:
     embargo_json_key_source:
       type: string
       label: 'When embargoed, comma separated list of Image Upload JSON keys to filter against'
+    hide_on_embargo:
+      type: string
+      label: 'Hide Viewer if embargo is resolved as embargoed.'
 field.formatter.settings.strawberry_media_formatter:
   type: mapping
   label: 'Specific Config for strawberry_media_formatter'
@@ -223,6 +229,9 @@ field.formatter.settings.strawberry_media_formatter:
     embargo_json_key_source:
       type: string
       label: 'When embargoed, comma separated list of Image Upload JSON keys to filter against'
+    hide_on_embargo:
+      type: string
+      label: 'Hide Viewer if embargo is resolved as embargoed.'
     mediasource:
       type: mapping
       label: 'Sources for IIIF URL'
@@ -242,9 +251,6 @@ field.formatter.settings.strawberry_media_formatter:
     viewer_overrides:
       type: string
       label: 'OSD JSON based Viewer Overrides'
-    hide_on_embargo:
-      type: string
-      label: 'Hide Viewer if embargo is resolved as embargoed.'
 
 field.formatter.settings.strawberry_3d_formatter:
   type: mapping
@@ -281,6 +287,9 @@ field.formatter.settings.strawberry_3d_formatter:
     embargo_json_key_source:
       type: string
       label: 'When embargoed, comma separated list of 3D Model, UV textures and MTL Upload JSON keys to filter against'
+    hide_on_embargo:
+      type: string
+      label: 'Hide Viewer if embargo is resolved as embargoed.'
 field.formatter.settings.strawberry_metadata_formatter:
   type: mapping
   label: 'Specific Config for strawberry_metadata_formatter using Twig'
@@ -372,7 +381,6 @@ field.formatter.settings.strawberry_paged_formatter:
       type: boolean
       label: 'If textselection from DjaVUXML should be enabled or not'
 
-
 field.formatter.settings.strawberry_pannellum_formatter:
   type: mapping
   label: 'Specific Config for strawberry_pannellum_formatter'
@@ -426,6 +434,9 @@ field.formatter.settings.strawberry_pannellum_formatter:
     viewer_overrides:
       type: string
       label: 'Pannellum JSON based Viewer Overrides'
+    hide_on_embargo:
+      type: string
+      label: 'Hide Viewer if embargo is resolved as embargoed.'
 
 field.formatter.settings.strawberry_video_formatter:
   type: mapping
@@ -464,6 +475,9 @@ field.formatter.settings.strawberry_video_formatter:
     embargo_json_key_source:
       type: string
       label: 'When embargoed, comma separated list of Video and Subtitle Upload JSON keys to filter against'
+    hide_on_embargo:
+      type: string
+      label: 'Hide Viewer if embargo is resolved as embargoed.'
 
 field.formatter.settings.strawberry_pdf_formatter:
   type: mapping
@@ -504,6 +518,10 @@ field.formatter.settings.strawberry_pdf_formatter:
     embargo_json_key_source:
       type: string
       label: 'When embargoed, comma separated list of PDF Upload JSON keys to filter against'
+    hide_on_embargo:
+      type: string
+      label: 'Hide Viewer if embargo is resolved as embargoed.'
+
 field.formatter.settings.strawberry_uv_formatter:
   type: mapping
   label: 'Specific Config for strawberry_uv_formatter'
@@ -633,6 +651,9 @@ field.formatter.settings.strawberry_warc_formatter:
     embargo_json_key_source:
       type: string
       label: 'When embargoed, comma separated list of WebArchive packages Upload JSON keys to filter against'
+    hide_on_embargo:
+      type: string
+      label: 'Hide Viewer if embargo is resolved as embargoed.'
 
 # Multiple JSON type / View Mode Mappings
 format_strawberryfield.viewmodemapping_settings:
@@ -735,6 +756,9 @@ field.formatter.settings.strawberry_map_formatter:
     embargo_json_key_source:
       type: string
       label: 'Not used. Inherited. When embargoed, comma separated list of Image Upload JSON keys to filter against'
+    hide_on_embargo:
+      type: string
+      label: 'Hide Viewer if embargo is resolved as embargoed.'
 # Given any DS field plugin formatter key a type
 ds.field_plugin.*:
   type: mapping
@@ -794,6 +818,9 @@ field.formatter.settings.strawberry_citation_formatter:
         label: 'style'
     localekey:
       type: string
+    hide_on_embargo:
+      type: string
+      label: 'Hide Viewer if embargo is resolved as embargoed.'
 condition.plugin.ado_type_condition:
   type: condition.plugin
   label: 'ADO Type Condition'
@@ -815,3 +842,27 @@ condition.plugin.ado_jmespath_condition:
       label: 'ADO JMESPATHS'
       sequence:
         type: string
+condition.plugin.ado_flavor_condition:
+  type: condition.plugin
+  label: 'ADO Flavor Condition'
+  mapping:
+    ado_flavors:
+      type: sequence
+      label: 'ADO Flavors'
+      sequence:
+        type: string
+    ado_flavors_op:
+      type: boolean
+      label: 'If all Flavours need to match'
+    ado_direct:
+      type: boolean
+      label: 'IF ADO has indexed (Search API) Flavor'
+    ado_children:
+      type: boolean
+      label: 'IF Children of ADO have at least one indexed (Search API) Flavour'
+    ado_grandchildren:
+      type: boolean
+      label: 'IF Grand Children of ADO have at least one indexed (Search API) Flavour'
+    ado_level_op:
+      type: boolean
+      label: 'IF all child levels need to match'

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -84,6 +84,10 @@ format_strawberryfield.embargo_settings:
       type: boolean
       label: 'If Embargo is Globally enabled'
       default: false
+    file_embargo_enabled:
+      type: boolean
+      label: 'If File download paths should also inherit embargo.'
+      default: false
     global_ip_bypass_enabled:
       type: boolean
       label: 'If Global IP Range Bypass Settings are enabled'

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -84,10 +84,14 @@ format_strawberryfield.embargo_settings:
       type: boolean
       label: 'If Embargo is Globally enabled'
       default: false
-    global_ip_bypass_mode:
+    global_ip_bypass_enabled:
       type: boolean
-      label: 'If Global IP Range Bypass Mode is enabled'
+      label: 'If Global IP Range Bypass Settings are enabled'
       default: false
+    global_ip_bypass_mode:
+      type: string
+      label: 'Global IP Range Bypass Mode'
+      default: 'local'
     global_ip_bypass_addresses:
       type: array
       items:

--- a/config/schema/format_strawberryfield.schema.yml
+++ b/config/schema/format_strawberryfield.schema.yml
@@ -9,7 +9,7 @@ format_strawberryfield.iiif_settings:
       type: string
       label: 'Internal IIIF server URL'
     iiif_content_search_api_page_count:
-      type: int
+      type: integer
       label: 'The max results to show per page on a iiif_content_search_api_page_count'
     iiif_content_search_api_visual_enabled_processors:
       type: string
@@ -21,13 +21,13 @@ format_strawberryfield.iiif_settings:
       type: string
       label: 'Comma separated list of Strawberry Runner Processors for plain text annotations (no OCR) that can be fetched by the Content Search API on query.'
     iiif_content_search_api_active:
-      type: bool
+      type: boolean
       label: 'If IIIF Content Search API V1 and V2 are enabled.'
     iiif_content_search_validate_exposed:
-      type: bool
+      type: boolean
       label: 'If IIIF Only explicit definitions in a manifest allow a search against them'
     iiif_content_search_time_targetannotations:
-      type: bool
+      type: boolean
       label: 'If IIIF Content Search results for Time based media target the VTT annotation itself or the parent Canvas'
     iiif_content_search_api_parent_node_fields:
       type: sequence
@@ -40,7 +40,7 @@ format_strawberryfield.iiif_settings:
         type: string
         label: 'A Search API field'
     iiif_content_search_api_metadata:
-      type: bool
+      type: boolean
       label: 'If IIIF Content Search Should also search/return metadata.'
     iiiif_content_search_api_metadata_parent_node_fields:
       type: sequence
@@ -61,10 +61,10 @@ format_strawberryfield.iiif_settings:
         type: string
         label: 'A Search API field'
     iiif_content_search_api_results_per_page:
-      type: int
+      type: string
       label: 'Number of results per page'
     iiif_content_search_api_query_length:
-      type: int
+      type: string
       label: 'max size of the allowed term passed (?q)'
 
 
@@ -93,8 +93,8 @@ format_strawberryfield.embargo_settings:
       label: 'Global IP Range Bypass Mode'
       default: 'local'
     global_ip_bypass_addresses:
-      type: array
-      items:
+      type: sequence
+      sequence:
         type: string
       label: 'global_ip_bypass_addresses list'
 

--- a/format_strawberryfield.module
+++ b/format_strawberryfield.module
@@ -475,7 +475,7 @@ function format_strawberryfield_views_post_render(ViewExecutable $view, &$output
                 $embargo_tags[] = 'format_strawberryfield:embargo:'
                   . $embargo_info[1];
               }
-              if ($embargo_info[2]) {
+              if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
                 $embargo_context[] = 'ip';
               }
             }

--- a/src/Controller/MetadataAPIController.php
+++ b/src/Controller/MetadataAPIController.php
@@ -563,7 +563,7 @@ class MetadataAPIController extends ControllerBase
                             $context_embargo['data_embargo']['until']
                               = $embargo_info[1];
                           }
-                          if ($embargo_info[2]) {
+                          if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
                             $embargo_context[] = 'ip';
                           }
                         } else {

--- a/src/Controller/MetadataDisplaySearchController.php
+++ b/src/Controller/MetadataDisplaySearchController.php
@@ -280,7 +280,7 @@ class MetadataDisplaySearchController extends
                 $embargo_tags[]= 'format_strawberryfield:embargo:'.$embargo_info[1];
                 $context_embargo['data_embargo']['until'] = $embargo_info[1];
               }
-              if ($embargo_info[2]) {
+              if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
                 $embargo_context[] = 'ip';
               }
             }

--- a/src/Controller/MetadataExposeDisplayController.php
+++ b/src/Controller/MetadataExposeDisplayController.php
@@ -236,7 +236,7 @@ class MetadataExposeDisplayController extends ControllerBase {
                 . $embargo_info[1];
               $context_embargo['data_embargo']['until'] = $embargo_info[1];
             }
-            if ($embargo_info[2]) {
+            if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
               $embargo_context[] = 'ip';
             }
           }

--- a/src/EmbargoResolver.php
+++ b/src/EmbargoResolver.php
@@ -331,4 +331,12 @@ class EmbargoResolver implements EmbargoResolverInterface {
     return FALSE;
   }
 
+  public function isEmbargoEnabled(): bool {
+    return (bool) $this->embargoConfig->get('enabled');
+  }
+
+  public function isFileEmbargoEnabled(): bool {
+    return (bool) ($this->embargoConfig->get('enabled') && $this->embargoConfig->get('file_embargo_enabled'));
+  }
+
 }

--- a/src/EmbargoResolverInterface.php
+++ b/src/EmbargoResolverInterface.php
@@ -25,4 +25,14 @@ interface EmbargoResolverInterface {
    */
   public function embargoInfo(ContentEntityInterface $entity, array $jsondata);
 
+  /**
+   * @return bool
+   */
+  public function isEmbargoEnabled():bool;
+
+  /**
+   * @return bool
+   */
+  public function isFileEmbargoEnabled():bool;
+
 }

--- a/src/Form/EmbargoSettingsForm.php
+++ b/src/Form/EmbargoSettingsForm.php
@@ -81,6 +81,19 @@ class EmbargoSettingsForm extends ConfigFormBase {
       '#required' => FALSE
     ];
 
+    $form['file_embargo_enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => 'Embargo Direct File Paths',
+      '#description' => $this->t('If enabled, users that cannot bypass an embargo, even if they know the direct path to a file, will not be able to download or stream media. The Site administrator will be responsible for hiding Formatters(Viewers) that are file based to avoid them showing up without media. Formatters will not act on this option and automatically hide themselves. IIIF URLs are not affected by this. Note: this has performance implications, especially on streamed media, even if the user is allowed to see an ADO that holds a media file.'),      '#description' => $this->t('If enabled, users that can not bypass an embargo, even if they know the direct path to a file, will not be able to download or stream. The Site administrator will be responsible of hiding Formatters(Viewers) that are file based to avoid them showing up without media. Formatters will not act automatically hiding themselves on this option. Note: this has performance implications, specially on streamed media, even if the user is allowed to see an ADO that holds a file.'),
+      '#default_value' => $config->get('file_embargo_enabled') ?? '',
+      '#required' => FALSE,
+      '#states' => [
+        'visible' => [
+          ':input[name="enabled"]' => ['checked' => true],
+        ],
+      ]
+    ];
+
     $form['global_ip_bypass_enabled'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Enable Global IP Range Bypass Settings'),
@@ -145,6 +158,7 @@ class EmbargoSettingsForm extends ConfigFormBase {
       ->set('date_until_json_key',trim($form_state->getValue('date_until_json_key')))
       ->set('ip_json_key', trim($form_state->getValue('ip_json_key')))
       ->set('enabled', (bool) $form_state->getValue('enabled'))
+      ->set('file_embargo_enabled', (bool) $form_state->getValue('file_embargo_enabled'))
       ->set('global_ip_bypass_enabled', (bool) $form_state->getValue('global_ip_bypass_enabled') ?? FALSE)
       ->set('global_ip_bypass_mode', $form_state->getValue('global_ip_bypass_mode') ?? 'local')
       ->set('global_ip_bypass_addresses', $global_ips ?? [])

--- a/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
@@ -139,6 +139,7 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
     $upload_keys = explode(',', $upload_keys_string);
     $upload_keys = array_filter($upload_keys);
     $upload_keys = array_map('trim', $upload_keys);
+    $hide_on_embargo =  $this->getSetting('hide_on_embargo') ?? FALSE;
     $embargo_context = [];
     $embargo_tags = [];
 
@@ -191,7 +192,7 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
         if ($embargo_info[1]) {
           $embargo_tags[]= 'format_strawberryfield:embargo:'.$embargo_info[1];
         }
-        if ($embargo_info[2]) {
+        if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
           $embargo_context[] = 'ip';
         }
       }
@@ -202,7 +203,7 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
         $upload_keys = $embargo_upload_keys_string;
       }
 
-      if (!$embargoed || !empty($embargo_upload_keys_string)) {
+      if (!$embargoed || (!empty($embargo_upload_keys_string) && !$hide_on_embargo) || ($embargoed && !$hide_on_embargo)) {
         $ordersubkey = 'sequence';
         $conditions_model[] = [
           'source' => ['dr:mimetype'],

--- a/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/Strawberry3DFormatter.php
@@ -322,7 +322,7 @@ class Strawberry3DFormatter extends StrawberryBaseFormatter {
 
       if (empty($elements[$delta])) {
         $elements[$delta] = [
-          '#markup' => '<i class="fas fa-times-circle"></i>',
+          '#markup' => '<i class="d-none field-iiif-no-viewer"></i>',
           '#prefix' => '<span>',
           '#suffix' => '</span>',
         ];

--- a/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
@@ -286,7 +286,7 @@ class StrawberryAudioFormatter extends StrawberryDirectJsonFormatter {
 
         if (empty($elements[$delta])) {
           $elements[$delta] = [
-            '#markup' => '<i class="fas fa-times-circle"></i>',
+            '#markup' => '<i class="d-none field-iiif-no-viewer"></i>',
             '#prefix' => '<span>',
             '#suffix' => '</span>',
           ];

--- a/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryAudioFormatter.php
@@ -127,6 +127,7 @@ class StrawberryAudioFormatter extends StrawberryDirectJsonFormatter {
     $upload_keys_string = strlen(trim($this->getSetting('upload_json_key_source') ?? '')) > 0 ? trim($this->getSetting('upload_json_key_source')) : '';
     $upload_keys = explode(',', $upload_keys_string);
     $upload_keys = array_filter($upload_keys);
+    $hide_on_embargo =  $this->getSetting('hide_on_embargo') ?? FALSE;
     $embargo_context = [];
     $embargo_tags = [];
 
@@ -198,7 +199,7 @@ class StrawberryAudioFormatter extends StrawberryDirectJsonFormatter {
         if ($embargo_info[1]) {
           $embargo_tags[]= 'format_strawberryfield:embargo:'.$embargo_info[1];
         }
-        if ($embargo_info[2]) {
+        if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
           $embargo_context[] = 'ip';
         }
       }
@@ -209,7 +210,7 @@ class StrawberryAudioFormatter extends StrawberryDirectJsonFormatter {
         $upload_keys = $embargo_upload_keys_string;
       }
 
-      if (!$embargoed || !empty($embargo_upload_keys_string)) {
+      if (!$embargoed || (!empty($embargo_upload_keys_string) && !$hide_on_embargo) || ($embargoed && !$hide_on_embargo)) {
         $ordersubkey = 'sequence';
         $media = $this->fetchMediaFromJsonWithFilter($delta, $items, $elements,
           TRUE, $jsondata, 'Audio', $key, $ordersubkey, $number_media,

--- a/src/Plugin/Field/FieldFormatter/StrawberryBaseFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryBaseFormatter.php
@@ -122,6 +122,7 @@ abstract class StrawberryBaseFormatter extends FormatterBase implements Containe
       'use_iiif_globals' => TRUE,
       'upload_json_key_source' => '',
       'embargo_json_key_source' => '',
+      'hide_on_embargo' => TRUE
     ];
   }
 
@@ -166,6 +167,9 @@ abstract class StrawberryBaseFormatter extends FormatterBase implements Containe
     ]);
     $summary[] = $this->t('Embargo Alternate upload JSON Keys: %value', [
       '%value' => strlen(trim($this->getSetting('embargo_json_key_source' ) ?? '')) == 0 ? 'Do not provide alternate files when embargoed' : $this->getSetting('embargo_json_key_source')
+    ]);
+    $summary[] = $this->t('Viewer for embargoed Objects is %hide', [
+        '%hide' => $this->getSetting('hide_on_embargo') ? 'hidden' : 'visible'
     ]);
     return $summary;
   }
@@ -237,6 +241,16 @@ abstract class StrawberryBaseFormatter extends FormatterBase implements Containe
         ],
       ],
       '#element_validate' => [[$this, 'validateUrl']],
+    ];
+    $element['hide_on_embargo'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Hide the Viewer in the presence of an Embargo.'),
+      '#description' => $this->t('Recommended. If unchecked, acting on an embargo could still be managed at either a Metadata Display Level (e.g a IIIF Manifest) or the Media/File itself, if enabled.'),
+      '#default_value' => $this->getSetting('hide_on_embargo') ?? FALSE,
+      '#required' => FALSE,
+      '#attributes' => [
+        'data-formatter-selector' => 'hide_on_embargo',
+      ],
     ];
 
     return $element;

--- a/src/Plugin/Field/FieldFormatter/StrawberryCitationFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryCitationFormatter.php
@@ -238,6 +238,7 @@ class StrawberryCitationFormatter extends StrawberryBaseFormatter {
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
     $metadatadisplayentity_uuid = $this->getSetting('metadatadisplayentity_uuid');
+    $hide_on_embargo =  $this->getSetting('hide_on_embargo') ?? FALSE;
     $nodeid = $items->getEntity()->id();
     $embargo_context = [];
     $embargo_tags = [];
@@ -292,7 +293,7 @@ class StrawberryCitationFormatter extends StrawberryBaseFormatter {
           $embargo_tags[]= 'format_strawberryfield:embargo:'.$embargo_info[1];
           $context_embargo['data_embargo']['until'] = $embargo_info[1];
         }
-        if ($embargo_info[2]) {
+        if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
           $embargo_context[] = 'ip';
         }
       }
@@ -301,74 +302,77 @@ class StrawberryCitationFormatter extends StrawberryBaseFormatter {
       }
 
       try {
-        // @TODO So we can generate two type of outputs here,
-        // A) HTML visible (like smart metadata displays)
-        // B) Downloadable formats.
-        // C) Embeded (but hidden JSON-LD, etc)
-        // So we need to make sure People can "tag" that need.
+        if (!$embargoed || ($embargoed && !$hide_on_embargo)) {
+          // @TODO So we can generate two type of outputs here,
+          // A) HTML visible (like smart metadata displays)
+          // B) Downloadable formats.
+          // C) Embeded (but hidden JSON-LD, etc)
+          // So we need to make sure People can "tag" that need.
 
-        // Order as: structures based on sequence key
-        // We will assume here people are using our automatic keys
-        // If they are using other ones, they will have to apply ordering
-        // Directly on their Twig Templates.
-        $ordersubkey = 'sequence';
-        foreach (StrawberryfieldJsonHelper::AS_FILE_TYPE as $key) {
-          StrawberryfieldJsonHelper::orderSequence($jsondata, $key, $ordersubkey);
-        }
-        $context = [
-            'data' => $jsondata,
-            'node' => $items->getEntity(),
-            'iiif_server' => $this->getIiifUrls()['public'],
-          ] + $context_embargo;
-        $original_context = $context;
+          // Order as: structures based on sequence key
+          // We will assume here people are using our automatic keys
+          // If they are using other ones, they will have to apply ordering
+          // Directly on their Twig Templates.
+          $ordersubkey = 'sequence';
+          foreach (StrawberryfieldJsonHelper::AS_FILE_TYPE as $key) {
+            StrawberryfieldJsonHelper::orderSequence($jsondata, $key, $ordersubkey);
+          }
+          $context = [
+              'data' => $jsondata,
+              'node' => $items->getEntity(),
+              'iiif_server' => $this->getIiifUrls()['public'],
+            ] + $context_embargo;
+          $original_context = $context;
 
-        // Allow other modules to provide extra Context!
-        // Call modules that implement the hook, and let them add items.
-        \Drupal::moduleHandler()->alter('format_strawberryfield_twigcontext', $context);
-        // In case someone decided to wipe the original context?
-        // We bring it back!
-        $context = $context + $original_context;
-        // Render data from metadata template into JSON string.
-        $rendered_json_string = $metadatadisplayentity->renderNative($context);
+          // Allow other modules to provide extra Context!
+          // Call modules that implement the hook, and let them add items.
+          \Drupal::moduleHandler()
+            ->alter('format_strawberryfield_twigcontext', $context);
+          // In case someone decided to wipe the original context?
+          // We bring it back!
+          $context = $context + $original_context;
+          // Render data from metadata template into JSON string.
+          $rendered_json_string = $metadatadisplayentity->renderNative($context);
 
-        // Get styles selected from formatter settings.
-        $selected_styles = $this->settings['citationstyle'];
-        // Get language key from settings.
-        $selected_locale_key = false;
-        if ($this->getSetting('localekey')) {
-          $selected_locale_key = $this->settings['localekey'];
-        }
-        $selected_locale_value = array_key_exists($selected_locale_key, $jsondata) ? $jsondata[$selected_locale_key] : false;
-        if ($selected_locale_value) {
-          $available_locale = trim($selected_locale_value);
-        }
-        elseif ($langcode) {
-          $available_locale = trim($langcode);
-        }
+          // Get styles selected from formatter settings.
+          $selected_styles = $this->settings['citationstyle'];
+          // Get language key from settings.
+          $selected_locale_key = FALSE;
+          if ($this->getSetting('localekey')) {
+            $selected_locale_key = $this->settings['localekey'];
+          }
+          $selected_locale_value = array_key_exists($selected_locale_key, $jsondata) ? $jsondata[$selected_locale_key] : FALSE;
+          if ($selected_locale_value) {
+            $available_locale = trim($selected_locale_value);
+          }
+          elseif ($langcode) {
+            $available_locale = trim($langcode);
+          }
 
-        $data = json_decode($rendered_json_string);
-        $json_error = json_last_error();
-        if ($json_error != JSON_ERROR_NONE) {
-          $message = $this->t('There was an issue decoding your metadata as JSON for node @id, field @field',
-            [
-              '@id' => $nodeid,
-              '@field' => $items->getName(),
-            ]);
-          return $elements[$delta] = ['#markup' => $message];
+          $data = json_decode($rendered_json_string);
+          $json_error = json_last_error();
+          if ($json_error != JSON_ERROR_NONE) {
+            $message = $this->t('There was an issue decoding your metadata as JSON for node @id, field @field',
+              [
+                '@id' => $nodeid,
+                '@field' => $items->getName(),
+              ]);
+            return $elements[$delta] = ['#markup' => $message];
+          }
+          $render = new Render();
+          $bibliography = $render->bibliography($available_locale, $selected_styles, $data);
+          $elements[$delta] = [
+            '#type' => 'container',
+            '#attributes' => [
+              'id' => 'bibliography' . $uniqueid,
+              'class' => ['bibliography'],
+            ]
+          ];
+          $elements[$delta]['#attached']['library'][] = 'format_strawberryfield/citations_strawberry';
+          $elements[$delta]['bibliography'] = [
+            '#markup' => \Drupal\Core\Render\Markup::create($bibliography),
+          ];
         }
-        $render = new Render();
-        $bibliography = $render->bibliography($available_locale, $selected_styles, $data);
-        $elements[$delta] = [
-          '#type' => 'container',
-          '#attributes' => [
-            'id' => 'bibliography' . $uniqueid,
-            'class' => ['bibliography'],
-          ]
-        ];
-        $elements[$delta]['#attached']['library'][] = 'format_strawberryfield/citations_strawberry';
-        $elements[$delta]['bibliography'] = [
-          '#markup' => \Drupal\Core\Render\Markup::create($bibliography),
-        ];
       }
       catch (\Exception $e) {
         // Render each element as markup.

--- a/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryImageFormatter.php
@@ -178,7 +178,7 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
           $embargo_tags[] = 'format_strawberryfield:embargo:' . $embargo_info[1];
           $context_embargo['data_embargo']['until'] = $embargo_info[1];
         }
-        if ($embargo_info[2]) {
+        if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
           $embargo_context[] = 'ip';
         }
       } else {
@@ -199,7 +199,7 @@ class StrawberryImageFormatter extends StrawberryBaseFormatter {
         $upload_keys = $embargo_upload_keys;
       }
 
-      if (!$embargoed || (!empty($embargo_upload_keys_string))) {
+      if (!$embargoed || (!empty($embargo_upload_keys_string) && !$hide_on_embargo) || ($embargoed && !$hide_on_embargo)) {
         $ordersubkey = 'sequence';
         $media = $this->fetchMediaFromJsonWithFilter(
           $delta, $items, $elements,

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -325,7 +325,7 @@ Not all options can be overriden. `id`,`tileSources`, `element` and other might 
       }
       if (empty($elements[$delta])) {
         $elements[$delta] = [
-          '#markup' => '<i class="d-none fas fa-times-circle"></i>',
+          '#markup' => '<i class="d-none field-iiif-no-viewer"></i>',
           '#prefix' => '<span>',
           '#suffix' => '</span>',
         ];

--- a/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMediaFormatter.php
@@ -58,7 +58,6 @@ class StrawberryMediaFormatter extends StrawberryBaseIIIFManifestFormatter {
         'viewer_overrides' => '',
         'mediasource' => NULL,
         'main_mediasource' => NULL,
-        'hide_on_embargo' => FALSE,
       ] + parent::defaultSettings();
   }
 
@@ -236,11 +235,6 @@ Not all options can be overriden. `id`,`tileSources`, `element` and other might 
         '%max_height' => $this->getSetting('max_height') . ' pixels',
       ]
     );
-    $summary[] = $this->t('Viewer for embargoed Objects is %hide',
-      [
-        '%hide' => $this->getSetting('hide_on_embargo') ? 'hidden' : 'visible'
-      ]
-    );
 
     return $summary;
   }
@@ -289,7 +283,6 @@ Not all options can be overriden. `id`,`tileSources`, `element` and other might 
          "checksum": "f231aed5ae8c2e02ef0c5df6fe38a99b"
          }
       }*/
-      $embargoed = FALSE;
       $embargo_info = $this->embargoResolver->embargoInfo($items->getEntity(), $jsondata);
       // Check embargo
       if (is_array($embargo_info)) {
@@ -298,7 +291,7 @@ Not all options can be overriden. `id`,`tileSources`, `element` and other might 
         if ($embargo_info[1]) {
           $embargo_tags[] = 'format_strawberryfield:embargo:' . $embargo_info[1];
         }
-        if ($embargo_info[2]) {
+        if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
           $embargo_context[] = 'ip';
         }
       }

--- a/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMetadataTwigFormatter.php
@@ -111,11 +111,14 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
    * {@inheritdoc}
    */
   public static function defaultSettings() {
-    return parent::defaultSettings() + [
+    $settings = parent::defaultSettings();
+    unset($settings['hide_on_embargo']);
+    return $settings + [
       'label' => 'Descriptive Metadata',
       'specs' => 'http://schema.org',
       'metadatadisplayentity_uuid' => NULL,
       'metadatadisplayentity_uselabel' => TRUE,
+      'hide_on_embargo' => FALSE
     ];
   }
 
@@ -124,12 +127,12 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
    */
   public function settingsForm(array $form, FormStateInterface $form_state) {
     $entity = NULL;
+    $form = parent::settingsForm($form, $form_state);
     if ($this->getSetting('metadatadisplayentity_uuid')) {
       $entities = $this->entityTypeManager->getStorage('metadatadisplay_entity')->loadByProperties(['uuid' => $this->getSetting('metadatadisplayentity_uuid')]);
       $entity = reset($entities);
     }
-
-    return [
+    $form = $form + [
       'customtext' => [
         '#markup' => '<h3>Use this form to select the template for your metadata.</h3><p>Several templates such as MODS 3.6 and a simple Object Description ship with Archipelago. To design your own template for any metadata standard you like, or see the full list of existing templates, visit <a href="/metadatadisplay/list">/metadatadisplay/list</a>. </p>',
       ],
@@ -163,6 +166,10 @@ class StrawberryMetadataTwigFormatter extends StrawberryBaseFormatter implements
         '#default_value' => $this->getSetting('metadatadisplayentity_uselabel'),
       ],
     ];
+    // These don't apply to this Formatter.
+    unset($form['upload_json_key_source']);
+    unset($form['embargo_json_key_source']);
+    return $form;
   }
 
   /**

--- a/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
@@ -121,7 +121,9 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
    * {@inheritdoc}
    */
   public static function defaultSettings() {
-    return parent::defaultSettings() + [
+    $settings = parent::defaultSettings();
+    unset($settings['hide_on_embargo']);
+    return $settings + [
         'mediasource' => [
           'metadataexposeentity' => 'metadataexposeentity',
         ],
@@ -134,7 +136,7 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
         'viewer_overrides' => '',
         'max_width' => 720,
         'max_height' => 480,
-        'hide_on_embargo' => TRUE,
+        'hide_on_embargo' => FALSE,
       ];
   }
 
@@ -654,7 +656,7 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
       }
       if (empty($elements[$delta])) {
         $elements[$delta] = [
-          '#markup' => '<i class="d-none fas fa-times-circle"></i>',
+          '#markup' => '<i class="d-none field-iiif-no-viewer"></i>',
           '#prefix' => '<span>',
           '#suffix' => '</span>',
         ];

--- a/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryMiradorFormatter.php
@@ -134,7 +134,7 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
         'viewer_overrides' => '',
         'max_width' => 720,
         'max_height' => 480,
-        'hide_on_embargo' => FALSE,
+        'hide_on_embargo' => TRUE,
       ];
   }
 
@@ -464,11 +464,6 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
     if ($this->getSetting('custom_js')) {
       $summary[] = $this->t('Using Custom Mirador with Plugins');
     }
-    $summary[] = $this->t('Viewer for embargoed Objects is %hide',
-      [
-        '%hide' => $this->getSetting('hide_on_embargo') ? 'hidden' : 'visible'
-      ]
-    );
 
     return array_merge($summary, parent::settingsSummary());
   }
@@ -484,7 +479,7 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
     $max_height = $this->getSetting('max_height');
     $mediasource = is_array($this->getSetting('mediasource')) ? $this->getSetting('mediasource') : [];
     $main_mediasource = $this->getSetting('main_mediasource');
-    $hide_on_embargo =  $this->getSetting('hide_on_embargo');
+    $hide_on_embargo =  $this->getSetting('hide_on_embargo') ?? FALSE;
     $viewer_overrides = $this->getSetting('viewer_overrides');
     $viewer_overrides_json = json_decode(trim($viewer_overrides), TRUE);
 
@@ -558,7 +553,7 @@ class StrawberryMiradorFormatter extends StrawberryBaseFormatter implements Cont
             $embargo_tags[] = 'format_strawberryfield:embargo:'
               . $embargo_info[1];
           }
-          if ($embargo_info[2]) {
+          if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
             $embargo_context[] = 'ip';
           }
         }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
@@ -121,7 +121,9 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
    * {@inheritdoc}
    */
   public static function defaultSettings() {
-    return parent::defaultSettings() + [
+    $settings = parent::defaultSettings();
+    unset($settings['hide_on_embargo']);
+    return $settings + [
         'iiif_group' => TRUE,
         'mediasource' => 'json_key',
         'json_key_source' => 'as:image',
@@ -132,6 +134,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
         'max_height' => 480,
         'textselection' => FALSE,
         'hascover_json_key_source' => 'hascover',
+        'hide_on_embargo' => FALSE,
         'ia_reader_images_base_url' => 'https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.40.3/BookReader/images/',
       ];
   }
@@ -612,7 +615,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
 
     if (empty($element)) {
       $element = [
-        '#markup' => '<i class="d-none fas fa-times-circle"></i>',
+        '#markup' => '<i class="d-none field-iiif-no-viewer"></i>',
         '#prefix' => '<span>',
         '#suffix' => '</span>',
       ];

--- a/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPagedFormatter.php
@@ -130,7 +130,6 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
         'metadataexposeentity_source' => NULL,
         'max_width' => 720,
         'max_height' => 480,
-        'hide_on_embargo' => FALSE,
         'textselection' => FALSE,
         'hascover_json_key_source' => 'hascover',
         'ia_reader_images_base_url' => 'https://cdn.jsdelivr.net/gh/internetarchive/bookreader@4.40.3/BookReader/images/',
@@ -362,12 +361,6 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
       ]
     );
 
-    $summary[] = $this->t('Viewer for embargoed Objects is %hide',
-      [
-        '%hide' => $this->getSetting('hide_on_embargo') ? 'hidden' : 'visible'
-      ]
-    );
-
     $summary[] = $this->t('JSON key providing Book Cover configuration: %key',
       [
         '%key' => $this->getSetting('hascover_json_key_source') ?? 'hascover'
@@ -548,7 +541,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
               . $embargo_info[1];
             $context_embargo['data_embargo']['until'] = $embargo_info[1];
           }
-          if ($embargo_info[2]) {
+          if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
             $embargo_context[] = 'ip';
           }
         }
@@ -714,7 +707,7 @@ class StrawberryPagedFormatter extends StrawberryBaseFormatter implements Contai
         $embargo_tags[] = 'format_strawberryfield:embargo:'
           . $embargo_info[1];
       }
-      if ($embargo_info[2]) {
+      if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
         $embargo_context[] = 'ip';
       }
     }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -611,7 +611,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
                   // Should we put a thumb? Just hide?
                   // @TODO we can bring a plugin here and there that deals with
                   $elements[$delta]['panorama' . $i] = [
-                    '#markup' => '<i class="fas fa-times-circle"></i>',
+                    '#markup' => '<i class="d-none field-iiif-no-viewer"></i>',
                     '#prefix' => '<span>',
                     '#suffix' => '</span>',
                   ];

--- a/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPannellumFormatter.php
@@ -277,6 +277,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
     $upload_keys = explode(',', $upload_keys_string);
     $upload_keys = array_filter($upload_keys);
     $upload_keys = array_map('trim', $upload_keys);
+    $hide_on_embargo =  $this->getSetting('hide_on_embargo') ?? FALSE;
     $embargo_context = [];
     $embargo_tags = [];
 
@@ -353,7 +354,7 @@ class StrawberryPannellumFormatter extends StrawberryBaseFormatter {
           $embargo_tags[]= 'format_strawberryfield:embargo:'.$embargo_info[1];
           $context_embargo['data_embargo']['until'] = $embargo_info[1];
         }
-        if ($embargo_info[2]) {
+        if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
           $embargo_context[] = 'ip';
         }
       }

--- a/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
@@ -257,7 +257,7 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
 
       if (empty($elements[$delta])) {
         $elements[$delta] = [
-          '#markup' => '<i class="fas fa-times-circle"></i>',
+          '#markup' => '<i class="d-none field-iiif-no-viewer"></i>',
           '#prefix' => '<span>',
           '#suffix' => '</span>',
         ];

--- a/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryPdfFormatter.php
@@ -168,6 +168,8 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
     $upload_keys_string = strlen(trim($this->getSetting('upload_json_key_source') ?? '')) > 0 ? trim($this->getSetting('upload_json_key_source')) : '';
     $upload_keys = explode(',', $upload_keys_string);
     $upload_keys = array_filter($upload_keys);
+    $hide_on_embargo =  $this->getSetting('hide_on_embargo') ?? FALSE;
+    $embargoed = FALSE;
     $embargo_context = [];
     $embargo_tags = [];
 
@@ -233,7 +235,7 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
           $embargo_tags[]= 'format_strawberryfield:embargo:'.$embargo_info[1];
           $context_embargo['data_embargo']['until'] = $embargo_info[1];
         }
-        if ($embargo_info[2]) {
+        if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
           $embargo_context[] = 'ip';
         }
       }
@@ -241,7 +243,7 @@ class StrawberryPdfFormatter extends StrawberryBaseFormatter {
         $context_embargo['data_embargo']['embargoed'] = $embargo_info;
       }
 
-      if (!$embargoed || !empty($embargo_upload_keys_string)) {
+      if (!$embargoed || (!empty($embargo_upload_keys_string) && !$hide_on_embargo) || ($embargoed && !$hide_on_embargo)) {
         $ordersubkey = 'sequence';
         $conditions[] = [
           'source' => ['dr:mimetype'],

--- a/src/Plugin/Field/FieldFormatter/StrawberryUVFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryUVFormatter.php
@@ -121,10 +121,13 @@ class StrawberryUVFormatter extends StrawberryBaseFormatter implements Container
    * {@inheritdoc}
    */
   public static function defaultSettings() {
-    return parent::defaultSettings() + [
+    $settings = parent::defaultSettings();
+    unset($settings['hide_on_embargo']);
+    return $settings + [
         'metadataexposeentity_source' => NULL,
         'max_width' => 720,
-        'max_height' => 480
+        'max_height' => 480,
+        'hide_on_embargo' => FALSE,
       ];
   }
 
@@ -354,7 +357,7 @@ class StrawberryUVFormatter extends StrawberryBaseFormatter implements Container
       }
       if (empty($elements[$delta])) {
         $elements[$delta] = [
-          '#markup' => '<i class="d-none fas fa-times-circle"></i>',
+          '#markup' => '<i class="d-none field-iiif-no-viewer"></i>',
           '#prefix' => '<span>',
           '#suffix' => '</span>',
         ];

--- a/src/Plugin/Field/FieldFormatter/StrawberryUVFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryUVFormatter.php
@@ -124,8 +124,7 @@ class StrawberryUVFormatter extends StrawberryBaseFormatter implements Container
     return parent::defaultSettings() + [
         'metadataexposeentity_source' => NULL,
         'max_width' => 720,
-        'max_height' => 480,
-        'hide_on_embargo' => FALSE,
+        'max_height' => 480
       ];
   }
 
@@ -236,11 +235,6 @@ class StrawberryUVFormatter extends StrawberryBaseFormatter implements Container
         '%max_height' => $this->getSetting('max_height') . ' pixels',
       ]
     );
-    $summary[] = $this->t('Viewer for embargoed Objects is %hide',
-      [
-        '%hide' => $this->getSetting('hide_on_embargo') ? 'hidden' : 'visible'
-      ]
-    );
     return array_merge($summary, parent::settingsSummary());
   }
 
@@ -254,7 +248,7 @@ class StrawberryUVFormatter extends StrawberryBaseFormatter implements Container
     $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width .'px';
     $max_height = $this->getSetting('max_height');
 
-    $hide_on_embargo =  $this->getSetting('hide_on_embargo');
+    $hide_on_embargo =  $this->getSetting('hide_on_embargo') ?? FALSE;
     // This won't be evaluated and will stay false even if embargoed
     // if hide_on_embargo is not enabled
     // bc all embargo decision will anyways be delegated to the
@@ -294,7 +288,7 @@ class StrawberryUVFormatter extends StrawberryBaseFormatter implements Container
             $embargo_tags[] = 'format_strawberryfield:embargo:'
               . $embargo_info[1];
           }
-          if ($embargo_info[2]) {
+          if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
             $embargo_context[] = 'ip';
           }
         }

--- a/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
@@ -313,7 +313,7 @@ class StrawberryVideoFormatter extends StrawberryDirectJsonFormatter {
 
         if (empty($elements[$delta])) {
           $elements[$delta] = [
-            '#markup' => '<i class="fas fa-times-circle"></i>',
+            '#markup' => '<i class="d-none field-iiif-no-viewer"></i>',
             '#prefix' => '<span>',
             '#suffix' => '</span>',
           ];

--- a/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryVideoFormatter.php
@@ -156,6 +156,7 @@ class StrawberryVideoFormatter extends StrawberryDirectJsonFormatter {
     $upload_keys_string = strlen(trim($this->getSetting('upload_json_key_source') ?? '')) > 0 ? trim($this->getSetting('upload_json_key_source')) : '';
     $upload_keys = explode(',', $upload_keys_string);
     $upload_keys = array_filter($upload_keys);
+    $hide_on_embargo =  $this->getSetting('hide_on_embargo') ?? FALSE;
     $embargo_context = [];
     $embargo_tags = [];
 
@@ -228,7 +229,7 @@ class StrawberryVideoFormatter extends StrawberryDirectJsonFormatter {
         if ($embargo_info[1]) {
           $embargo_tags[] = 'format_strawberryfield:embargo:' . $embargo_info[1];
         }
-        if ($embargo_info[2]) {
+        if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
           $embargo_context[] = 'ip';
         }
       }
@@ -239,7 +240,7 @@ class StrawberryVideoFormatter extends StrawberryDirectJsonFormatter {
         $upload_keys = $embargo_upload_keys_string;
       }
 
-      if (!$embargoed || !empty($embargo_upload_keys_string)) {
+      if (!$embargoed || (!empty($embargo_upload_keys_string) && !$hide_on_embargo) || ($embargoed && !$hide_on_embargo)) {
         $ordersubkey = 'sequence';
         // This fetchMediaFromJsonWithFilter impl. has JMESPATH filtering.
         $media = $this->fetchMediaFromJsonWithFilter($delta, $items, $elements,

--- a/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
@@ -139,6 +139,7 @@ class StrawberryWarcFormatter extends StrawberryDirectJsonFormatter {
     $navbar = $this->getSetting('navbar');
     $max_width_css = empty($max_width) || $max_width == 0 ? '100%' : $max_width . 'px';
     $max_height = $this->getSetting('max_height');
+    $hide_on_embargo =  $this->getSetting('hide_on_embargo') ?? FALSE;
     //@TODO allow more than one?
     $number_warcs = $this->getSetting('number_warcs');
 
@@ -202,7 +203,7 @@ class StrawberryWarcFormatter extends StrawberryDirectJsonFormatter {
         if ($embargo_info[1]) {
           $embargo_tags[] = 'format_strawberryfield:embargo:' . $embargo_info[1];
         }
-        if ($embargo_info[2]) {
+        if ($embargo_info[2] || ($embargo_info[3] == FALSE)) {
           $embargo_context[] = 'ip';
         }
       }
@@ -213,7 +214,7 @@ class StrawberryWarcFormatter extends StrawberryDirectJsonFormatter {
         $upload_keys = $embargo_upload_keys_string;
       }
 
-      if (!$embargoed || !empty($embargo_upload_keys_string)) {
+      if (!$embargoed || (!empty($embargo_upload_keys_string) && !$hide_on_embargo) || ($embargoed && !$hide_on_embargo)) {
         $ordersubkey = 'sequence';
         // Since the conditionals here are more complex
         // we do not call $this->fetchMediaFromJsonWithFilter()

--- a/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryWarcFormatter.php
@@ -323,7 +323,7 @@ class StrawberryWarcFormatter extends StrawberryDirectJsonFormatter {
               // Should we put a thumb? Just hide?
               // @TODO we can bring a plugin here and there that deals with
               $elements[$delta]['media_thumb' . $i] = [
-                '#markup' => '<i class="fas fa-times-circle"></i>',
+                '#markup' => '<i class="d-none field-iiif-no-viewer"></i>',
                 '#prefix' => '<span>',
                 '#suffix' => '</span>',
               ];


### PR DESCRIPTION
See #510 

Note for @alliomeria. Many already were hiding on embargo automatically EVEN without the checkbox. We only added the checkbox to IIIF driven ones (Mirador/OSD/UV), bc those would also allow the user to act at the template level, so the extra flexibility was needed.

With this now in place (unified UI). one could actually end in a more "insecure" situation for viewers that were automatically secured before. That is why I made the default == TRUE.

We will have to doc.

I even added the option for Maps and Metadata Displays, so one could actually hide "Object Description" completely if one wanted to do so.

This also includes now "Direct/At the file level" resolved embargo + finally removed the (X) mark on hidden viewers