### PR TITLE
ISSUE-576(D10): Recent Symfony does not accept "paths" with spaces/control characters breaking Ajax Facets

### DIFF
--- a/modules/format_strawberryfield_facets/src/Controller/SbfFacetBlockAjaxController.php
+++ b/modules/format_strawberryfield_facets/src/Controller/SbfFacetBlockAjaxController.php
@@ -54,8 +54,23 @@ class SbfFacetBlockAjaxController extends FacetBlockAjaxController {
     if (empty($path) || empty($facets_blocks)) {
       throw new NotFoundHttpException('No facet link or facet blocks found.');
     }
-
+    // Symfony No longer accepts Spaces or Control characters on a $path
+    // Since the Facets/Sorts and search are inside the $path from the facet_link argument,
+    // we need to move them out and into query parameters for the $new_request
+    $params = [];
+    $queryString = parse_url($path, PHP_URL_QUERY);
+    parse_str($queryString, $params);
+    $actual_path = explode('?', $path);
+    $path = $actual_path[0];
+    if (is_string($path)) {
+      $path = trim($path);
+    }
     $new_request = Request::create($path);
+    if (is_array($params)) {
+      foreach ($params as $key => $param) {
+        $new_request->query->set($key, $param);
+      }
+    }
     if ($session = $request->getSession()) {
       $new_request->setSession($session);
     }

--- a/modules/format_strawberryfield_views/src/Controller/ViewsExposedFormModalBlockAjaxController.php
+++ b/modules/format_strawberryfield_views/src/Controller/ViewsExposedFormModalBlockAjaxController.php
@@ -125,28 +125,30 @@ class ViewsExposedFormModalBlockAjaxController extends ControllerBase {
     if (empty($path) || empty($modalviews_blocks)) {
       throw new NotFoundHttpException('No Modal Exposed Views Form links or blocks found.');
     }
+    $params = [];
+    $queryString = parse_url($path, PHP_URL_QUERY);
 
+
+    parse_str($queryString, $params);
     // Now Dear Diego. the page argument is permeating on a POST
     // Making a new query that was on page 100 fail bc it might not a page 100 for that query
     // Drupal is hard
-    $path_expanded = UrlHelper::parse($path);
-    $filtered = UrlHelper::filterQueryParameters(
-      $path_expanded['query'], ['page']
-    );
-    $path_expanded['query'] = $filtered;
-    UrlHelper::buildQuery($path_expanded['query']);
-    $path_object = \Drupal::pathValidator()->getUrlIfValid($path_expanded['path']);
-    if (!$path_object) {
-      // Stay on the same page if the redirect was invalid.
-      throw new NotFoundHttpException('No Modal Exposed Views Form links or blocks found.');
-    }
-    $path_object->setOptions($path_expanded);
-    $path = $path_object->toString();
+    unset($params['page']);
 
+    $actual_path = explode('?', $path);
+    $path = $actual_path[0];
+    if (is_string($path)) {
+      $path = trim($path);
+    }
     // Make sure we are not updating blocks multiple times.
     $modalviews_blocks = array_unique($modalviews_blocks);
 
     $new_request = Request::create($path);
+    if (is_array($params)) {
+      foreach ($params as $key => $param) {
+        $new_request->query->set($key, $param);
+      }
+    }
     $new_request->setSession($request->getSession());
     // Add ajax_page_state to the new request if set.
     if ($request->request->has('ajax_page_state')) {


### PR DESCRIPTION
See #576 

This parses the Path at Facet Ajax Block Control to extract and remove Query arguments and pass them as query bag entries to the $new_request *sub request *