### PR TITLE
ISSUE-524: better native solr date range handling, better date math/timezone and also stricter checks on User input

### DIFF
--- a/modules/format_strawberryfield_facets/js/slider.js
+++ b/modules/format_strawberryfield_facets/js/slider.js
@@ -35,8 +35,12 @@
       let ctx = element.getContext('2d');
       let chart_data  = JSON.parse(settings.chart_data);
       let chart_labels = JSON.parse(settings.chart_labels);
+      let chart_type = "line";
+      if (chart_data.length == 1) {
+        chart_type = "bar"
+      }
       let histogram = new Chart(ctx, {
-        type: 'line',
+        type: chart_type,
         data: {
           labels: chart_labels,
           datasets: [

--- a/modules/format_strawberryfield_facets/js/slider.js
+++ b/modules/format_strawberryfield_facets/js/slider.js
@@ -48,7 +48,7 @@
               fill: true,
               stepped: true,
               showLine: true,
-              tension: 0.5
+              tension: 0.4
             },
           ]
         },
@@ -84,7 +84,6 @@
                   family: 'Arial'
                 },
                 ticks: {
-                  // forces step size to be 50 units
                   stepSize: 10
                 },
                 color: 'black'
@@ -134,14 +133,11 @@
       function autoSubmit(widget) {
         const slider = widget.querySelector('.sbf-date-facet-slider')
         const url = slider.dataset.drupalUrl;
-        console.log(slider.dataset.min);
-        console.log(slider.dataset.max);
         return url.replace('__date_range_min__', slider.dataset.min).replace('__date_range_max__', slider.dataset.max);
       }
 
       // Click on link will call Facets JS API on widget element.
       var changeHandler = function (e) {
-        //e.preventDefault();
         var $widget = $(widget);
         $widget.trigger('facets_filter', [autoSubmit(widget)]);
       };
@@ -168,8 +164,6 @@
           labels: JSON.parse(slider_settings.labels)
         });
       var changeHandlerInput = function (e) {
-        //e.preventDefault();
-        let error = Drupal.t("Wrong date");
         const slider = widget.querySelector('.sbf-date-facet-slider')
         let min_timestamp =  slider.dataset.min;
         let max_timestamp =  slider.dataset.max;
@@ -189,7 +183,6 @@
           else {
             max = ui_max = parseInt(e.target.value);
             max_timestamp =  toTimestamp(max, 12, 31, 0, 0, 0, 0);
-            console.log(max_timestamp);
           }
         }
         else if (e.target.type == "date") {

--- a/modules/format_strawberryfield_facets/js/slider.js
+++ b/modules/format_strawberryfield_facets/js/slider.js
@@ -116,13 +116,12 @@
 
 
 
-
       function toTimestamp(year, month, day, hour = 0, minute = 0, second = 0, millisecond = 0) {
         // Date.parse works only on safari for BCE!
         // New approach. Date Constructor
         let date_from_parts = new Date();
         date_from_parts.setFullYear(parseInt(year));
-        date_from_parts.setMonth(parseInt(month));
+        date_from_parts.setMonth(parseInt(month)-1);
         date_from_parts.setDate(parseInt(day));
         date_from_parts.setHours(hour,minute,second,millisecond);
         const datum = date_from_parts.getTime();
@@ -135,6 +134,8 @@
       function autoSubmit(widget) {
         const slider = widget.querySelector('.sbf-date-facet-slider')
         const url = slider.dataset.drupalUrl;
+        console.log(slider.dataset.min);
+        console.log(slider.dataset.max);
         return url.replace('__date_range_min__', slider.dataset.min).replace('__date_range_max__', slider.dataset.max);
       }
 
@@ -187,7 +188,8 @@
           }
           else {
             max = ui_max = parseInt(e.target.value);
-            max_timestamp =  toTimestamp(max, 12, 31, 23, 59, 59, 999);
+            max_timestamp =  toTimestamp(max, 12, 31, 0, 0, 0, 0);
+            console.log(max_timestamp);
           }
         }
         else if (e.target.type == "date") {
@@ -205,7 +207,7 @@
               max = ui_max = date_from_input.getFullYear();
               let month = date_from_input.getMonth();
               let day = date_from_input.getDay();
-              max_timestamp = toTimestamp(min, month, day, 23, 59, 59, 999);
+              max_timestamp = toTimestamp(min, month, day, 0, 0, 0, 0);
             }
           }
         }
