### PR TITLE
ISSUE-538--date-range-widget-accx ---> 1.6.0

### DIFF
--- a/modules/format_strawberryfield_facets/css/slider.css
+++ b/modules/format_strawberryfield_facets/css/slider.css
@@ -17,3 +17,42 @@
   color: black;
   color: var(--bb-primary-dark, var(--bs-body-color, black)) !important;
 }
+
+/**
+ * jQuery UI Slider Pips - Accessibility Contrast Fixes
+ * Overrides for jquery-ui-slider-pips library to meet WCAG AA contrast requirements (4.5:1 for normal text)
+ */
+.ui-slider-pips .ui-slider-pip {
+  color: #4a4a4a; /* 9.28:1 contrast ratio on white */
+}
+
+.ui-slider-pips .ui-slider-line {
+  background: #4a4a4a; /* 9.28:1 contrast ratio on white */
+}
+
+.ui-slider-pips [class*=ui-slider-pip-initial] {
+  font-weight: bold;
+  color: #0d8a58; /* 4.69:1 contrast ratio on white */
+}
+
+.ui-slider-pips .ui-slider-pip-initial-2 {
+  color: #106b96; /* 5.26:1 contrast ratio on white */
+}
+
+.ui-slider-pips [class*=ui-slider-pip-selected] {
+  font-weight: bold;
+  color: #c05500; /* 5.74:1 contrast ratio on white */
+}
+
+.ui-slider-pips .ui-slider-pip-inrange {
+  color: #000000; /* 21:1 contrast ratio on white */
+}
+
+.ui-slider-pips .ui-slider-pip-selected-2 {
+  color: #cc0000; /* 5.3:1 contrast ratio on white */
+}
+
+.ui-slider-pips [class*=ui-slider-pip-selected] .ui-slider-line,
+.ui-slider-pips .ui-slider-pip-inrange .ui-slider-line {
+  background: #000000; /* 21:1 contrast ratio on white */
+}

--- a/modules/format_strawberryfield_facets/css/slider.css
+++ b/modules/format_strawberryfield_facets/css/slider.css
@@ -22,37 +22,37 @@
  * jQuery UI Slider Pips - Accessibility Contrast Fixes
  * Overrides for jquery-ui-slider-pips library to meet WCAG AA contrast requirements (4.5:1 for normal text)
  */
