### PR TITLE
ISSUE-526: Allows TRUE, "1" and 1 as valid global IP embargo flags via metadata

### DIFF
--- a/src/EmbargoResolver.php
+++ b/src/EmbargoResolver.php
@@ -186,9 +186,11 @@ class EmbargoResolver implements EmbargoResolverInterface {
             }
 
             if ($this->embargoConfig->get('global_ip_bypass_enabled')) {
-              $global_ip_embargo = FALSE;
               // If the key is there and set to TRUE. Replace/Additive/Local does not apply here
-              if (is_bool($jsondata[$ip_embargo_key] ?? []) && $jsondata[$ip_embargo_key] == TRUE) {
+              // Variations of TRUE.
+              $global_ip_embargo = $jsondata[$ip_embargo_key] ?? FALSE;
+              $global_ip_embargo = ((is_bool($global_ip_embargo) && $global_ip_embargo == TRUE) || $global_ip_embargo == "1" || $global_ip_embargo == 1);
+              if ($global_ip_embargo) {
                 $ip_embargo = $this->evaluateGlobalIPembargo($current_ip);
                 $noembargo = $noembargo && $ip_embargo;
               }


### PR DESCRIPTION
See #526 

@alliomeria this is what we have running now. Tested. I don't see any issues but please check one more time and merge (today hopefully) if you can. We do might need a DOCS update to state that "1" and 1 are allowed?

Thanks