@@ -213,7 +215,6 @@
           e.target.reportValidity()
         }
         else {
-
           $slider.slider('option', 'values', [ui_min, ui_max]).slider("pips", "refresh").slider("float", "refresh");
           slider.dataset.min = min_timestamp;
           slider.dataset.max = max_timestamp;

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/processor/DateRangeProcessor.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/processor/DateRangeProcessor.php
@@ -113,7 +113,7 @@ class DateRangeProcessor extends ProcessorPluginBase implements PreQueryProcesso
         }
       }
 
-      $query[$filter_key][] = $facet->getUrlAlias() . $url_processor->getSeparator() . '(min:__range_slider_min__,max:__range_slider_max__)';
+      $query[$filter_key][] = $facet->getUrlAlias() . $url_processor->getSeparator() . '(min:__date_range_min__,max:__date_range_max__)';
       $url->setOption('query', $query);
       $result->setUrl($url);
     }

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/processor/DateRangeSliderProcessor.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/processor/DateRangeSliderProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\format_strawberryfield_facets\Plugin\facets\processor;
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\facets\FacetInterface;
 use Drupal\facets\Processor\BuildProcessorInterface;
 use Drupal\facets\Processor\PreQueryProcessorInterface;
@@ -127,6 +128,26 @@ class DateRangeSliderProcessor extends DateRangeProcessor implements PreQueryPro
       }
     }
     return $results;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state, FacetInterface $facet) {
+    $configuration = $this->getConfiguration();
+
+    $build['enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Use Format Strawberryfield Date Range Slider'),
+      '#default_value' => $configuration['enabled'],
+      '#states' => [
+        'required' => [
+          ':input[name="facet_settings[sbf_date_range_slider][status]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    return $build;
   }
 
 }

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/query_type/SearchApiDateRange.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/query_type/SearchApiDateRange.php
@@ -91,8 +91,9 @@ class SearchApiDateRange extends QueryTypePluginBase {
                 $dt_max = new DateTime($dt_max_utc->format('Y-m-d\TH:i:s'), new DateTimeZone($time_zone));
                 // Offset can be retrieved from both min or max.
                 $offset = $dt_max->getOffset() / 3600;
-
+                $offset = (int) $offset;
                 if ($offset < 0) {
+
                   $min_value = $dt_min->add(new DateInterval('PT' . abs($offset) . 'H'))
                     ->format('Y-m-d\TH:i:s\Z');
                   $max_value = $dt_max->add(new DateInterval('PT' . abs($offset) . 'H'))
@@ -208,5 +209,4 @@ class SearchApiDateRange extends QueryTypePluginBase {
       'include_edges' => TRUE,
     ];
   }
-
 }

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/query_type/SearchApiDateRange.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/query_type/SearchApiDateRange.php
@@ -80,7 +80,9 @@ class SearchApiDateRange extends QueryTypePluginBase {
                 $diff_years = gmdate('Y', $max) - gmdate('Y', $min) + 1;
                 $gap = abs(ceil($diff_years / $min_count_for_facet));
                 $gap = $gap == 0 ? 1 : $gap;
-                $reminder = $diff_years % $min_count_for_facet;
+                $reminder = $diff_years % $gap;
+                error_log('all-gap-sizes:'.$gap);
+                error_log('last-gap-size:'.$reminder);
 
                 // Reminder is unused for now, bc I can't request to solr that the last or first range covers more
                 // via the search API (i could via custom code)
@@ -88,7 +90,7 @@ class SearchApiDateRange extends QueryTypePluginBase {
                 $gap = $gap < $base_gap ? $base_gap : $gap;
                   // Only way to communicate to the Widget itself. Setting it here only survives a single PHP call and does
                   // not permanently override the defaults. Which is what we need!
-                $widget_config['dynamic_step'] = $gap;
+                $widget_config['dynamic_step'] = $reminder > 0 ? $reminder : $gap;
                 $this->facet->getWidgetInstance()->setConfiguration($widget_config);
                 // Now, Solr Index might have dates offset. Bc Drupal will calculate a certain date based on its internal timezone
                 // during "index" but Solr will get then another based on UTC
@@ -110,9 +112,9 @@ class SearchApiDateRange extends QueryTypePluginBase {
                     ->format('Y-m-d\TH:i:s\Z');
                 }
                 else {
-                  $min_value = $dt_min->sub(new DateInterval('PT' . $offset . 'H'))
+                  $min_value = $dt_min->sub(new DateInterval('PT' . abs($offset) . 'H'))
                     ->format('Y-m-d\TH:i:s\Z');
-                  $max_value = $dt_max->sub(new DateInterval('PT' . $offset . 'H'))
+                  $max_value = $dt_max->sub(new DateInterval('PT' . abs($offset) . 'H'))
                     ->format('Y-m-d\TH:i:s\Z');
                 }
 

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeSliderWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeSliderWidget.php
@@ -31,6 +31,8 @@ class DateRangeSliderWidget extends DateSliderWidget {
     }
 
     $facet_settings = &$build['#attached']['drupalSettings']['facets']['sliders'][$facet->id()];
+    $is_bce = $facet_settings['real_minmax'][0] ?? 0;
+    $is_bce = $is_bce < 0 ? TRUE : FALSE;
     $id = Html::getUniqueId('facet-sbf-slider-'.$facet->id().'-manual-input');
     if ( $this->getConfiguration()['allow_full_entry'] || $this->getConfiguration()['allow_year_entry']) {
       $build['#items']['manual_input'] = [
@@ -43,7 +45,7 @@ class DateRangeSliderWidget extends DateSliderWidget {
       ];
     }
 
-    if (($this->getConfiguration()['allow_full_entry'] ?? FALSE) && ($this->getConfiguration()['allow_year_entry'] ?? FALSE)) {
+    if (($this->getConfiguration()['allow_full_entry'] ?? FALSE) && ($this->getConfiguration()['allow_year_entry'] ?? FALSE) && !$is_bce) {
       $build['#items']['manual_input']['select_input'] = [
           '#type' => 'checkbox',
           '#title' => t('Full Date entry'),
@@ -54,7 +56,7 @@ class DateRangeSliderWidget extends DateSliderWidget {
       ];
     }
 
-    if ($this->getConfiguration()['allow_full_entry']) {
+    if ($this->getConfiguration()['allow_full_entry'] && !$is_bce) {
       $build['#items']['manual_input']['manual_input_full'] = [
         '#type' => 'container',
         'min_full' => [

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeSliderWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeSliderWidget.php
@@ -194,31 +194,4 @@ class DateRangeSliderWidget extends DateSliderWidget {
     return 'date_range';
   }
 
-
-  protected function getRangeFromResults(array $results) {
-    /* @var \Drupal\facets\Result\ResultInterface[] $results */
-    $min = NULL;
-    $max = NULL;
-    foreach ($results as $result) {
-      if ($result->getRawValue() == 'summary_date_facet') {
-        continue;
-      }
-      // Warning. Depending on the "field" (normal data v/s date range) type RAW values might be UNIX Time stamps or actual
-      // ISO Dates. Normalize to unix.
-
-      $raw = DateRangeProcessor::DateToUnix($result->getRawValue());
-      $min = $min ?? $raw;
-      $max = $max ?? $raw;
-      $min = $min < $raw ? $min : $raw;
-      $max = $max > $raw ? $max : $raw;
-    }
-    // Should we yet again cast via timezone here
-    // date -r -4197038400
-    //Sat Dec 31 23:17:15 LMT 1836
-   //  but the input once transformed was properly 1837
-
-    return ['min' => $min, 'max' => $max];
-  }
-
-
 }

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeSliderWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeSliderWidget.php
@@ -4,6 +4,10 @@ namespace Drupal\format_strawberryfield_facets\Plugin\facets\widget;
 
 use Drupal\Component\Utility\Html;
 use Drupal\facets\FacetInterface;
+use Drupal\format_strawberryfield_facets\Plugin\facets\processor\DateRangeProcessor;
+use DateTime;
+use DateTimeZone;
+use DateInterval;
 
 /**
  * The range slider widget.
@@ -199,12 +203,22 @@ class DateRangeSliderWidget extends DateSliderWidget {
       if ($result->getRawValue() == 'summary_date_facet') {
         continue;
       }
-      $min = $min ?? $result->getRawValue();
-      $max = $max ?? $result->getRawValue();
-      $min = $min < $result->getRawValue() ? $min : $result->getRawValue();
-      $max = $max > $result->getRawValue() ? $max : $result->getRawValue();
+      // Warning. Depending on the "field" (normal data v/s date range) type RAW values might be UNIX Time stamps or actual
+      // ISO Dates. Normalize to unix.
+
+      $raw = DateRangeProcessor::DateToUnix($result->getRawValue());
+      $min = $min ?? $raw;
+      $max = $max ?? $raw;
+      $min = $min < $raw ? $min : $raw;
+      $max = $max > $raw ? $max : $raw;
     }
+    // Should we yet again cast via timezone here
+    // date -r -4197038400
+    //Sat Dec 31 23:17:15 LMT 1836
+   //  but the input once transformed was properly 1837
+
     return ['min' => $min, 'max' => $max];
   }
+
 
 }

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeWidget.php
@@ -7,8 +7,12 @@ namespace Drupal\format_strawberryfield_facets\Plugin\facets\widget;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\facets\FacetInterface;
 use Drupal\facets\Result\Result;
-use Drupal\facets\Result\ResultInterface;
 use Drupal\facets\Widget\WidgetPluginBase;
+use Drupal\format_strawberryfield_facets\Plugin\facets\processor\DateRangeProcessor;
+use DateTime;
+use DateTimeZone;
+use DateInterval;
+
 
 /**
  * The Date Range widget.
@@ -241,11 +245,20 @@ class DateRangeWidget extends WidgetPluginBase {
       if ($result->getRawValue() == 'summary_date_facet') {
         continue;
       }
-      $min = $min ?? $result->getRawValue();
-      $max = $max ?? $result->getRawValue();
-      $min = $min < $result->getRawValue() ? $min : $result->getRawValue();
-      $max = $max > $result->getRawValue() ? $max : $result->getRawValue();
+      // Warning. Depending on the "field" (normal data v/s date range) type RAW values might be UNIX Time stamps or actual
+      // ISO Dates. Normalize to unix.
+
+      $raw = DateRangeProcessor::DateToUnix($result->getRawValue());
+      $min = $min ?? $raw;
+      $max = $max ?? $raw;
+      $min = $min < $raw ? $min : $raw;
+      $max = $max > $raw ? $max : $raw;
     }
+    // Should we yet again cast via timezone here
+    // date -r -4197038400
+    //Sat Dec 31 23:17:15 LMT 1836
+    //  but the input once transformed was properly 1837
+
     return ['min' => $min, 'max' => $max];
   }
 

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateSliderWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateSliderWidget.php
@@ -519,7 +519,6 @@ class DateSliderWidget extends WidgetPluginBase {
     }
     $dynamic_step = $this->getConfiguration()['dynamic_step'];
     // Check for explicit NULL bc $active_max Might be a 0.
-    error_log('step '.$dynamic_step);
     // NOTE for tomorrow (will remove later)
     // Because we have to use Time Zone offsets on the query
     // The buckets from the date range (not the ones from the normal dates)
@@ -532,15 +531,11 @@ class DateSliderWidget extends WidgetPluginBase {
     if ($dynamic_step && $active_max!== NULL  ) {
       // check if $max + step is IN active value, if any.
       $next_range = strtotime("+{$dynamic_step} years", $max);
-      error_log('step '.$dynamic_step);
-
       if ($active_max < $next_range) {
         // If active is lower than the calculated next range
         // We make max == active. There might be an error depending on the
         // Gap itself. If the gap is very large (means low hard limit, large span)
         $max = $active_max;
-        error_log('-- adjusting to active');
-        error_log('-- Next range'. gmdate(DATE_ATOM, $next_range));
       }
       else {
         // We make the Max the next range assuming the dynamic step here
@@ -551,15 +546,13 @@ class DateSliderWidget extends WidgetPluginBase {
         $max = $next_range;
       }
     }
-    error_log('active '.gmdate(DATE_ATOM, $active_max));
-    error_log('max_from results '.gmdate(DATE_ATOM, $original_max));
-
-    error_log('max_used '.gmdate(DATE_ATOM, $max));
     $time_zone = Utility::getTimeZone($this->facet->getFacetSource()->getIndex());
     // Now we need to reverse the Timezone offset generated during indexing.
     // We do the inverse in SearchApiDateRange to fit the actual indexed values
     $dt_min_utc = new DateTime('@' . $min);
     $dt_min = new DateTime($dt_min_utc->format('Y-m-d\TH:i:s'), new DateTimeZone($time_zone));
+    // So far we don't need min, bc it starts at 1-1. But we might in the future if the ranges
+    // end being inconsistent.
     $dt_max_utc = new DateTime('@' . $max);
     $dt_max = new DateTime($dt_max_utc->format('Y-m-d\TH:i:s'), new DateTimeZone($time_zone));
     // Offset can be retrieved from both min or max.
@@ -571,8 +564,6 @@ class DateSliderWidget extends WidgetPluginBase {
     else {
       $max = $dt_max->sub(new DateInterval('PT' . abs($offset) . 'H'))->getTimestamp();
     }
-
-    error_log('max_used with timezoneoffset '.$max);
 
     return ['min' => $min, 'max' => $max];
   }

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateSliderWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateSliderWidget.php
@@ -518,9 +518,19 @@ class DateSliderWidget extends WidgetPluginBase {
     }
     $dynamic_step = $this->getConfiguration()['dynamic_step'];
     // Check for explicit NULL bc $active_max Might be a 0.
-    if ($dynamic_step && $active_max!== NULL ) {
+    error_log('step '.$dynamic_step);
+    // NOTE for tomorrow (will remove later)
+    // Because we have to use Time Zone offsets on the query
+    // The buckets from the date range (not the ones from the normal dates)
+    // Are already offset. So what happens is if we take that value as the max and min
+    // And query again, we will YET again offset by time zone
+    // That has really NO effect when the dynamic step is large, but if it is
+    // One year, then we have a back and forth jump.
+    // Solution, the facets here need to have timezone yet again removed!
+    if ($dynamic_step && $dynamic_step > 1 && $active_max!== NULL  ) {
       // check if $max + step is IN active value, if any.
       $next_range = strtotime("+{$dynamic_step} years", $max);
+      error_log('step '.$dynamic_step);
       error_log('active '.gmdate(DATE_ATOM, $active_max));
       error_log('max_from results '.gmdate(DATE_ATOM, $max));
       error_log('Next range'. gmdate(DATE_ATOM, $next_range));

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateSliderWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateSliderWidget.php
@@ -19,7 +19,7 @@ use Drupal\format_strawberryfield_facets\Plugin\facets\processor\DateRangeProces
  *
  * @FacetsWidget(
  *   id = "sbf_date_slider",
- *   label = @Translation("Format Strawberryfield Date slider"),
+ *   label = @Translation("Format Strawberryfield Date Slider"),
  *   description = @Translation("A widget that shows a slider for Dates."),
  * )
  */

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateSliderWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateSliderWidget.php
@@ -394,13 +394,13 @@ class DateSliderWidget extends WidgetPluginBase {
     $form['restrict_to_fixed'] =  [
       '#type'          => 'checkbox',
       '#title'         => $this->t('Cap result based max/min to Fixed Ranges.'),
-      '#description'        => $this->t('Even if max and min are "Based on search results", max and min will be capped to the Fixed values. This allows Outliers and wrong metadata to be never be taken in account.'),
+      '#description'   => $this->t('Even if max and min are "Based on search results", max and min will be capped to the Fixed values. This allows Outliers and wrong metadata to be never be taken in account.'),
       '#default_value' => $config['restrict_to_fixed'] ?? $this->defaultConfiguration()['restrict_to_fixed'],
     ];
     $form['restrict_frequency_to_range'] =  [
       '#type'          => 'checkbox',
       '#title'         => $this->t('Use the real facet max/min instead of the User selected input'),
-      '#description'         => $this->t('When checked, the user input will not be used in the Widget, but the actual max/min from the facets'),
+      '#description'   => $this->t('When checked, the user input will not be used in the Widget, but the actual max/min from the facets'),
       '#default_value' => $config['restrict_frequency_to_range'] ?? $this->defaultConfiguration()['restrict_frequency_to_range'],
     ];
 
@@ -440,15 +440,16 @@ class DateSliderWidget extends WidgetPluginBase {
 
     $form['step_variable_granularity'] = [
       '#type'          => 'checkbox',
-      '#title'         => $this->t('Variable date Granularity and Date range Facet Query "gap", based on results'),
+      '#title'         => $this->t('Variable date Granularity and Date range Facet Query "gap" in the Slider UI, based on results'),
       '#default_value' => $config['step_variable_granularity'],
       '#description'   => $this->t(
-        'When enabled, sliders steps will vary based on the min/max facet values (divided by the the hard limit of this facet). By default, e.g when no active values or no hard limit, base slider "step" setting in years will be used.'
+        'Gaps are always calculated dynamically and will vary based on the min/max facet values (divided by the the hard limit of this facet). But when this is enabled, sliders steps (UI) will also use that GAP . If not, by default the base slider "step" setting in years will be used.'
       ),
     ];
     $form['allow_full_entry'] =  [
       '#type'          => 'checkbox',
       '#title'         => $this->t('Allow manual Full DD/MM/YYYY entry'),
+      '#description'         => $this->t('Because of Browser support limitations for BCE dates entry in FULL ISO8601 format, if the returned range contains a negative year this input will be hidden.'),
       '#default_value' => $config['allow_full_entry'],
     ];
     $form['allow_year_entry'] =  [
@@ -564,17 +565,14 @@ class DateSliderWidget extends WidgetPluginBase {
     // Offset can be retrieved from both min or max.
     $offset = $dt_max->getOffset() / 3600;
     $offset = (int) $offset;
-    error_log($offset);
     if ($offset > 0) {
-      $max_value = $dt_max->add(new DateInterval('PT' . abs($offset) . 'H'))
-        ->format('Y-m-d\TH:i:s\Z');
+      $max = $dt_max->add(new DateInterval('PT' . abs($offset) . 'H'))->getTimestamp();
     }
     else {
-      $max_value = $dt_max->sub(new DateInterval('PT' . abs($offset) . 'H'))
-        ->format('Y-m-d\TH:i:s\Z');
+      $max = $dt_max->sub(new DateInterval('PT' . abs($offset) . 'H'))->getTimestamp();
     }
 
-    error_log('max_used with timezoneoffset '.$max_value);
+    error_log('max_used with timezoneoffset '.$max);
 
     return ['min' => $min, 'max' => $max];
   }


### PR DESCRIPTION
# What?

See #524 and follow us on slack for more "dating" tips 😮‍💨 

Still missing here:
- ~add BCE/AC select box to the year/full date entry boxes in the widget~. Done differently. Full date input hides if one of the ranges is negative. Less UI for now is good.
- ~Totally remake the JS side of things date parsing bc the timestamps for BCE are totally wrong (no clue yet how)~ DONE
- ~Check/double check all Widget settings we have. See if all are respected.~ DONE (the old range widget was not working. mea culpa. Fixed)
- ~Incorporate a few shared ideas in slack like  allow "extra slack/+-gap" to any start/end when faceting via JSON on the backend, that way even if the query is 2021-2025(my most complex years)~. So far the solution is approximate but good enough. The last gap now uses the modulus of the GAP (bc it will not be exact) and we pass that data between query and widget back and forth. I can get an histogram that returns 2018-2028 (with 2028  maybe a good year?)

In the case of a single range (1899-01-01 to December 31st of the same year) the histogram turns into a single bar, If not it becomes invisible. 

Will follow up with more pulls for that tomorrow