-.ui-slider-pips .ui-slider-pip {
+.sbf-date-facet-slider.ui-slider-pips .ui-slider-pip {
   color: #4a4a4a; /* 9.28:1 contrast ratio on white */
 }
 
-.ui-slider-pips .ui-slider-line {
+.sbf-date-facet-slider.ui-slider-pips .ui-slider-line {
   background: #4a4a4a; /* 9.28:1 contrast ratio on white */
 }
 
-.ui-slider-pips [class*=ui-slider-pip-initial] {
+.sbf-date-facet-slider.ui-slider-pips [class*=ui-slider-pip-initial] {
   font-weight: bold;
   color: #0d8a58; /* 4.69:1 contrast ratio on white */
 }
 
-.ui-slider-pips .ui-slider-pip-initial-2 {
+.sbf-date-facet-slider.ui-slider-pips .ui-slider-pip-initial-2 {
   color: #106b96; /* 5.26:1 contrast ratio on white */
 }
 
-.ui-slider-pips [class*=ui-slider-pip-selected] {
+.sbf-date-facet-slider.ui-slider-pips [class*=ui-slider-pip-selected] {
   font-weight: bold;
   color: #c05500; /* 5.74:1 contrast ratio on white */
 }
 
-.ui-slider-pips .ui-slider-pip-inrange {
+.sbf-date-facet-slider.ui-slider-pips .ui-slider-pip-inrange {
   color: #000000; /* 21:1 contrast ratio on white */
 }
 
-.ui-slider-pips .ui-slider-pip-selected-2 {
+.sbf-date-facet-slider.ui-slider-pips .ui-slider-pip-selected-2 {
   color: #cc0000; /* 5.3:1 contrast ratio on white */
 }
 
-.ui-slider-pips [class*=ui-slider-pip-selected] .ui-slider-line,
-.ui-slider-pips .ui-slider-pip-inrange .ui-slider-line {
+.sbf-date-facet-slider.ui-slider-pips [class*=ui-slider-pip-selected] .ui-slider-line,
+.sbf-date-facet-slider.ui-slider-pips .ui-slider-pip-inrange .ui-slider-line {
   background: #000000; /* 21:1 contrast ratio on white */
 }

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeSliderWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeSliderWidget.php
@@ -33,14 +33,16 @@ class DateRangeSliderWidget extends DateSliderWidget {
     $facet_settings = &$build['#attached']['drupalSettings']['facets']['sliders'][$facet->id()];
     $is_bce = $facet_settings['real_minmax'][0] ?? 0;
     $is_bce = $is_bce < 0 ? TRUE : FALSE;
-    $id = Html::getUniqueId('facet-sbf-slider-'.$facet->id().'-manual-input');
+
+    // Generate unique IDs for form elements (AJAX-safe)
+    $id = Html::getUniqueId('facet-sbf-slider-'.$facet->id());
     if ( $this->getConfiguration()['allow_full_entry'] || $this->getConfiguration()['allow_year_entry']) {
       $build['#items']['manual_input'] = [
         '#type' => 'details',
         '#title' => t('More Options'),
         '#collapsible' => TRUE,
         '#collapsed' => TRUE,
-        '#id' => $id,
+        '#id' => $id . '-manual-input',
         '#title_display' => 'before',
       ];
     }
@@ -48,10 +50,11 @@ class DateRangeSliderWidget extends DateSliderWidget {
     if (($this->getConfiguration()['allow_full_entry'] ?? FALSE) && ($this->getConfiguration()['allow_year_entry'] ?? FALSE) && !$is_bce) {
       $build['#items']['manual_input']['select_input'] = [
           '#type' => 'checkbox',
+          '#id' => $id . '-manual-input-fulldate',
           '#title' => t('Full Date entry'),
           '#default_value' => FALSE,
           '#attributes' => [
-          'data-date-entry-selector' => $id.'-fulldate'
+          'data-date-entry-selector' => $id . '-manual-input-fulldate'
         ]
       ];
     }
@@ -62,6 +65,7 @@ class DateRangeSliderWidget extends DateSliderWidget {
         'min_full' => [
           '#type' => 'date',
           '#title' => $this->t('Date from'),
+          '#id' => $id . '-min',
           '#value' => $facet_settings['real_minmax'][0],
           '#date_date_element' => 'datetime',
           '#date_date_format' => 'mm-dd-Y',
@@ -71,7 +75,7 @@ class DateRangeSliderWidget extends DateSliderWidget {
           '#date_timezone' => $facet_settings['time_zone'] ?? 'UTC',
           '#attributes' => [
             'class' => ['facet-date-range'],
-            'id' => $facet->id() . '_min',
+            'id' => $id . '-min',
             'name' => $facet->id() . '_min',
             'min' => $facet_settings['real_minmax'][0],
             'max' => $facet_settings['real_minmax'][1],
@@ -81,6 +85,7 @@ class DateRangeSliderWidget extends DateSliderWidget {
         'max_full' => [
           '#type' => 'date',
           '#title' => $this->t('Date to'),
+          '#id' => $id . '-max',
           '#value' => $facet_settings['real_minmax'][1],
           '#date_date_element' => 'datetime',
           '#date_date_format' => 'mm-dd-Y',
@@ -90,7 +95,7 @@ class DateRangeSliderWidget extends DateSliderWidget {
           '#date_timezone' => $facet_settings['time_zone'] ?? 'Asia/Kolkata',
           '#attributes' => [
             'class' => ['facet-date-range'],
-            'id' => $facet->id() . '_max',
+            'id' => $id . '-max',
             'name' => $facet->id() . '_max',
             'min' => $facet_settings['real_minmax'][0],
             'max' => $facet_settings['real_minmax'][1],
@@ -104,13 +109,14 @@ class DateRangeSliderWidget extends DateSliderWidget {
         'min_year' => [
           '#type' => 'number',
           '#title' => $this->t('Year from'),
+          '#id' => $id . '-year-min',
           '#value' => $facet_settings['min'],
           '#min' => $facet_settings['min'],
           '#max' => $facet_settings['max'],
           '#step' => 1,
           '#attributes' => [
             'class' => ['facet-date-range'],
-            'id' => $facet->id() . '_year_min',
+            'id' => $id . '-year-min',
             'name' => $facet->id() . '_year_min',
             'min' =>  $facet_settings['min'],
             'max' => $facet_settings['max'],
@@ -120,13 +126,14 @@ class DateRangeSliderWidget extends DateSliderWidget {
         'max_year' => [
           '#type' => 'number',
           '#title' => $this->t('Year to'),
+          '#id' => $id . '-year-max',
           '#value' => $facet_settings['max'],
           '#min' => $facet_settings['min'],
           '#max' => $facet_settings['max'],
           '#step' => 1,
           '#attributes' => [
             'class' => ['facet-date-range'],
-            'id' => $facet->id() . '_year_max',
+            'id' => $id . '-year-max',
             'name' => $facet->id() . '_year_max',
             'min' => $facet_settings['min'],
             'max' => $facet_settings['max'],

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeSliderWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeSliderWidget.php
@@ -145,22 +145,22 @@ class DateRangeSliderWidget extends DateSliderWidget {
     if (isset($build['#items']['manual_input']['manual_input_full']) &&  ($this->getConfiguration()['allow_full_entry'] ?? FALSE) && ($this->getConfiguration()['allow_year_entry'] ?? FALSE)) {
       $build['#items']['manual_input']['manual_input_full']['min_full']['#states'] = [
         'visible' => [
-          ':input[data-date-entry-selector="'.$id.'-fulldate'.'"]' => ['checked' => TRUE],
+          ':input[data-date-entry-selector="'.$id.'-manual-input-fulldate'.'"]' => ['checked' => TRUE],
         ],
       ];
       $build['#items']['manual_input']['manual_input_full']['max_full']['#states'] = [
         'visible' => [
-          ':input[data-date-entry-selector="'.$id.'-fulldate'.'"]' => ['checked' => TRUE],
+          ':input[data-date-entry-selector="'.$id.'-manual-input-fulldate'.'"]' => ['checked' => TRUE],
         ],
       ];
       $build['#items']['manual_input']['manual_input_year']['min_year']['#states'] = [
         'visible' => [
-          ':input[data-date-entry-selector="'.$id.'-fulldate'.'"]' => ['checked' => FALSE],
+          ':input[data-date-entry-selector="'.$id.'-manual-input-fulldate'.'"]' => ['checked' => FALSE],
         ],
       ];
       $build['#items']['manual_input']['manual_input_year']['max_year']['#states'] = [
         'visible' => [
-          ':input[data-date-entry-selector="'.$id.'-fulldate'.'"]' => ['checked' => FALSE],
+          ':input[data-date-entry-selector="'.$id.'-manual-input-fulldate'.'"]' => ['checked' => FALSE],
         ],
       ];
     }

--- a/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeWidget.php
+++ b/modules/format_strawberryfield_facets/src/Plugin/facets/widget/DateRangeWidget.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\format_strawberryfield_facets\Plugin\facets\widget;
 
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\facets\FacetInterface;
 use Drupal\facets\Result\Result;
@@ -67,14 +68,18 @@ class DateRangeWidget extends WidgetPluginBase {
       $max = gmdate('Y-m-d', (int) $max);
     }
 
+    // Generate unique IDs for form elements (AJAX-safe)
+    $id = Html::getUniqueId('facet-sbf-date-range-'.$facet->id());
+
     $build['#items'] = [
       'min' => [
         '#type' => 'date',
         '#title' => $this->t('Date from'),
+        '#id' => $id . '-min',
         '#value' => $min,
         '#attributes' => [
           'class' => ['facet-date-range'],
-          'id' => $facet->id() . '_min',
+          'id' => $id . '-min',
           'name' => $facet->id() . '_min',
           'min' => $min,
           'max' => $max,
@@ -84,10 +89,11 @@ class DateRangeWidget extends WidgetPluginBase {
       'max' => [
         '#type' => 'date',
         '#title' => $this->t('Date to'),
+        '#id' => $id . '_max',
         '#value' => $max,
         '#attributes' => [
           'class' => ['facet-date-range'],
-          'id' => $facet->id() . '_max',
+          'id' => $id . '_max',
           'name' => $facet->id() . '_max',
           'min' => $min,
           'max' => $max,


### PR DESCRIPTION
Proposing accessibility fixes for date range slider facet widget and date range facet widget:
See #538 

1. Added ['#id'] values to each labeled form element so that the labels will get rendered with a 'for="\<the id\>". This associates the labels with the form elements for screen readers. We use Html::getUniqueId() as the basis for these ids. Hopefully this keeps them ajax safe?
2. Altered the color values of jquery-ui-slider-pips labels to meet WCAG AA contrast requirements.